### PR TITLE
Fix: Upgrade sysbench to 1.1.0 and use native --warmup-time flag

### DIFF
--- a/docs/ENVIRONMENT_SETUP.md
+++ b/docs/ENVIRONMENT_SETUP.md
@@ -26,6 +26,8 @@ DB_NAME=test_dataset
 
 ### 3. Install dependencies
 
+#### Python packages
+
 Install the required Python packages:
 
 ```bash
@@ -40,6 +42,30 @@ pip install -r requirements.txt
 - **python-dotenv**: Environment variable management
 
 **Note**: `psutil` is essential for the Performance Evaluation System to collect accurate CPU, memory, and I/O metrics. See [Performance Evaluation Documentation](./PERFORMANCE_EVALUATION.md#system-monitoring-with-psutil) for details.
+
+#### Sysbench (required for OLTP benchmarking)
+
+The tuner uses sysbench's native `--warmup-time` flag, which was introduced in **sysbench 1.1.0**. The prepackaged system version (typically 1.0.20) is **not sufficient** — you must build 1.1.0 from source.
+
+```bash
+# Clone and build sysbench 1.1.0 from source
+git clone --depth 1 https://github.com/akopytov/sysbench.git /tmp/sysbench-build
+cd /tmp/sysbench-build
+./autogen.sh
+./configure --with-pgsql --without-mysql --prefix=/usr
+make -j$(nproc)
+sudo make install
+
+# Verify
+sysbench --version  # should print: sysbench 1.1.0-...
+```
+
+> **Platform notes:**
+> - **Arch/Manjaro**: Remove the packaged version first: `sudo pacman -R sysbench`
+> - **Ubuntu/Debian**: No packaged 1.1.0 yet — build from source as above. You may need `sudo apt install automake libtool libpq-dev` before running `./autogen.sh`.
+> - **Fedora/RHEL**: `sudo dnf remove sysbench`, then build from source. May need `sudo dnf install automake libtool postgresql-devel`.
+> - **macOS (Homebrew)**: `brew install automake libtool libpq`, then build from source with `./configure --with-pgsql --without-mysql --prefix=/usr/local`.
+> - **Windows**: sysbench has no native Windows build. Use **WSL2** (Windows Subsystem for Linux) and follow the Ubuntu/Debian instructions above inside your WSL2 environment. See [Microsoft's WSL2 setup guide](https://learn.microsoft.com/en-us/windows/wsl/install) if you haven't installed it yet.
 
 ### 4. Important Security Notes
 

--- a/src/benchmarks/sysbench/executor.py
+++ b/src/benchmarks/sysbench/executor.py
@@ -189,7 +189,7 @@ class SysbenchExecutor(BenchmarkExecutor):
         ]
 
         if warmup > 0:
-            cmd.append(f"--warmup={warmup}")
+            cmd.append(f"--warmup-time={warmup}")
 
         if seed is not None:
             cmd.append(f"--rand-seed={seed}")


### PR DESCRIPTION
## What

Fixes the sysbench warmup regression introduced in PR #5. The original fix used  which doesn't exist in sysbench 1.0.x.

## Why

sysbench 1.0.20 (the packaged version on most distros) does not support the  flag — it was introduced in 1.1.0 as . Running with 1.0.x caused all workers to fail with:
```bash
invalid option: --warmup=10
```

## How

1. **Code fix**: Changed  to  in 
2. **Documentation**: Added sysbench 1.1.0 build-from-source instructions to  with per-platform notes (Linux distros, macOS, Windows via WSL2)

## Testing

- Built sysbench 1.1.0 from source on Arch Linux
- Verified sysbench 1.1.0-3ceba0b reports 
- Verified   --warmup-time=N                 execute events for this many seconds with statistics disabled before the actual benchmark run with statistics enabled [0] shows  flag
- Ran  — workers complete successfully

## Files Changed

-  — Use  instead of nonexistent 
-  — Document sysbench 1.1.0 requirement with build instructions
