### PR TITLE
feat: extensive-tier knob audit & per-worker metrics logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,13 @@
+# AI related files
+.prompts/
+.chats/
+.claude/
+CLAUDE.md
+
 # Drafts and documentation
 Draft*.md
 *.draft
 drafts/
-.prompts/
-.chats/
 notes/
 code-snippets/
 

--- a/docs/AUTOTUNING_KNOB_POLICY.md
+++ b/docs/AUTOTUNING_KNOB_POLICY.md
@@ -1,0 +1,594 @@
+# PostgreSQL Autotuning Knob Policy
+
+This document records the inclusion/exclusion design decision for every knob in the PostgreSQL snapshot (`397` total).
+It avoids implementation-centric framing and instead classifies knobs by **optimization scope**: performance optimization vs.
+semantics, security, topology, observability, and infrastructure policy.
+
+See also: [`src/knobs/policy.py`](../src/knobs/policy.py) — the authoritative source of the exclusion registry.
+
+---
+
+## 1. Policy intent and scope
+
+### What this tuner optimizes
+
+The PBT tuner's objective is to maximize workload throughput and minimize query latency by searching the space of
+PostgreSQL runtime configuration parameters. The knob policy determines which parameters are admitted into that search
+space and which are excluded — and records the reasoning for every decision.
+
+### In scope
+
+Parameters that directly influence **workload execution efficiency**:
+
+- Memory allocation (`shared_buffers`, `work_mem`, buffer pools)
+- Planner cost model (`seq_page_cost`, `random_page_cost`, cost weights)
+- Parallelism (`max_parallel_workers`, worker counts)
+- I/O behavior (`effective_io_concurrency`, bgwriter, checkpoint timing)
+- WAL and durability trade-offs (`wal_level`, `fsync`, `synchronous_commit`)
+- Autovacuum scheduling and resource limits
+
+### Out of scope
+
+Parameters that define **what the database is** rather than **how fast it runs**:
+
+- Security policy (SSL/TLS, authentication, encryption)
+- Network topology (`port`, `listen_addresses`, replication connection strings)
+- File system paths and identity (`data_directory`, `config_file`, `shared_preload_libraries`)
+- Locale and formatting (`TimeZone`, `DateStyle`, `lc_*`)
+- Crash and recovery behavior (`restart_after_crash`, `exit_on_error`)
+- Audit/logging controls (`logging_collector`, `log_destination`, `log_file_mode`)
+- Debug/developer options (`debug_print_plan`, `debug_discard_caches`)
+- Data integrity bypass flags (`zero_damaged_pages`, `ignore_checksum_failure`)
+
+---
+
+## 2. Exclusion categories
+
+Each exclusion is assigned a `reason_code`. The table below defines each code, its enforcement nature (absolute vs.
+conditional), and the conditions under which a knob in that category could be re-admitted.
+
+| Reason Code | Description | Nature | Re-enable criteria |
+|---|---|:---:|---|
+| `internal_context` | PostgreSQL `context = internal` parameters are read-only compile-time or memory-layout constants. No runtime interface can modify them. | **Absolute** | Cannot be re-enabled; inherently immutable. |
+| `applicator_dependency` | Disabling this knob would break the tuner's settings-application mechanism (ALTER SYSTEM). | **Absolute** | Cannot be re-enabled without replacing the settings applicator. |
+| `data_integrity` | Flags that bypass checksum validation or system index integrity. Enabling these in an automated loop risks silent data corruption across worker configurations. | **Absolute** | Never safe under automated tuning. |
+| `system_catalog_safety` | Permits direct writes to system catalog tables. Automating this risks internal catalog corruption. | **Absolute** | Never in an automated context. |
+| `debug_only` | Developer-mode flags with no production performance semantics. | **Absolute** | Not applicable to production optimization. |
+| `domain_scope_non_performance` | String parameters encoding identity, paths, locale, credentials, or recovery targets. They define operational configuration, not execution efficiency. (~70 parameters.) | **Absolute** | Not within this tuner's optimization objective. |
+| `semantic_behavior` | Flags that change SQL transactional semantics (`default_transaction_read_only`, `default_transaction_deferrable`). These alter the meaning of queries, not their speed. | **Absolute** | Not applicable. |
+| `network_binding` | `port`: modifies the postmaster listen port. Not a performance parameter; changes require restart and break benchmark connectivity. | **Absolute** | Not applicable. |
+| `network_discovery` | `bonjour`: Bonjour service advertisement. Unrelated to workload performance. | **Absolute** | Not applicable. |
+| `session_semantics` | Per-session transaction toggles (`transaction_deferrable`, `transaction_read_only`). Setting these globally via ALTER SYSTEM does not represent stable workload-wide optimization. | **Absolute** | Not applicable for global optimization. |
+| `security_transport` | SSL/TLS transport policy parameters. Security policy is external to the tuner's optimization objective. | **Conditional** | May be admitted in isolated research environments where SSL state is fixed and stable, via an explicit policy bypass. |
+| `benchmark_validity` | Parameters that introduce artificial latency (`pre_auth_delay`, `post_auth_delay`) or can cancel in-flight benchmark statements (`statement_timeout`). | **Conditional** | `pre_auth_delay` and `post_auth_delay` remain excluded. `statement_timeout` may be re-admitted if the evaluator manages its own per-step timeouts at each stage (partial admission implemented in Phase C for the VACUUM ANALYZE step). |
+| `mutual_exclusion` | Log statistics flags that are mutually exclusive at the PostgreSQL level. Enabling more than one subsystem flag at a time causes a configuration error. | **Conditional** | May be re-admitted if the tuner treats this group as a categorical single-select parameter and only ever activates one value at a time. |
+| `format_readback` | Octal-permission parameters (`log_file_mode`, `unix_socket_permissions`). PostgreSQL stores these as integers; the canonical form is octal, which the pipeline cannot reliably round-trip. | **Conditional** | Can be re-enabled once the pipeline handles octal encoding and validation for these specific parameters. |
+| `logging_pipeline_dependency` | `logging_collector`: redirects PostgreSQL log output away from stderr to managed files. The tuner's orchestration depends on stderr-based log collection. | **Conditional** | Can be re-enabled if the tuner's log collector is updated to read PostgreSQL-managed log files. |
+| `stability` | JIT compilation parameters (`jit` and family). JIT shows known instability in benchmark workloads in this environment: intermittent degradation and crashes under certain query patterns make benchmark scores unreliable. | **Conditional** | Can be re-enabled on PostgreSQL builds and environments where JIT is validated stable for the target workload (e.g., PG16+ OLAP with controlled query patterns). |
+| `os_alignment` | `max_stack_depth` must not exceed the OS `ulimit -s` stack size limit. The tuner cannot safely determine the correct OS-safe upper bound at runtime without reading `/proc/1/limits` or equivalent. | **Conditional** | Re-enable by adding OS stack limit discovery to the evaluator and clamping `max_stack_depth` at each worker startup. |
+| `storage_safety` | `allow_in_place_tablespaces`: enables tablespace creation in the PostgreSQL data directory path. Toggling in a tuning loop risks tablespace layout side effects. | **Conditional** | Can be re-enabled in controlled environments where tablespace layout is pre-fixed and verified. |
+| `uncurated_intmax_sentinel` | Numeric parameters whose PostgreSQL-native maximum is ≥ 2,000,000,000 (INT_MAX class) without a curated [`TuningMetadata`](../src/knobs/knob_metadata.py) entry defining practical bounds. The unbounded upper limit makes random search unsafe. | **Conditional** | Add a `TuningMetadata` entry in [`src/knobs/knob_metadata.py`](../src/knobs/knob_metadata.py) with practical `min_val`/`max_val` bounds and an `impact_tier`. The parameter is automatically promoted to the appropriate tier CSV on the next preprocessing run. |
+
+### Sub-categories within `domain_scope_non_performance`
+
+The `domain_scope_non_performance` code covers several distinct semantic groups:
+
+| Sub-group | Examples | ~Count |
+|---|---|---:|
+| Paths and file locations | `data_directory`, `config_file`, `hba_file`, `ssl_cert_file` | 15 |
+| Identity and naming | `cluster_name`, `application_name`, `event_source` | 5 |
+| Locale and formatting | `TimeZone`, `DateStyle`, `lc_*`, `timezone_abbreviations` | 10 |
+| Replication topology | `primary_conninfo`, `recovery_target_*`, `synchronous_standby_names` | 10 |
+| Logging controls | `log_destination`, `log_directory`, `log_filename`, `log_line_prefix` | 7 |
+| Security credentials | `ssl_cert_file`, `ssl_key_file`, `ssl_ca_file`, `krb_server_keyfile` | 8 |
+| Library loading | `shared_preload_libraries`, `session_preload_libraries`, `local_preload_libraries` | 3 |
+| Misc operational | `search_path`, `temp_tablespaces`, `restrict_nonsystem_relation_kind` | 10 |
+
+---
+
+## 3. Source-stage classification rationale
+
+Policy classification happens in `retrieval.py::get_all_knobs_with_metadata()`, which calls
+`annotate_autotuning_policy()` from `src/knobs/policy.py` before returning. This adds three columns to every row of
+the 397-knob dataframe:
+
+| Column | Type | Meaning |
+|---|---|---|
+| `eligible_for_autotuning` | `bool` | `True` if the knob is admitted to the optimization search space |
+| `autotuning_exclusion_reason_code` | `str` | Category code from §2 (empty string for admitted knobs) |
+| `autotuning_exclusion_reason_detail` | `str` | Human-readable exclusion reason (empty string for admitted knobs) |
+
+Downstream preprocessing reads `eligible_for_autotuning` and defines no additional policy of its own. A separate
+bounds safety gate (`apply_bounds_safety_gate()`) excludes uncurated INT_MAX-sentinel knobs as a second pass over
+the already-annotated dataframe.
+
+### Benefits of source-stage classification
+
+- **Single authority.** `src/knobs/policy.py` is the only module where exclusion decisions are made.
+- **Full auditability.** The complete 397-row annotated dataframe is available for dashboards, reports, and tests.
+- **Structured logging.** The pipeline logs a grouped breakdown of excluded knobs by reason code at each run.
+- **Safe re-enablement.** Adding or removing a policy entry requires a change to exactly one dict in one file.
+
+---
+
+## 4. Operational guidance
+
+### Adding a new exclusion
+
+1. Look up the knob name as it appears in `pg_settings.name`.
+2. Select the appropriate `reason_code` from the table in §2.
+3. Add an entry to `AUTOTUNING_SOURCE_EXCLUSIONS` in [`src/knobs/policy.py`](../src/knobs/policy.py):
+
+	```python
+	"knob_name": (
+		 "reason_code",
+		 "One sentence explaining why this knob is excluded.",
+	),
+	```
+
+4. Update the knob's row in the [full inventory](#5-full-knob-decision-inventory-all-397) below: set Decision to
+	`Exclude`, and fill in the Reason Code and Reason columns.
+5. Run the preprocessing pipeline and confirm the exclusion count increases by 1:
+
+	```bash
+	python -m src.knobs.preprocess_knobs data/postgresql_all_knobs_demo.csv
+	```
+
+6. Run the unit tests: `pytest tests/unit/knobs/`.
+
+### Removing an exclusion (re-admitting a knob)
+
+1. Find the knob entry in `AUTOTUNING_SOURCE_EXCLUSIONS`.
+2. Verify all re-enable conditions for its `reason_code` (§2) are satisfied.
+3. Delete the entry from `AUTOTUNING_SOURCE_EXCLUSIONS`.
+4. If the knob's native max is ≥ 2,000,000,000, also add a `TuningMetadata` entry (see below).
+5. Run the preprocessing pipeline and confirm the knob appears in the expected tier CSV.
+6. Update the inventory row to `Include` and set the appropriate Reason Code.
+7. Run the unit tests: `pytest tests/unit/knobs/`.
+
+### Promoting an `uncurated_intmax_sentinel` knob
+
+The most common re-admission path. Most INT_MAX-sentinel knobs are excluded purely by the bounds safety gate, not by
+an `AUTOTUNING_SOURCE_EXCLUSIONS` entry. To promote one:
+
+1. Research practical operating bounds in the PostgreSQL documentation and community tuning guides.
+2. Add a `TuningMetadata` entry in [`src/knobs/knob_metadata.py`](../src/knobs/knob_metadata.py):
+
+	```python
+	"knob_name": TuningMetadata(
+		 description="What this knob controls.",
+		 min_val=<practical_min>,
+		 max_val=<practical_max>,
+		 unit="<unit or empty string>",
+		 impact_tier="extensive",  # or "standard", "core", "minimal"
+		 log_scale=False,          # True for memory knobs that span orders of magnitude
+	),
+	```
+
+3. Run the pipeline: the knob is automatically promoted to the correct tier CSV.
+4. Verify: `pytest tests/unit/knobs/test_knob_metadata.py`.
+
+### Changing a reason code
+
+If a knob's exclusion reason is reclassified (e.g., `stability` → `benchmark_validity`):
+
+1. Update the `AUTOTUNING_SOURCE_EXCLUSIONS` entry in `policy.py`.
+2. Update the knob's row in the inventory table below.
+3. Run the pipeline and unit tests.
+
+### Version upgrade: handling new knobs
+
+When upgrading to a new PostgreSQL minor or major version, run the preprocessing pipeline and inspect the log output
+for any new knobs appearing without a policy exclusion annotation that may represent out-of-scope parameters. Add
+entries to `AUTOTUNING_SOURCE_EXCLUSIONS` as needed before merging.
+
+---
+
+## 5. Full knob decision inventory
+
+Columns:
+
+- **Min/Max**: Curated bounds for curated knobs; native pg_settings bounds otherwise.
+- **Decision**: Include or Exclude.
+- **Reason Code / Reason**: Clear rationale category and detail.
+
+| Knob | Min | Max | Unit | Vartype | Context | Decision | Reason Code | Reason |
+|---|---:|---:|---|---|---|---|---|---|
+| DateStyle | — | — | — | string | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| IntervalStyle | — | — | — | enum | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| TimeZone | — | — | — | string | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| allow_alter_system | — | — | — | bool | sighup | Exclude | applicator_dependency | Tuner applies settings via ALTER SYSTEM; disabling this breaks configuration application. |
+| allow_in_place_tablespaces | — | — | — | bool | superuser | Exclude | storage_safety | Storage/path behavior option; excluded from autotuning safety policy. |
+| allow_system_table_mods | — | — | — | bool | superuser | Exclude | system_catalog_safety | System catalog mutation option; excluded from autotuning safety policy. |
+| application_name | — | — | — | string | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| archive_cleanup_command | — | — | — | string | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| archive_command | — | — | — | string | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| archive_library | — | — | — | string | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| archive_mode | — | — | — | enum | postmaster | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| archive_timeout | 0.0 | 1073741823.0 | s | integer | sighup | Exclude | benchmark_validity | WAL archiving timer; not relevant as benchmarks don't measure archiving latency. |
+| array_nulls | — | — | — | bool | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| authentication_timeout | 1.0 | 600.0 | s | integer | sighup | Exclude | benchmark_validity | Login timeout setting; not a workload performance tuning knob. |
+| autovacuum | — | — | — | bool | sighup | Include | admitted_curated | Enable autovacuum. Usually keep on. |
+| autovacuum_analyze_scale_factor | 0.01 | 0.5 | — | real | sighup | Include | admitted_curated | fraction of table modified for analyze. |
+| autovacuum_analyze_threshold | 0.0 | 2147483647.0 | — | integer | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| autovacuum_freeze_max_age | 100000.0 | 2000000000.0 | — | integer | postmaster | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| autovacuum_max_workers | 1 | 8 | — | integer | sighup | Include | admitted_curated | Max autovacuum worker processes. |
+| autovacuum_multixact_freeze_max_age | 10000.0 | 2000000000.0 | — | integer | postmaster | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| autovacuum_naptime | 1 | 600 | s | integer | sighup | Include | admitted_curated | Time between autovacuum runs. |
+| autovacuum_vacuum_cost_delay | -1.0 | 50.0 | ms | real | sighup | Include | admitted_curated | ms delay after cost limit is hit. |
+| autovacuum_vacuum_cost_limit | -1 | 2000 | — | integer | sighup | Include | admitted_curated | per-worker autovacuum cost limit. |
+| autovacuum_vacuum_insert_scale_factor | 0.01 | 0.5 | — | real | sighup | Include | admitted_curated | fraction of table inserted for vacuum. |
+| autovacuum_vacuum_insert_threshold | -1.0 | 2147483647.0 | — | integer | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| autovacuum_vacuum_max_threshold | -1.0 | 2147483647.0 | — | integer | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| autovacuum_vacuum_scale_factor | 0.01 | 0.5 | — | real | sighup | Include | admitted_curated | fraction of table modified for vacuum. |
+| autovacuum_vacuum_threshold | 0.0 | 2147483647.0 | — | integer | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| autovacuum_work_mem | -1.0 | 2147483647.0 | kB | integer | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| autovacuum_worker_slots | 1 | 16 | — | integer | postmaster | Include | admitted_curated | Autovacuum worker slot capacity; aligned with practical worker process limits. |
+| backend_flush_after | 0 | 256 | 8kB | integer | user | Include | admitted_curated | pages written by backend before OS flush. |
+| backslash_quote | — | — | — | enum | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| backtrace_functions | — | — | — | string | superuser | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| bgwriter_delay | 10 | 2000 | ms | integer | sighup | Include | admitted_curated | ms between bgwriter rounds. |
+| bgwriter_flush_after | 0 | 256 | 8kB | integer | sighup | Include | admitted_curated | pages written by bgwriter before OS flush. |
+| bgwriter_lru_maxpages | 0 | 1000 | — | integer | sighup | Include | admitted_curated | pages per bgwriter round. |
+| bgwriter_lru_multiplier | 0.0 | 10.0 | — | real | sighup | Include | admitted_curated | multiplier for pages to write based on recent usage. |
+| block_size | 8192.0 | 8192.0 | — | integer | internal | Exclude | internal_context | Internal parameters cannot be modified via PostgreSQL runtime/config interfaces. |
+| bonjour | — | — | — | bool | postmaster | Exclude | network_discovery | Service discovery/network behavior, not performance tuning. |
+| bonjour_name | — | — | — | string | postmaster | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| bytea_output | — | — | — | enum | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| check_function_bodies | — | — | — | bool | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| checkpoint_completion_target | 0.1 | 0.9 | — | real | sighup | Include | admitted_curated | Spread checkpoint I/O over this fraction of checkpoint_timeout. |
+| checkpoint_flush_after | 0 | 256 | 8kB | integer | sighup | Include | admitted_curated | pages written by checkpointer before OS flush. |
+| checkpoint_timeout | 30 | 3600 | s | integer | sighup | Include | admitted_curated | Max time between automatic checkpoints. Affects recovery time. |
+| checkpoint_warning | 0.0 | 2147483647.0 | s | integer | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| client_connection_check_interval | 0.0 | 2147483647.0 | ms | integer | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| client_encoding | — | — | — | string | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| client_min_messages | — | — | — | enum | user | Exclude | benchmark_validity | Low message-level settings can alter runtime overhead and benchmark comparability. |
+| cluster_name | — | — | — | string | postmaster | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| commit_delay | 0 | 10000 | — | integer | superuser | Include | admitted_curated | microseconds to wait for group commit. |
+| commit_siblings | 0 | 20 | — | integer | user | Include | admitted_curated | concurrent active transactions to trigger commit_delay. |
+| commit_timestamp_buffers | 0 | 1024 | 8kB | integer | postmaster | Include | admitted_curated | SLRU buffers for commit timestamps (must be multiple of 16). |
+| compute_query_id | — | — | — | enum | superuser | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| config_file | — | — | — | string | postmaster | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| constraint_exclusion | — | — | — | enum | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| cpu_index_tuple_cost | 0.0001 | 0.01 | — | real | user | Include | admitted_curated | Cost of processing each index entry. |
+| cpu_operator_cost | 0.0001 | 0.01 | — | real | user | Include | admitted_curated | Cost of executing operators/functions. |
+| cpu_tuple_cost | 0.001 | 0.1 | — | real | user | Include | admitted_curated | Cost of processing each row. |
+| createrole_self_grant | — | — | — | string | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| cursor_tuple_fraction | 0.0 | 1.0 | — | real | user | Include | admitted_curated | planner estimator for cursor retrieval fraction. |
+| data_checksums | — | — | — | bool | internal | Exclude | internal_context | Internal parameters cannot be modified via PostgreSQL runtime/config interfaces. |
+| data_directory | — | — | — | string | postmaster | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| data_directory_mode | 0.0 | 511.0 | — | integer | internal | Exclude | internal_context | Internal parameters cannot be modified via PostgreSQL runtime/config interfaces. |
+| data_sync_retry | — | — | — | bool | postmaster | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| deadlock_timeout | 1.0 | 2147483647.0 | ms | integer | superuser | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| debug_assertions | — | — | — | bool | internal | Exclude | internal_context | Internal parameters cannot be modified via PostgreSQL runtime/config interfaces. |
+| debug_discard_caches | 0.0 | 0.0 | — | integer | superuser | Exclude | debug_only | Debug/developer option; not valid for production workload tuning. |
+| debug_io_direct | — | — | — | string | postmaster | Exclude | debug_only | Debug/developer option; can produce high-volume internal debug output and distort benchmarks. |
+| debug_logical_replication_streaming | — | — | — | enum | user | Exclude | debug_only | Debug/developer option; not valid for production workload tuning. |
+| debug_parallel_query | — | — | — | enum | user | Exclude | debug_only | Debug/developer option; not valid for production workload tuning. |
+| debug_pretty_print | — | — | — | bool | user | Exclude | debug_only | Debug/developer option; not valid for production workload tuning. |
+| debug_print_parse | — | — | — | bool | user | Exclude | debug_only | Debug/developer option; not valid for production workload tuning. |
+| debug_print_plan | — | — | — | bool | user | Exclude | debug_only | Debug/developer option; not valid for production workload tuning. |
+| debug_print_rewritten | — | — | — | bool | user | Exclude | debug_only | Debug/developer option; not valid for production workload tuning. |
+| default_statistics_target | 10 | 10000 | — | integer | user | Include | admitted_curated | Statistics sample size for ANALYZE. Higher = better plans, slower ANALYZE. |
+| default_table_access_method | — | — | — | string | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| default_tablespace | — | — | — | string | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| default_text_search_config | — | — | — | string | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| default_toast_compression | — | — | — | enum | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| default_transaction_deferrable | — | — | — | bool | user | Exclude | semantic_behavior | Changes SQL behavioral semantics rather than performance characteristics. |
+| default_transaction_isolation | — | — | — | enum | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| default_transaction_read_only | — | — | — | bool | user | Exclude | semantic_behavior | Changes SQL behavioral semantics rather than performance characteristics. |
+| dynamic_library_path | — | — | — | string | superuser | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| dynamic_shared_memory_type | — | — | — | enum | postmaster | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| effective_cache_size | 65536 | 1048576 | 8kB | integer | user | Include | admitted_curated | Planner's OS cache estimate. Doesn't allocate memory, only affects plans. |
+| effective_io_concurrency | 0 | 200 | — | integer | user | Include | admitted_curated | Expected concurrent I/O. SSD: 100-200, HDD: 1-2 |
+| enable_async_append | — | — | — | bool | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| enable_bitmapscan | — | — | — | bool | user | Include | admitted_curated | Enable bitmap scans. |
+| enable_distinct_reordering | — | — | — | bool | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| enable_gathermerge | — | — | — | bool | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| enable_group_by_reordering | — | — | — | bool | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| enable_hashagg | — | — | — | bool | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| enable_hashjoin | — | — | — | bool | user | Include | admitted_curated | Enable hash joins. |
+| enable_incremental_sort | — | — | — | bool | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| enable_indexonlyscan | — | — | — | bool | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| enable_indexscan | — | — | — | bool | user | Include | admitted_curated | Enable index scans. Usually leave on. |
+| enable_material | — | — | — | bool | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| enable_memoize | — | — | — | bool | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| enable_mergejoin | — | — | — | bool | user | Include | admitted_curated | Enable merge joins. |
+| enable_nestloop | — | — | — | bool | user | Include | admitted_curated | Enable nested loop joins. |
+| enable_parallel_append | — | — | — | bool | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| enable_parallel_hash | — | — | — | bool | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| enable_partition_pruning | — | — | — | bool | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| enable_partitionwise_aggregate | — | — | — | bool | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| enable_partitionwise_join | — | — | — | bool | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| enable_presorted_aggregate | — | — | — | bool | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| enable_self_join_elimination | — | — | — | bool | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| enable_seqscan | — | — | — | bool | user | Include | admitted_curated | Enable sequential scans. Usually leave on. |
+| enable_sort | — | — | — | bool | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| enable_tidscan | — | — | — | bool | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| escape_string_warning | — | — | — | bool | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| event_source | — | — | — | string | postmaster | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| event_triggers | — | — | — | bool | superuser | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| exit_on_error | — | — | — | bool | user | Exclude | stability | Alters error/crash behavior and destabilizes tuning loop execution. |
+| extension_control_path | — | — | — | string | superuser | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| external_pid_file | — | — | — | string | postmaster | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| extra_float_digits | -15.0 | 3.0 | — | integer | user | Exclude | semantic_behavior | Client display precision; semantic client behavior, not server performance. |
+| file_copy_method | — | — | — | enum | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| file_extend_method | — | — | — | enum | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| from_collapse_limit | 1.0 | 2147483647.0 | — | integer | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| fsync | — | — | — | bool | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| full_page_writes | — | — | — | bool | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| geqo | — | — | — | bool | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| geqo_effort | 1 | 10 | — | integer | user | Include | admitted_curated | GEQO effort level. |
+| geqo_generations | 0.0 | 2147483647.0 | — | integer | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| geqo_pool_size | 0.0 | 2147483647.0 | — | integer | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| geqo_seed | 0.0 | 1.0 | — | real | user | Include | admitted_curated | GEQO random seed. |
+| geqo_selection_bias | 1.5 | 2.0 | — | real | user | Include | admitted_curated | GEQO selection bias. |
+| geqo_threshold | 2.0 | 2147483647.0 | — | integer | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| gin_fuzzy_search_limit | 0.0 | 2147483647.0 | — | integer | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| gin_pending_list_limit | 64.0 | 2147483647.0 | kB | integer | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| gss_accept_delegation | — | — | — | bool | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| hash_mem_multiplier | 1.0 | 8.0 | — | real | user | Include | admitted_curated | Hash operation memory multiplier; bounded to avoid aggressive memory oversubscription. |
+| hba_file | — | — | — | string | postmaster | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| hot_standby | — | — | — | bool | postmaster | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| hot_standby_feedback | — | — | — | bool | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| huge_page_size | 0.0 | 2147483647.0 | kB | integer | postmaster | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| huge_pages | — | — | — | enum | postmaster | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| huge_pages_status | — | — | — | enum | internal | Exclude | internal_context | Internal parameters cannot be modified via PostgreSQL runtime/config interfaces. |
+| icu_validation_level | — | — | — | enum | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| ident_file | — | — | — | string | postmaster | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| idle_in_transaction_session_timeout | 0.0 | 2147483647.0 | ms | integer | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| idle_replication_slot_timeout | 0.0 | 2147483647.0 | s | integer | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| idle_session_timeout | 0.0 | 2147483647.0 | ms | integer | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| ignore_checksum_failure | — | — | — | bool | superuser | Exclude | data_integrity | Dangerous data-integrity bypass option; excluded from autotuning. |
+| ignore_invalid_pages | — | — | — | bool | postmaster | Exclude | data_integrity | Dangerous data-integrity bypass option; excluded from autotuning. |
+| ignore_system_indexes | — | — | — | bool | backend | Exclude | data_integrity | Dangerous data-integrity bypass option; excluded from autotuning. |
+| in_hot_standby | — | — | — | bool | internal | Exclude | internal_context | Internal parameters cannot be modified via PostgreSQL runtime/config interfaces. |
+| integer_datetimes | — | — | — | bool | internal | Exclude | internal_context | Internal parameters cannot be modified via PostgreSQL runtime/config interfaces. |
+| io_combine_limit | 1 | 128 | 8kB | integer | user | Include | admitted_curated | I/O combine limit. |
+| io_max_combine_limit | 1 | 128 | 8kB | integer | postmaster | Include | admitted_curated | Max I/O combine limit. |
+| io_max_concurrency | -1 | 256 | — | integer | postmaster | Include | admitted_curated | Max I/O concurrency. |
+| io_method | — | — | — | enum | postmaster | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| io_workers | 1 | 16 | — | integer | sighup | Include | admitted_curated | I/O worker count (PG17+); bounded to practical CPU-core-aligned range. |
+| jit | — | — | — | bool | user | Exclude | stability | Known instability for benchmark workloads in this environment. |
+| jit_above_cost | -1.0 | 1.79769e+308 | — | real | user | Exclude | stability | Known instability for benchmark workloads in this environment. |
+| jit_debugging_support | — | — | — | bool | superuser-backend | Exclude | stability | Known instability for benchmark workloads in this environment. |
+| jit_dump_bitcode | — | — | — | bool | superuser | Exclude | stability | Known instability for benchmark workloads in this environment. |
+| jit_expressions | — | — | — | bool | user | Exclude | stability | Known instability for benchmark workloads in this environment. |
+| jit_inline_above_cost | -1.0 | 1.79769e+308 | — | real | user | Exclude | stability | Known instability for benchmark workloads in this environment. |
+| jit_optimize_above_cost | -1.0 | 1.79769e+308 | — | real | user | Exclude | stability | Known instability for benchmark workloads in this environment. |
+| jit_profiling_support | — | — | — | bool | superuser-backend | Exclude | stability | Known instability for benchmark workloads in this environment. |
+| jit_provider | — | — | — | string | postmaster | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| jit_tuple_deforming | — | — | — | bool | user | Exclude | stability | Known instability for benchmark workloads in this environment. |
+| join_collapse_limit | 1.0 | 2147483647.0 | — | integer | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| krb_caseins_users | — | — | — | bool | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| krb_server_keyfile | — | — | — | string | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| lc_messages | — | — | — | string | superuser | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| lc_monetary | — | — | — | string | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| lc_numeric | — | — | — | string | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| lc_time | — | — | — | string | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| listen_addresses | — | — | — | string | postmaster | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| lo_compat_privileges | — | — | — | bool | superuser | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| local_preload_libraries | — | — | — | string | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| lock_timeout | 0.0 | 2147483647.0 | ms | integer | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| log_autovacuum_min_duration | -1.0 | 2147483647.0 | ms | integer | sighup | Exclude | benchmark_validity | Autovacuum logging threshold; does not affect actual maintenance pacing. |
+| log_checkpoints | — | — | — | bool | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| log_connections | — | — | — | string | superuser-backend | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| log_destination | — | — | — | string | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| log_directory | — | — | — | string | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| log_disconnections | — | — | — | bool | superuser-backend | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| log_duration | — | — | — | bool | superuser | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| log_error_verbosity | — | — | — | enum | superuser | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| log_executor_stats | — | — | — | bool | superuser | Exclude | mutual_exclusion | Mutually exclusive with statement/parser/planner stats and can cause config errors. |
+| log_file_mode | 0.0 | 511.0 | — | integer | sighup | Exclude | format_readback | Octal-mode parameter with unreliable readback/validation in this pipeline. |
+| log_filename | — | — | — | string | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| log_hostname | — | — | — | bool | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| log_line_prefix | — | — | — | string | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| log_lock_failures | — | — | — | bool | superuser | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| log_lock_waits | — | — | — | bool | superuser | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| log_min_duration_sample | -1.0 | 2147483647.0 | ms | integer | superuser | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| log_min_duration_statement | -1.0 | 2147483647.0 | ms | integer | superuser | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| log_min_error_statement | — | — | — | enum | superuser | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| log_min_messages | — | — | — | enum | superuser | Exclude | benchmark_validity | Low log-level settings (debug*) can flood logs and materially skew benchmark timing. |
+| log_parameter_max_length | -1.0 | 1073741823.0 | B | integer | superuser | Exclude | benchmark_validity | Log truncation limit; does not affect workload performance. |
+| log_parameter_max_length_on_error | -1.0 | 1073741823.0 | B | integer | user | Exclude | benchmark_validity | Error log truncation; does not affect workload performance. |
+| log_parser_stats | — | — | — | bool | superuser | Exclude | mutual_exclusion | Mutually exclusive with statement/planner/executor stats and can cause config errors. |
+| log_planner_stats | — | — | — | bool | superuser | Exclude | mutual_exclusion | Mutually exclusive with statement/parser/executor stats and can cause config errors. |
+| log_recovery_conflict_waits | — | — | — | bool | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| log_replication_commands | — | — | — | bool | superuser | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| log_rotation_age | 0.0 | 35791394.0 | min | integer | sighup | Exclude | benchmark_validity | Log file rotation schedule; does not affect workload performance. |
+| log_rotation_size | 0.0 | 2147483647.0 | kB | integer | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| log_startup_progress_interval | 0.0 | 2147483647.0 | ms | integer | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| log_statement | — | — | — | enum | superuser | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| log_statement_sample_rate | 0.0 | 1.0 | — | real | superuser | Exclude | benchmark_validity | Fraction of statements logged; can skew benchmark measurements. |
+| log_statement_stats | — | — | — | bool | superuser | Exclude | mutual_exclusion | Mutually exclusive with parser/planner/executor stats and can cause config errors. |
+| log_temp_files | -1.0 | 2147483647.0 | kB | integer | superuser | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| log_timezone | — | — | — | string | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| log_transaction_sample_rate | 0.0 | 1.0 | — | real | superuser | Exclude | benchmark_validity | Fraction of transactions logged; can skew benchmark measurements. |
+| log_truncate_on_rotation | — | — | — | bool | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| logging_collector | — | — | — | bool | postmaster | Exclude | logging_pipeline_dependency | Redirects logs and interferes with restart/log-driven orchestration behavior. |
+| logical_decoding_work_mem | 64.0 | 2147483647.0 | kB | integer | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| maintenance_io_concurrency | 0 | 200 | — | integer | user | Include | admitted_curated | Maintenance I/O concurrency for VACUUM/CREATE INDEX, similar semantics to effective_io_concurrency. |
+| maintenance_work_mem | 65536 | 262144 | kB | integer | user | Include | admitted_curated | For VACUUM, CREATE INDEX. Can be larger than work_mem. |
+| max_active_replication_origins | 0.0 | 262143.0 | — | integer | postmaster | Exclude | benchmark_validity | Replication origin slots; not relevant as benchmarks don't use replication fanout. |
+| max_connections | 50 | 200 | — | integer | postmaster | Include | admitted_curated | Max concurrent connections. Requires restart. High values increase memory. |
+| max_files_per_process | 64.0 | 2147483647.0 | — | integer | postmaster | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| max_function_args | 100.0 | 100.0 | — | integer | internal | Exclude | internal_context | Internal parameters cannot be modified via PostgreSQL runtime/config interfaces. |
+| max_identifier_length | 63.0 | 63.0 | — | integer | internal | Exclude | internal_context | Internal parameters cannot be modified via PostgreSQL runtime/config interfaces. |
+| max_index_keys | 32.0 | 32.0 | — | integer | internal | Exclude | internal_context | Internal parameters cannot be modified via PostgreSQL runtime/config interfaces. |
+| max_locks_per_transaction | 10.0 | 2147483647.0 | — | integer | postmaster | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| max_logical_replication_workers | 0 | 10 | — | integer | postmaster | Include | admitted_curated | Logical replication worker cap; bounded for stability in non-replication-centric tuning runs. |
+| max_notify_queue_pages | 64.0 | 2147483647.0 | — | integer | postmaster | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| max_parallel_apply_workers_per_subscription | 0 | 8 | — | integer | sighup | Include | admitted_curated | Logical replication apply parallelism; low-impact for non-replication benchmarks but safely tunable. |
+| max_parallel_maintenance_workers | 0 | 4 | — | integer | user | Include | admitted_curated | Max parallel workers for maintenance (CREATE INDEX, VACUUM). |
+| max_parallel_workers | 0 | 16 | — | integer | user | Include | admitted_curated | Max parallel workers system-wide. Must be <= max_worker_processes. |
+| max_parallel_workers_per_gather | 0 | 4 | — | integer | user | Include | admitted_curated | Parallelism for analytical queries. Limited by CPU cores. |
+| max_pred_locks_per_page | 0.0 | 2147483647.0 | — | integer | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| max_pred_locks_per_relation | -2147483648.0 | 2147483647.0 | — | integer | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| max_pred_locks_per_transaction | 10.0 | 2147483647.0 | — | integer | postmaster | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| max_prepared_transactions | 0.0 | 262143.0 | — | integer | postmaster | Exclude | benchmark_validity | 2PC transaction slots; not used by standard OLTP/OLAP benchmarks. |
+| max_replication_slots | 0.0 | 262143.0 | — | integer | postmaster | Exclude | benchmark_validity | Replication slot cap; not relevant as benchmarks don't use replication fanout. |
+| max_slot_wal_keep_size | -1.0 | 2147483647.0 | MB | integer | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| max_stack_depth | 100.0 | 2147483647.0 | kB | integer | superuser | Exclude | os_alignment | Depends on OS stack limits and can crash backend when misaligned. |
+| max_standby_archive_delay | -1.0 | 2147483647.0 | ms | integer | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| max_standby_streaming_delay | -1.0 | 2147483647.0 | ms | integer | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| max_sync_workers_per_subscription | 0.0 | 262143.0 | — | integer | sighup | Exclude | benchmark_validity | Sync parallelism for replication; not relevant for standalone benchmarks. |
+| max_wal_senders | 0 | 10 | — | integer | postmaster | Include | admitted_curated | WAL sender process cap; safely bounded for environments without heavy replication fanout. |
+| max_wal_size | 80 | 10240 | MB | integer | sighup | Include | admitted_curated | Max WAL size before forced checkpoint. |
+| max_worker_processes | 4 | 16 | — | integer | postmaster | Include | admitted_curated | Max background workers. Requires restart. Must be >= max_parallel_workers. |
+| md5_password_warnings | — | — | — | bool | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| min_dynamic_shared_memory | 0.0 | 2147483647.0 | MB | integer | postmaster | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| min_parallel_index_scan_size | 0 | 16384 | 8kB | integer | user | Include | admitted_curated | pages required to trigger parallel index scan. |
+| min_parallel_table_scan_size | 0 | 65536 | 8kB | integer | user | Include | admitted_curated | pages required to trigger parallel table scan. |
+| min_wal_size | 80 | 2048 | MB | integer | sighup | Include | admitted_curated | Minimum WAL size to keep. |
+| multixact_member_buffers | 4 | 64 | 8kB | integer | postmaster | Include | admitted_curated | MultiXact member SLRU buffers (pages); bounded for stable memory usage. |
+| multixact_offset_buffers | 4 | 64 | 8kB | integer | postmaster | Include | admitted_curated | MultiXact offset SLRU buffers (pages); bounded for stable memory usage. |
+| notify_buffers | 4 | 64 | 8kB | integer | postmaster | Include | admitted_curated | LISTEN/NOTIFY buffers (pages); bounded for safe memory footprint. |
+| num_os_semaphores | 0.0 | 2147483647.0 | — | integer | internal | Exclude | internal_context | Internal parameters cannot be modified via PostgreSQL runtime/config interfaces. |
+| oauth_validator_libraries | — | — | — | string | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| parallel_leader_participation | — | — | — | bool | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| parallel_setup_cost | 1.0 | 10000.0 | — | real | user | Include | admitted_curated | Cost of starting parallel workers. |
+| parallel_tuple_cost | 0.0001 | 10.0 | — | real | user | Include | admitted_curated | Cost of transferring tuples between workers. |
+| password_encryption | — | — | — | enum | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| plan_cache_mode | — | — | — | enum | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| port | 1.0 | 65535.0 | — | integer | postmaster | Exclude | network_binding | Instance network binding parameter; not workload performance tuning. |
+| post_auth_delay | 0.0 | 2147.0 | s | integer | backend | Exclude | benchmark_validity | Artificially delays post-auth processing and distorts benchmark latency. |
+| pre_auth_delay | 0.0 | 60.0 | s | integer | sighup | Exclude | benchmark_validity | Artificially delays connection auth and distorts benchmark latency. |
+| primary_conninfo | — | — | — | string | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| primary_slot_name | — | — | — | string | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| quote_all_identifiers | — | — | — | bool | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| random_page_cost | 0.1 | 4.0 | — | real | user | Include | admitted_curated | Critical for index vs seqscan decisions. SSD: 1.0-1.5, HDD: 3.0-4.0 |
+| recovery_end_command | — | — | — | string | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| recovery_init_sync_method | — | — | — | enum | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| recovery_min_apply_delay | 0.0 | 2147483647.0 | ms | integer | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| recovery_prefetch | — | — | — | enum | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| recovery_target | — | — | — | string | postmaster | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| recovery_target_action | — | — | — | enum | postmaster | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| recovery_target_inclusive | — | — | — | bool | postmaster | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| recovery_target_lsn | — | — | — | string | postmaster | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| recovery_target_name | — | — | — | string | postmaster | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| recovery_target_time | — | — | — | string | postmaster | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| recovery_target_timeline | — | — | — | string | postmaster | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| recovery_target_xid | — | — | — | string | postmaster | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| recursive_worktable_factor | 0.1 | 100.0 | — | real | user | Include | admitted_curated | planner multiplier for recursive queries. |
+| remove_temp_files_after_crash | — | — | — | bool | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| reserved_connections | 0 | 5 | — | integer | postmaster | Include | admitted_curated | Reserved connection slots; conservative bounds preserve user connection capacity. |
+| restart_after_crash | — | — | — | bool | sighup | Exclude | stability | Alters crash recovery behavior and destabilizes tuning loop execution. |
+| restore_command | — | — | — | string | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| restrict_nonsystem_relation_kind | — | — | — | string | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| row_security | — | — | — | bool | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| scram_iterations | 1.0 | 2147483647.0 | — | integer | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| search_path | — | — | — | string | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| segment_size | 131072.0 | 131072.0 | 8kB | integer | internal | Exclude | internal_context | Internal parameters cannot be modified via PostgreSQL runtime/config interfaces. |
+| send_abort_for_crash | — | — | — | bool | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| send_abort_for_kill | — | — | — | bool | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| seq_page_cost | 0.1 | 2.0 | — | real | user | Include | admitted_curated | Cost of sequential page fetch. Usually kept at 1.0 as baseline. |
+| serializable_buffers | 16 | 1024 | 8kB | integer | postmaster | Include | admitted_curated | SLRU buffers for serializable transactions (must be multiple of 16). |
+| server_encoding | — | — | — | string | internal | Exclude | internal_context | Internal parameters cannot be modified via PostgreSQL runtime/config interfaces. |
+| server_version | — | — | — | string | internal | Exclude | internal_context | Internal parameters cannot be modified via PostgreSQL runtime/config interfaces. |
+| server_version_num | 180003.0 | 180003.0 | — | integer | internal | Exclude | internal_context | Internal parameters cannot be modified via PostgreSQL runtime/config interfaces. |
+| session_preload_libraries | — | — | — | string | superuser | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| session_replication_role | — | — | — | enum | superuser | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| shared_buffers | 16384 | 131072 | 8kB | integer | postmaster | Include | admitted_curated | Most impactful knob. Log scale because doubling matters more than addition. |
+| shared_memory_size | 0.0 | 2147483647.0 | MB | integer | internal | Exclude | internal_context | Internal parameters cannot be modified via PostgreSQL runtime/config interfaces. |
+| shared_memory_size_in_huge_pages | -1.0 | 2147483647.0 | — | integer | internal | Exclude | internal_context | Internal parameters cannot be modified via PostgreSQL runtime/config interfaces. |
+| shared_memory_type | — | — | — | enum | postmaster | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| shared_preload_libraries | — | — | — | string | postmaster | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| ssl | — | — | — | bool | sighup | Exclude | security_transport | Security transport policy parameter, excluded from autotuning scope. |
+| ssl_ca_file | — | — | — | string | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| ssl_cert_file | — | — | — | string | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| ssl_ciphers | — | — | — | string | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| ssl_crl_dir | — | — | — | string | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| ssl_crl_file | — | — | — | string | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| ssl_dh_params_file | — | — | — | string | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| ssl_groups | — | — | — | string | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| ssl_key_file | — | — | — | string | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| ssl_library | — | — | — | string | internal | Exclude | internal_context | Internal parameters cannot be modified via PostgreSQL runtime/config interfaces. |
+| ssl_max_protocol_version | — | — | — | enum | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| ssl_min_protocol_version | — | — | — | enum | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| ssl_passphrase_command | — | — | — | string | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| ssl_passphrase_command_supports_reload | — | — | — | bool | sighup | Exclude | security_transport | Security transport policy parameter, excluded from autotuning scope. |
+| ssl_prefer_server_ciphers | — | — | — | bool | sighup | Exclude | security_transport | Security transport policy parameter, excluded from autotuning scope. |
+| ssl_tls13_ciphers | — | — | — | string | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| standard_conforming_strings | — | — | — | bool | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| statement_timeout | 0.0 | 2147483647.0 | ms | integer | user | Exclude | benchmark_validity | Can cancel post-workload maintenance and produce false failure signals. |
+| stats_fetch_consistency | — | — | — | enum | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| subtransaction_buffers | 0 | 1024 | 8kB | integer | postmaster | Include | admitted_curated | SLRU buffers for subtransactions (must be multiple of 16). |
+| summarize_wal | — | — | — | bool | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| superuser_reserved_connections | 0 | 5 | — | integer | postmaster | Include | admitted_curated | Reserved connection slots for superusers; tuned conservatively to prevent starvation. |
+| sync_replication_slots | — | — | — | bool | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| synchronize_seqscans | — | — | — | bool | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| synchronized_standby_slots | — | — | — | string | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| synchronous_commit | — | — | — | enum | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| synchronous_standby_names | — | — | — | string | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| syslog_facility | — | — | — | enum | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| syslog_ident | — | — | — | string | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| syslog_sequence_numbers | — | — | — | bool | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| syslog_split_messages | — | — | — | bool | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| tcp_keepalives_count | 0.0 | 2147483647.0 | — | integer | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| tcp_keepalives_idle | 0.0 | 2147483647.0 | s | integer | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| tcp_keepalives_interval | 0.0 | 2147483647.0 | s | integer | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| tcp_user_timeout | 0.0 | 2147483647.0 | ms | integer | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| temp_buffers | 1024 | 4096 | 8kB | integer | user | Include | admitted_curated | Temp buffer size per session. |
+| temp_file_limit | -1.0 | 2147483647.0 | kB | integer | superuser | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| temp_tablespaces | — | — | — | string | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| timezone_abbreviations | — | — | — | string | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| trace_connection_negotiation | — | — | — | bool | postmaster | Exclude | debug_only | Debug/developer trace option; can generate noisy logs and perturb timing. |
+| trace_notify | — | — | — | bool | user | Exclude | debug_only | Debug/developer trace option; can generate noisy logs and perturb timing. |
+| trace_sort | — | — | — | bool | user | Exclude | debug_only | Debug/developer trace option; can generate noisy logs and perturb timing. |
+| track_activities | — | — | — | bool | superuser | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| track_activity_query_size | 100.0 | 1048576.0 | B | integer | postmaster | Exclude | benchmark_validity | pg_stat_activity query truncation; memory overhead is trivial and unmeasured. |
+| track_commit_timestamp | — | — | — | bool | postmaster | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| track_cost_delay_timing | — | — | — | bool | superuser | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| track_counts | — | — | — | bool | superuser | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| track_functions | — | — | — | enum | superuser | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| track_io_timing | — | — | — | bool | superuser | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| track_wal_io_timing | — | — | — | bool | superuser | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| transaction_buffers | 0 | 1024 | 8kB | integer | postmaster | Include | admitted_curated | SLRU buffers for transactions (must be multiple of 16). |
+| transaction_deferrable | — | — | — | bool | user | Exclude | session_semantics | Transaction/session semantic toggle, not a stable global performance knob. |
+| transaction_isolation | — | — | — | enum | user | Exclude | session_semantics | Transaction/session semantic toggle, not a stable global performance knob. |
+| transaction_read_only | — | — | — | bool | user | Exclude | session_semantics | Transaction/session semantic toggle, not a stable global performance knob. |
+| transaction_timeout | 0.0 | 2147483647.0 | ms | integer | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| transform_null_equals | — | — | — | bool | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| unix_socket_directories | — | — | — | string | postmaster | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| unix_socket_group | — | — | — | string | postmaster | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| unix_socket_permissions | 0.0 | 511.0 | — | integer | postmaster | Exclude | format_readback | Octal-mode parameter with unreliable readback/validation in this pipeline. |
+| update_process_title | — | — | — | bool | superuser | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| vacuum_buffer_usage_limit | 128 | 2048 | kB | integer | user | Include | admitted_curated | buffer usage limit for vacuum (pages). |
+| vacuum_cost_delay | 0.0 | 100.0 | ms | real | user | Exclude | maintenance_only | Manual VACUUM cost delay affects only post-workload unmeasured maintenance. |
+| vacuum_cost_limit | 1 | 2000 | — | integer | user | Include | admitted_curated | aggregate cost cap for vacuum. |
+| vacuum_cost_page_dirty | 0 | 1000 | — | integer | user | Include | admitted_curated | cost of dirtying a page. |
+| vacuum_cost_page_hit | 0 | 100 | — | integer | user | Include | admitted_curated | cost of vacuuming a buffer-hit page. |
+| vacuum_cost_page_miss | 0 | 1000 | — | integer | user | Include | admitted_curated | cost of vacuuming a disk-read page. |
+| vacuum_failsafe_age | 0.0 | 2100000000.0 | — | integer | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| vacuum_freeze_min_age | 0 | 100000000 | — | integer | user | Include | admitted_curated | minimum age before freezing tuples. |
+| vacuum_freeze_table_age | 0.0 | 2000000000.0 | — | integer | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| vacuum_max_eager_freeze_failure_rate | 0.0 | 1.0 | — | real | user | Include | admitted_native_bounded | Safe bounded native PostgreSQL domain (`real`). Included as an extensive-tier candidate. |
+| vacuum_multixact_failsafe_age | 0.0 | 2100000000.0 | — | integer | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| vacuum_multixact_freeze_min_age | 0 | 100000000 | — | integer | user | Include | admitted_curated | minimum age before freezing multixacts. |
+| vacuum_multixact_freeze_table_age | 0.0 | 2000000000.0 | — | integer | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| vacuum_truncate | — | — | — | bool | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| wal_block_size | 8192.0 | 8192.0 | — | integer | internal | Exclude | internal_context | Internal parameters cannot be modified via PostgreSQL runtime/config interfaces. |
+| wal_buffers | 64 | 2048 | 8kB | integer | postmaster | Include | admitted_curated | WAL buffer size. Default -1 means auto (1/32 of shared_buffers). |
+| wal_compression | — | — | — | enum | superuser | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| wal_consistency_checking | — | — | — | string | superuser | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| wal_decode_buffer_size | 65536.0 | 1073741823.0 | B | integer | postmaster | Exclude | benchmark_validity | Recovery decode buffer; benchmarks measure normal execution, not crash recovery. |
+| wal_init_zero | — | — | — | bool | superuser | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| wal_keep_size | 0.0 | 2147483647.0 | MB | integer | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| wal_level | — | — | — | enum | postmaster | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| wal_log_hints | — | — | — | bool | postmaster | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| wal_receiver_create_temp_slot | — | — | — | bool | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| wal_receiver_status_interval | 0.0 | 2147483.0 | s | integer | sighup | Exclude | benchmark_validity | Replication heartbeat interval; not relevant for standalone benchmarks. |
+| wal_receiver_timeout | 0.0 | 2147483647.0 | ms | integer | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| wal_recycle | — | — | — | bool | superuser | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| wal_retrieve_retry_interval | 1.0 | 2147483647.0 | ms | integer | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| wal_segment_size | 1048576.0 | 1073741824.0 | B | integer | internal | Exclude | internal_context | Internal parameters cannot be modified via PostgreSQL runtime/config interfaces. |
+| wal_sender_timeout | 0.0 | 2147483647.0 | ms | integer | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| wal_skip_threshold | 0.0 | 2147483647.0 | kB | integer | user | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| wal_summary_keep_time | 0.0 | 35791394.0 | min | integer | sighup | Exclude | benchmark_validity | WAL summary retention; does not affect workload performance. |
+| wal_sync_method | — | — | — | enum | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| wal_writer_delay | 1 | 5000 | ms | integer | sighup | Include | admitted_curated | ms between WAL flushes. |
+| wal_writer_flush_after | 0.0 | 2147483647.0 | 8kB | integer | sighup | Exclude | uncurated_intmax_sentinel | Native max value is INT_MAX-sentinel/unbounded; requires curated practical bounds before safe autotuning admission. |
+| work_mem | 4096 | 65536 | kB | integer | user | Include | admitted_curated | Per-operation memory. Total can be work_mem * connections * operations_per_query |
+| xmlbinary | — | — | — | enum | user | Exclude | semantic_behavior | XML encoding toggle; semantic client behavior, not server performance. |
+| xmloption | — | — | — | enum | user | Exclude | semantic_behavior | XML default handling; semantic client behavior, not server performance. |
+| zero_damaged_pages | — | — | — | bool | superuser | Exclude | data_integrity | Dangerous data-integrity bypass option; excluded from autotuning. |

--- a/src/benchmarks/sysbench/executor.py
+++ b/src/benchmarks/sysbench/executor.py
@@ -148,13 +148,13 @@ class SysbenchExecutor(BenchmarkExecutor):
         )
 
         if returncode != 0:
+            failure_detail = (stderr or stdout or "sysbench exited without output").strip()
             logger.error(
                 "Sysbench failed (exit %d): %s",
-                returncode, stderr,
+                returncode,
+                failure_detail,
             )
-            metrics = PerformanceMetrics()
-            metrics.error_rate = 1.0
-            return metrics
+            raise RuntimeError(f"Sysbench failed (exit {returncode}): {failure_detail}")
 
         metrics = self._parse_output(stdout)
         return metrics
@@ -202,7 +202,12 @@ class SysbenchExecutor(BenchmarkExecutor):
             stderr=subprocess.PIPE,
             text=True,
         )
-        stdout, stderr = process.communicate()
+        try:
+            stdout, stderr = process.communicate(timeout=duration + warmup + 15)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            stdout, stderr = process.communicate()
+            return "", "Sysbench timeout expired", -1
         return stdout, stderr, process.returncode
 
     @staticmethod

--- a/src/benchmarks/tpch/executor.py
+++ b/src/benchmarks/tpch/executor.py
@@ -256,11 +256,23 @@ class TPCHExecutor(BenchmarkExecutor):
                         f"Failed to establish healthy connection after {max_conn_retries} attempts"
                     ) from e
 
+        # Enforce safety timeout to prevent bad configs from hanging indefinitely.
+        base_timeout_ms = 300000  # 5 minutes
+        statement_timeout_ms = int(base_timeout_ms * self.scale_factor)
+
+        cursor = conn.cursor()
+        cursor.execute(f"SET statement_timeout = {statement_timeout_ms}")
+        cursor.close()
+        logger.debug(
+            "Enforcing failsafe statement_timeout=%ds for TPC-H execution (SF=%.1f)",
+            statement_timeout_ms // 1000, self.scale_factor
+        )
+
         query_indices = list(range(len(self.queries)))
 
         if warmup_passes > 0:
             logger.debug("TPC-H warmup: Executing %d cache warming pass(es)", warmup_passes)
-            cursor = conn.cursor()
+            cursor = conn.cursor()  # type: ignore
             for _ in range(warmup_passes):
                 for idx in query_indices:
                     try:
@@ -295,12 +307,12 @@ class TPCHExecutor(BenchmarkExecutor):
                 total_queries += 1
             except Exception as e:
                 errors += 1
-                total_queries += 1
-                logger.debug(
-                    "Query Q%d failed (%.0fms): %s",
+                logger.warning(
+                    "Query Q%d failed (%.0fms): %s. Fast-failing remaining queries to avoid reward hacking.",
                     idx + 1,
                     (time.time() - query_start) * 1000.0, e
                 )
+                break
 
         cursor.close()
 
@@ -309,7 +321,24 @@ class TPCHExecutor(BenchmarkExecutor):
 
         total_time = time.time() - measurement_start
 
-        # Compute metrics
+        # If any query failed, bomb the metrics to prevent reward hacking
+        if errors > 0:
+            logger.warning(
+                "TPC-H evaluation failed %d queries. Assigning fatal penalty.", errors
+            )
+            return PerformanceMetrics(
+                latency_p50=999999.9,
+                latency_p95=999999.9,
+                latency_p99=999999.9,
+                throughput=0.0,
+                memory_utilization=100.0,
+                error_rate=100.0,
+                total_queries=len(self.queries),
+                total_time=total_time,
+                failure_type="query_failed_or_timeout"
+            )
+
+        # Compute metrics for a fully successful run
         metrics = PerformanceMetrics()
         metrics.total_queries = total_queries
         metrics.total_time = total_time
@@ -327,7 +356,7 @@ class TPCHExecutor(BenchmarkExecutor):
             logger.warning("No successful queries during measurement")
 
         if total_queries > 0:
-            metrics.error_rate = errors / total_queries
+            metrics.error_rate = 0.0  # Since errors > 0 are already caught above
 
         logger.debug(
             "TPC-H results: %d queries in %.1fs, "

--- a/src/knobs/__init__.py
+++ b/src/knobs/__init__.py
@@ -1,6 +1,7 @@
 """PostgreSQL knob retrieval and analysis utilities."""
 
 from .retrieval import PostgreSQLKnobRetriever, KnobCategory, ConfigParameter
+from .policy import annotate_autotuning_policy, ensure_autotuning_policy_annotations
 from .preprocess_knobs import (
     preprocess_and_save_knobs,
     load_knobs_for_tier,
@@ -16,6 +17,8 @@ __all__ = [
     "PostgreSQLKnobRetriever",
     "KnobCategory",
     "ConfigParameter",
+    "annotate_autotuning_policy",
+    "ensure_autotuning_policy_annotations",
     "preprocess_and_save_knobs",
     "load_knobs_for_tier",
     "TuningMetadata",

--- a/src/knobs/knob_metadata.py
+++ b/src/knobs/knob_metadata.py
@@ -80,7 +80,7 @@ KNOB_TUNING_METADATA: Dict[str, TuningMetadata] = {
 
     "work_mem": TuningMetadata(
         tuning_min=4096,  # 4MB (kB)
-        tuning_max=262144,  # 256MB
+        tuning_max=65536,
         scale="log",
         impact_tier="minimal",
         tuning_priority=1,
@@ -107,7 +107,7 @@ KNOB_TUNING_METADATA: Dict[str, TuningMetadata] = {
 
     "maintenance_work_mem": TuningMetadata(
         tuning_min=65536,  # 64MB (kB)
-        tuning_max=2097152,  # 2GB
+        tuning_max=262144,
         scale="log",
         impact_tier="core",
         tuning_priority=2,
@@ -160,7 +160,7 @@ KNOB_TUNING_METADATA: Dict[str, TuningMetadata] = {
     ),
 
     "max_connections": TuningMetadata(
-        tuning_min=10,
+        tuning_min=50,
         tuning_max=200,
         scale="linear",
         impact_tier="core",
@@ -175,6 +175,120 @@ KNOB_TUNING_METADATA: Dict[str, TuningMetadata] = {
         impact_tier="core",
         tuning_priority=3,
         notes="Max background workers. Requires restart. Must be >= max_parallel_workers."
+    ),
+
+    "maintenance_io_concurrency": TuningMetadata(
+        tuning_min=0,
+        tuning_max=200,
+        scale="linear",
+        impact_tier="standard",
+        tuning_priority=3,
+        notes="Maintenance I/O concurrency for VACUUM/CREATE INDEX, " \
+        "similar semantics to effective_io_concurrency."
+    ),
+
+    "io_workers": TuningMetadata(
+        tuning_min=1,
+        tuning_max=16,
+        scale="linear",
+        impact_tier="standard",
+        tuning_priority=3,
+        notes="I/O worker count (PG17+); bounded to practical CPU-core-aligned range."
+    ),
+
+    "max_parallel_apply_workers_per_subscription": TuningMetadata(
+        tuning_min=0,
+        tuning_max=8,
+        scale="linear",
+        impact_tier="extensive",
+        tuning_priority=5,
+        notes="Logical replication apply parallelism; low-impact for " \
+        "non-replication benchmarks but safely tunable."
+    ),
+
+    "hash_mem_multiplier": TuningMetadata(
+        tuning_min=1.0,
+        tuning_max=8.0,
+        scale="linear",
+        impact_tier="standard",
+        tuning_priority=3,
+        notes="Hash operation memory multiplier; bounded to avoid " \
+        "aggressive memory oversubscription."
+    ),
+
+    "autovacuum_worker_slots": TuningMetadata(
+        tuning_min=1,
+        tuning_max=16,
+        scale="linear",
+        impact_tier="standard",
+        tuning_priority=4,
+        notes="Autovacuum worker slot capacity; aligned with practical worker process limits."
+    ),
+
+    "max_wal_senders": TuningMetadata(
+        tuning_min=0,
+        tuning_max=10,
+        scale="linear",
+        impact_tier="extensive",
+        tuning_priority=5,
+        notes="WAL sender process cap; safely bounded for " \
+        "environments without heavy replication fanout."
+    ),
+
+    "max_logical_replication_workers": TuningMetadata(
+        tuning_min=0,
+        tuning_max=10,
+        scale="linear",
+        impact_tier="extensive",
+        tuning_priority=5,
+        notes="Logical replication worker cap; bounded for " \
+        "stability in non-replication-centric tuning runs."
+    ),
+
+    "superuser_reserved_connections": TuningMetadata(
+        tuning_min=0,
+        tuning_max=5,
+        scale="linear",
+        impact_tier="extensive",
+        tuning_priority=5,
+        notes="Reserved connection slots for superusers; " \
+        "tuned conservatively to prevent starvation."
+    ),
+
+    "reserved_connections": TuningMetadata(
+        tuning_min=0,
+        tuning_max=5,
+        scale="linear",
+        impact_tier="extensive",
+        tuning_priority=5,
+        notes="Reserved connection slots; conservative bounds preserve user connection capacity."
+    ),
+
+    "notify_buffers": TuningMetadata(
+        tuning_min=4,
+        tuning_max=64,
+        scale="log",
+        impact_tier="extensive",
+        tuning_priority=5,
+        notes="LISTEN/NOTIFY buffers (pages); bounded for safe memory footprint."
+    ),
+
+    "multixact_member_buffers": TuningMetadata(
+        tuning_min=4,
+        tuning_max=64,
+        scale="log",
+        impact_tier="extensive",
+        tuning_priority=5,
+        notes="MultiXact member SLRU buffers (pages); bounded for stable memory usage."
+    ),
+
+    "multixact_offset_buffers": TuningMetadata(
+        tuning_min=4,
+        tuning_max=64,
+        scale="log",
+        impact_tier="extensive",
+        tuning_priority=5,
+        notes="MultiXact offset SLRU buffers (pages); bounded for stable memory usage."
     ),
 
     "seq_page_cost": TuningMetadata(
@@ -250,7 +364,7 @@ KNOB_TUNING_METADATA: Dict[str, TuningMetadata] = {
     ),
 
     "parallel_setup_cost": TuningMetadata(
-        tuning_min=0.0,
+        tuning_min=1.0,
         tuning_max=10000.0,
         scale="log",
         impact_tier="standard",
@@ -259,12 +373,327 @@ KNOB_TUNING_METADATA: Dict[str, TuningMetadata] = {
     ),
 
     "parallel_tuple_cost": TuningMetadata(
-        tuning_min=0.0,
-        tuning_max=1.0,
+        tuning_min=0.0001,
+        tuning_max=10.0,
         scale="log",
         impact_tier="standard",
         tuning_priority=4,
         notes="Cost of transferring tuples between workers."
+    ),
+
+    "bgwriter_delay": TuningMetadata(
+        tuning_min=10,
+        tuning_max=2000,
+        scale="log",
+        impact_tier="standard",
+        tuning_priority=4,
+        notes="ms between bgwriter rounds.",
+    ),
+
+    "bgwriter_lru_maxpages": TuningMetadata(
+        tuning_min=0,
+        tuning_max=1000,
+        scale="linear",
+        impact_tier="standard",
+        tuning_priority=4,
+        notes="pages per bgwriter round.",
+    ),
+
+    "bgwriter_flush_after": TuningMetadata(
+        tuning_min=0,
+        tuning_max=256,
+        scale="linear",
+        impact_tier="extensive",
+        tuning_priority=5,
+        notes="pages written by bgwriter before OS flush.",
+    ),
+
+    "bgwriter_lru_multiplier": TuningMetadata(
+        tuning_min=0.0,
+        tuning_max=10.0,
+        scale="linear",
+        impact_tier="extensive",
+        tuning_priority=5,
+        notes="multiplier for pages to write based on recent usage.",
+    ),
+
+    "wal_writer_delay": TuningMetadata(
+        tuning_min=1,
+        tuning_max=5000,
+        scale="log",
+        impact_tier="standard",
+        tuning_priority=4,
+        notes="ms between WAL flushes.",
+    ),
+
+    "commit_delay": TuningMetadata(
+        tuning_min=0,
+        tuning_max=10000,
+        scale="linear",
+        impact_tier="extensive",
+        tuning_priority=4,
+        notes="microseconds to wait for group commit.",
+    ),
+
+    "commit_siblings": TuningMetadata(
+        tuning_min=0,
+        tuning_max=20,
+        scale="linear",
+        impact_tier="extensive",
+        tuning_priority=4,
+        notes="concurrent active transactions to trigger commit_delay.",
+    ),
+
+    "checkpoint_flush_after": TuningMetadata(
+        tuning_min=0,
+        tuning_max=256,
+        scale="linear",
+        impact_tier="extensive",
+        tuning_priority=5,
+        notes="pages written by checkpointer before OS flush.",
+    ),
+
+    "vacuum_cost_limit": TuningMetadata(
+        tuning_min=1,
+        tuning_max=2000,
+        scale="linear",
+        impact_tier="standard",
+        tuning_priority=4,
+        notes="aggregate cost cap for vacuum.",
+    ),
+
+    "vacuum_cost_page_dirty": TuningMetadata(
+        tuning_min=0,
+        tuning_max=1000,
+        scale="linear",
+        impact_tier="extensive",
+        tuning_priority=5,
+        notes="cost of dirtying a page.",
+    ),
+
+    "vacuum_cost_page_hit": TuningMetadata(
+        tuning_min=0,
+        tuning_max=100,
+        scale="linear",
+        impact_tier="extensive",
+        tuning_priority=5,
+        notes="cost of vacuuming a buffer-hit page.",
+    ),
+
+    "vacuum_cost_page_miss": TuningMetadata(
+        tuning_min=0,
+        tuning_max=1000,
+        scale="linear",
+        impact_tier="extensive",
+        tuning_priority=5,
+        notes="cost of vacuuming a disk-read page.",
+    ),
+
+    "autovacuum_vacuum_cost_limit": TuningMetadata(
+        tuning_min=-1,
+        tuning_max=2000,
+        scale="linear",
+        impact_tier="extensive",
+        tuning_priority=4,
+        notes="per-worker autovacuum cost limit.",
+    ),
+
+    "autovacuum_vacuum_cost_delay": TuningMetadata(
+        tuning_min=-1.0,
+        tuning_max=50.0,
+        scale="linear",
+        impact_tier="extensive",
+        tuning_priority=4,
+        notes="ms delay after cost limit is hit.",
+    ),
+
+    "autovacuum_vacuum_scale_factor": TuningMetadata(
+        tuning_min=0.01,
+        tuning_max=0.5,
+        scale="linear",
+        impact_tier="extensive",
+        tuning_priority=4,
+        notes="fraction of table modified for vacuum.",
+    ),
+
+    "autovacuum_analyze_scale_factor": TuningMetadata(
+        tuning_min=0.01,
+        tuning_max=0.5,
+        scale="linear",
+        impact_tier="extensive",
+        tuning_priority=4,
+        notes="fraction of table modified for analyze.",
+    ),
+
+    "autovacuum_vacuum_insert_scale_factor": TuningMetadata(
+        tuning_min=0.01,
+        tuning_max=0.5,
+        scale="linear",
+        impact_tier="extensive",
+        tuning_priority=4,
+        notes="fraction of table inserted for vacuum.",
+    ),
+
+    "vacuum_buffer_usage_limit": TuningMetadata(
+        tuning_min=128,
+        tuning_max=2048,  # 16MB in 8k pages
+        scale="linear",
+        impact_tier="extensive",
+        tuning_priority=4,
+        notes="buffer usage limit for vacuum (pages).",
+    ),
+
+    "commit_timestamp_buffers": TuningMetadata(
+        tuning_min=0,
+        tuning_max=1024,
+        scale="log",
+        impact_tier="extensive",
+        tuning_priority=5,
+        notes="SLRU buffers for commit timestamps (must be multiple of 16).",
+    ),
+
+    "serializable_buffers": TuningMetadata(
+        tuning_min=16,
+        tuning_max=1024,
+        scale="log",
+        impact_tier="extensive",
+        tuning_priority=5,
+        notes="SLRU buffers for serializable transactions (must be multiple of 16).",
+    ),
+
+    "subtransaction_buffers": TuningMetadata(
+        tuning_min=0,
+        tuning_max=1024,
+        scale="log",
+        impact_tier="extensive",
+        tuning_priority=5,
+        notes="SLRU buffers for subtransactions (must be multiple of 16).",
+    ),
+
+    "transaction_buffers": TuningMetadata(
+        tuning_min=0,
+        tuning_max=1024,
+        scale="log",
+        impact_tier="extensive",
+        tuning_priority=5,
+        notes="SLRU buffers for transactions (must be multiple of 16).",
+    ),
+
+    "io_combine_limit": TuningMetadata(
+        tuning_min=1,
+        tuning_max=128,
+        scale="linear",
+        impact_tier="extensive",
+        tuning_priority=5,
+        notes="I/O combine limit.",
+    ),
+
+    "io_max_combine_limit": TuningMetadata(
+        tuning_min=1,
+        tuning_max=128,
+        scale="linear",
+        impact_tier="extensive",
+        tuning_priority=5,
+        notes="Max I/O combine limit.",
+    ),
+
+    "io_max_concurrency": TuningMetadata(
+        tuning_min=-1,
+        tuning_max=256,
+        scale="linear",
+        impact_tier="extensive",
+        tuning_priority=5,
+        notes="Max I/O concurrency.",
+    ),
+
+    "backend_flush_after": TuningMetadata(
+        tuning_min=0,
+        tuning_max=256,
+        scale="linear",
+        impact_tier="extensive",
+        tuning_priority=5,
+        notes="pages written by backend before OS flush.",
+    ),
+
+    "min_parallel_table_scan_size": TuningMetadata(
+        tuning_min=0,
+        tuning_max=65536,
+        scale="log",
+        impact_tier="standard",
+        tuning_priority=4,
+        notes="pages required to trigger parallel table scan.",
+    ),
+
+    "min_parallel_index_scan_size": TuningMetadata(
+        tuning_min=0,
+        tuning_max=16384,
+        scale="log",
+        impact_tier="standard",
+        tuning_priority=4,
+        notes="pages required to trigger parallel index scan.",
+    ),
+
+    "geqo_effort": TuningMetadata(
+        tuning_min=1,
+        tuning_max=10,
+        scale="linear",
+        impact_tier="extensive",
+        tuning_priority=5,
+        notes="GEQO effort level.",
+    ),
+
+    "geqo_seed": TuningMetadata(
+        tuning_min=0.0,
+        tuning_max=1.0,
+        scale="linear",
+        impact_tier="extensive",
+        tuning_priority=5,
+        notes="GEQO random seed.",
+    ),
+
+    "geqo_selection_bias": TuningMetadata(
+        tuning_min=1.5,
+        tuning_max=2.0,
+        scale="linear",
+        impact_tier="extensive",
+        tuning_priority=5,
+        notes="GEQO selection bias.",
+    ),
+
+    "cursor_tuple_fraction": TuningMetadata(
+        tuning_min=0.0,
+        tuning_max=1.0,
+        scale="linear",
+        impact_tier="extensive",
+        tuning_priority=5,
+        notes="planner estimator for cursor retrieval fraction.",
+    ),
+
+    "recursive_worktable_factor": TuningMetadata(
+        tuning_min=0.1,
+        tuning_max=100.0,
+        scale="log",
+        impact_tier="extensive",
+        tuning_priority=5,
+        notes="planner multiplier for recursive queries.",
+    ),
+
+    "vacuum_freeze_min_age": TuningMetadata(
+        tuning_min=0,
+        tuning_max=100000000,
+        scale="log",
+        impact_tier="extensive",
+        tuning_priority=4,
+        notes="minimum age before freezing tuples.",
+    ),
+
+    "vacuum_multixact_freeze_min_age": TuningMetadata(
+        tuning_min=0,
+        tuning_max=100000000,
+        scale="log",
+        impact_tier="extensive",
+        tuning_priority=4,
+        notes="minimum age before freezing multixacts.",
     ),
 
     "autovacuum": TuningMetadata(
@@ -296,7 +725,7 @@ KNOB_TUNING_METADATA: Dict[str, TuningMetadata] = {
 
     "temp_buffers": TuningMetadata(
         tuning_min=1024,  # 8MB (8kB blocks)
-        tuning_max=16384,  # 128MB
+        tuning_max=4096,  # 32MB (constrained)
         scale="log",
         impact_tier="standard",
         tuning_priority=4,
@@ -349,16 +778,18 @@ KNOB_TUNING_METADATA: Dict[str, TuningMetadata] = {
 
 # Tier definitions
 IMPACT_TIERS = {
-    "minimal": ["shared_buffers", "effective_cache_size", "work_mem", 
-                "random_page_cost", "max_parallel_workers_per_gather"],
+    "minimal": [
+        k for k, v in KNOB_TUNING_METADATA.items() if v.impact_tier == "minimal"
+    ],
 
-    "core": ["shared_buffers", "effective_cache_size", "work_mem", 
-             "random_page_cost", "max_parallel_workers_per_gather",
-             "maintenance_work_mem", "wal_buffers", "effective_io_concurrency",
-             "default_statistics_target", "checkpoint_timeout",
-             "checkpoint_completion_target", "max_connections", "max_worker_processes"],
-
-    "standard": list(KNOB_TUNING_METADATA.keys()),  # All knobs with metadata
+    "core": [
+        k for k, v in KNOB_TUNING_METADATA.items()
+        if v.impact_tier in ("minimal", "core")
+    ],
+    "standard": [
+        k for k, v in KNOB_TUNING_METADATA.items()
+        if v.impact_tier in ("minimal", "core", "standard")
+    ],
 
     "extensive": None,  # Will include all tunable knobs from pg_settings
 }
@@ -369,4 +800,4 @@ def get_knobs_by_tier(tier: str) -> list:
     tier_lower = tier.lower()
     if tier_lower not in IMPACT_TIERS:
         raise ValueError(f"Unknown tier: {tier}. Must be one of {list(IMPACT_TIERS.keys())}")
-    return IMPACT_TIERS[tier_lower]
+    return IMPACT_TIERS[tier_lower]  # type: ignore

--- a/src/knobs/policy.py
+++ b/src/knobs/policy.py
@@ -1,0 +1,371 @@
+"""Shared policy engine for PostgreSQL autotuning knob admission and exclusion."""
+
+from typing import Dict
+
+import pandas as pd
+
+from src.knobs.knob_metadata import KNOB_TUNING_METADATA
+
+
+AUTOTUNING_SOURCE_EXCLUSIONS: Dict[str, tuple[str, str]] = {
+    "vacuum_cost_delay": (
+        "maintenance_only",
+        "Manual VACUUM cost delay affects only post-workload unmeasured maintenance.",
+    ),
+    "max_stack_depth": (
+        "os_alignment",
+        "Depends on OS stack limits and can crash backend when misaligned.",
+    ),
+    "allow_alter_system": (
+        "applicator_dependency",
+        "Tuner applies settings via ALTER SYSTEM; disabling this breaks configuration application.",
+    ),
+    "bonjour": (
+        "network_discovery",
+        "Service discovery/network behavior, not performance tuning.",
+    ),
+    "transaction_deferrable": (
+        "session_semantics",
+        "Transaction/session semantic toggle, not a stable global performance knob.",
+    ),
+    "transaction_read_only": (
+        "session_semantics",
+        "Transaction/session semantic toggle, not a stable global performance knob.",
+    ),
+    "transaction_isolation": (
+        "session_semantics",
+        "Transaction/session semantic toggle, not a stable global performance knob.",
+    ),
+    "port": (
+        "network_binding",
+        "Instance network binding parameter; not workload performance tuning.",
+    ),
+    "ssl": (
+        "security_transport",
+        "Security transport policy parameter, excluded from autotuning scope.",
+    ),
+    "ssl_passphrase_command_supports_reload": (
+        "security_transport",
+        "Security transport policy parameter, excluded from autotuning scope.",
+    ),
+    "ssl_prefer_server_ciphers": (
+        "security_transport",
+        "Security transport policy parameter, excluded from autotuning scope.",
+    ),
+    "pre_auth_delay": (
+        "benchmark_validity",
+        "Artificially delays connection auth and distorts benchmark latency.",
+    ),
+    "post_auth_delay": (
+        "benchmark_validity",
+        "Artificially delays post-auth processing and distorts benchmark latency.",
+    ),
+    "log_statement_stats": (
+        "mutual_exclusion",
+        "Mutually exclusive with parser/planner/executor stats and can cause config errors.",
+    ),
+    "log_parser_stats": (
+        "mutual_exclusion",
+        "Mutually exclusive with statement/planner/executor stats and can cause config errors.",
+    ),
+    "log_planner_stats": (
+        "mutual_exclusion",
+        "Mutually exclusive with statement/parser/executor stats and can cause config errors.",
+    ),
+    "log_executor_stats": (
+        "mutual_exclusion",
+        "Mutually exclusive with statement/parser/planner stats and can cause config errors.",
+    ),
+    "log_file_mode": (
+        "format_readback",
+        "Octal-mode parameter with unreliable readback/validation in this pipeline.",
+    ),
+    "unix_socket_permissions": (
+        "format_readback",
+        "Octal-mode parameter with unreliable readback/validation in this pipeline.",
+    ),
+    "logging_collector": (
+        "logging_pipeline_dependency",
+        "Redirects logs and interferes with restart/log-driven orchestration behavior.",
+    ),
+    "jit": (
+        "stability",
+        "Known instability for benchmark workloads in this environment.",
+    ),
+    "jit_above_cost": (
+        "stability",
+        "Known instability for benchmark workloads in this environment.",
+    ),
+    "jit_inline_above_cost": (
+        "stability",
+        "Known instability for benchmark workloads in this environment.",
+    ),
+    "jit_optimize_above_cost": (
+        "stability",
+        "Known instability for benchmark workloads in this environment.",
+    ),
+    "jit_debugging_support": (
+        "stability",
+        "Known instability for benchmark workloads in this environment.",
+    ),
+    "jit_dump_bitcode": (
+        "stability",
+        "Known instability for benchmark workloads in this environment.",
+    ),
+    "jit_expressions": (
+        "stability",
+        "Known instability for benchmark workloads in this environment.",
+    ),
+    "jit_profiling_support": (
+        "stability",
+        "Known instability for benchmark workloads in this environment.",
+    ),
+    "jit_tuple_deforming": (
+        "stability",
+        "Known instability for benchmark workloads in this environment.",
+    ),
+    "statement_timeout": (
+        "benchmark_validity",
+        "Can cancel post-workload maintenance and produce false failure signals.",
+    ),
+    "zero_damaged_pages": (
+        "data_integrity",
+        "Dangerous data-integrity bypass option; excluded from autotuning.",
+    ),
+    "ignore_checksum_failure": (
+        "data_integrity",
+        "Dangerous data-integrity bypass option; excluded from autotuning.",
+    ),
+    "ignore_invalid_pages": (
+        "data_integrity",
+        "Dangerous data-integrity bypass option; excluded from autotuning.",
+    ),
+    "ignore_system_indexes": (
+        "data_integrity",
+        "Dangerous data-integrity bypass option; excluded from autotuning.",
+    ),
+    "post_column_optimize": (
+        "data_integrity",
+        "Developer/internal behavior toggle not suitable for autotuning.",
+    ),
+    "default_transaction_read_only": (
+        "semantic_behavior",
+        "Changes SQL behavioral semantics rather than performance characteristics.",
+    ),
+    "default_transaction_deferrable": (
+        "semantic_behavior",
+        "Changes SQL behavioral semantics rather than performance characteristics.",
+    ),
+    "exit_on_error": (
+        "stability",
+        "Alters error/crash behavior and destabilizes tuning loop execution.",
+    ),
+    "restart_after_crash": (
+        "stability",
+        "Alters crash recovery behavior and destabilizes tuning loop execution.",
+    ),
+    "debug_discard_caches": (
+        "debug_only",
+        "Debug/developer option; not valid for production workload tuning.",
+    ),
+    "debug_io_direct": (
+        "debug_only",
+        "Debug/developer option; can produce high-volume internal "
+        "debug output and distort benchmarks.",
+    ),
+    "debug_parallel_query": (
+        "debug_only",
+        "Debug/developer option; not valid for production workload tuning.",
+    ),
+    "debug_logical_replication_streaming": (
+        "debug_only",
+        "Debug/developer option; not valid for production workload tuning.",
+    ),
+    "debug_print_parse": (
+        "debug_only",
+        "Debug/developer option; not valid for production workload tuning.",
+    ),
+    "debug_print_plan": (
+        "debug_only",
+        "Debug/developer option; not valid for production workload tuning.",
+    ),
+    "debug_print_rewritten": (
+        "debug_only",
+        "Debug/developer option; not valid for production workload tuning.",
+    ),
+    "debug_pretty_print": (
+        "debug_only",
+        "Debug/developer option; not valid for production workload tuning.",
+    ),
+    "trace_connection_negotiation": (
+        "debug_only",
+        "Debug/developer trace option; can generate noisy logs and perturb timing.",
+    ),
+    "trace_notify": (
+        "debug_only",
+        "Debug/developer trace option; can generate noisy logs and perturb timing.",
+    ),
+    "trace_sort": (
+        "debug_only",
+        "Debug/developer trace option; can generate noisy logs and perturb timing.",
+    ),
+    "log_min_messages": (
+        "benchmark_validity",
+        "Low log-level settings (debug*) can flood logs and materially skew benchmark timing.",
+    ),
+    "client_min_messages": (
+        "benchmark_validity",
+        "Low message-level settings can alter runtime overhead and benchmark comparability.",
+    ),
+    "allow_system_table_mods": (
+        "system_catalog_safety",
+        "System catalog mutation option; excluded from autotuning safety policy.",
+    ),
+    "allow_in_place_tablespaces": (
+        "storage_safety",
+        "Storage/path behavior option; excluded from autotuning safety policy.",
+    ),
+    "log_rotation_age": (
+        "benchmark_validity",
+        "Log file rotation schedule; does not affect workload performance.",
+    ),
+    "log_parameter_max_length": (
+        "benchmark_validity",
+        "Log truncation limit; does not affect workload performance.",
+    ),
+    "log_parameter_max_length_on_error": (
+        "benchmark_validity",
+        "Error log truncation; does not affect workload performance.",
+    ),
+    "log_statement_sample_rate": (
+        "benchmark_validity",
+        "Fraction of statements logged; can skew benchmark measurements.",
+    ),
+    "log_transaction_sample_rate": (
+        "benchmark_validity",
+        "Fraction of transactions logged; can skew benchmark measurements.",
+    ),
+    "log_autovacuum_min_duration": (
+        "benchmark_validity",
+        "Autovacuum logging threshold; does not affect actual maintenance pacing.",
+    ),
+    "track_activity_query_size": (
+        "benchmark_validity",
+        "pg_stat_activity query truncation; memory overhead is trivial and unmeasured.",
+    ),
+    "authentication_timeout": (
+        "benchmark_validity",
+        "Login timeout setting; not a workload performance tuning knob.",
+    ),
+    "wal_receiver_status_interval": (
+        "benchmark_validity",
+        "Replication heartbeat interval; not relevant for standalone benchmarks.",
+    ),
+    "wal_summary_keep_time": (
+        "benchmark_validity",
+        "WAL summary retention; does not affect workload performance.",
+    ),
+    "max_active_replication_origins": (
+        "benchmark_validity",
+        "Replication origin slots; not relevant as benchmarks don't use replication fanout.",
+    ),
+    "max_replication_slots": (
+        "benchmark_validity",
+        "Replication slot cap; not relevant as benchmarks don't use replication fanout.",
+    ),
+    "max_sync_workers_per_subscription": (
+        "benchmark_validity",
+        "Sync parallelism for replication; not relevant for standalone benchmarks.",
+    ),
+    "max_prepared_transactions": (
+        "benchmark_validity",
+        "2PC transaction slots; not used by standard OLTP/OLAP benchmarks.",
+    ),
+    "archive_timeout": (
+        "benchmark_validity",
+        "WAL archiving timer; not relevant as benchmarks don't measure archiving latency.",
+    ),
+    "extra_float_digits": (
+        "semantic_behavior",
+        "Client display precision; semantic client behavior, not server performance.",
+    ),
+    "xmlbinary": (
+        "semantic_behavior",
+        "XML encoding toggle; semantic client behavior, not server performance.",
+    ),
+    "xmloption": (
+        "semantic_behavior",
+        "XML default handling; semantic client behavior, not server performance.",
+    ),
+    "wal_decode_buffer_size": (
+        "benchmark_validity",
+        "Recovery decode buffer; benchmarks measure normal execution, not crash recovery.",
+    ),
+}
+
+SOURCE_POLICY_COLUMNS = (
+    "eligible_for_autotuning",
+    "autotuning_exclusion_reason_code",
+    "autotuning_exclusion_reason_detail",
+)
+SUPPORTED_AUTOTUNING_VARTYPES = frozenset({"integer", "real", "bool", "enum"})
+INT_MAX_SENTINEL = 2_000_000_000
+
+
+def annotate_autotuning_policy(df: pd.DataFrame) -> pd.DataFrame:
+    """Annotate source-stage autotuning eligibility and exclusion reasons."""
+    annotated = df.copy()
+
+    annotated["eligible_for_autotuning"] = True
+    annotated["autotuning_exclusion_reason_code"] = ""
+    annotated["autotuning_exclusion_reason_detail"] = ""
+
+    internal_mask = annotated["context"] == "internal"
+    annotated.loc[internal_mask, "eligible_for_autotuning"] = False
+    annotated.loc[internal_mask, "autotuning_exclusion_reason_code"] = "internal_context"
+    annotated.loc[
+        internal_mask,
+        "autotuning_exclusion_reason_detail",
+    ] = "Internal parameters cannot be modified via PostgreSQL runtime/config interfaces."
+
+    for knob_name, (reason_code, reason_detail) in AUTOTUNING_SOURCE_EXCLUSIONS.items():
+        knob_mask = annotated["name"] == knob_name
+        if knob_mask.any():  # type: ignore
+            annotated.loc[knob_mask, "eligible_for_autotuning"] = False
+            annotated.loc[knob_mask, "autotuning_exclusion_reason_code"] = reason_code
+            annotated.loc[knob_mask, "autotuning_exclusion_reason_detail"] = reason_detail
+
+    return annotated
+
+
+def ensure_autotuning_policy_annotations(df: pd.DataFrame) -> pd.DataFrame:
+    """Ensure source-policy annotations are present exactly once in the workflow."""
+    if set(SOURCE_POLICY_COLUMNS).issubset(df.columns):
+        return df
+    return annotate_autotuning_policy(df)
+
+
+def apply_bounds_safety_gate(df: pd.DataFrame) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """
+    Exclude uncurated knobs with INT_MAX-style max bounds.
+
+    Returns
+    -------
+    tuple[pd.DataFrame, pd.DataFrame]
+        Filtered dataframe and dataframe of excluded knobs for audit/logging.
+    """
+    if "max_val" not in df.columns:
+        return df, df.iloc[0:0].copy()
+
+    max_vals = pd.to_numeric(df["max_val"], errors="coerce")
+    safe_bounds_mask = (
+        df["name"].isin(KNOB_TUNING_METADATA.keys())
+        | (max_vals < INT_MAX_SENTINEL)
+        | max_vals.isna()
+    )
+
+    excluded_details = df.loc[
+        ~safe_bounds_mask, ["name", "max_val", "vartype", "context"]
+    ].sort_values("name")
+
+    return df[safe_bounds_mask].copy(), excluded_details

--- a/src/knobs/preprocess_knobs.py
+++ b/src/knobs/preprocess_knobs.py
@@ -25,9 +25,69 @@ from pathlib import Path
 from typing import Optional, Dict
 import pandas as pd
 
+from src.knobs.policy import (
+    SUPPORTED_AUTOTUNING_VARTYPES,
+    apply_bounds_safety_gate,
+    ensure_autotuning_policy_annotations,
+)
 from src.knobs.retrieval import PostgreSQLKnobRetriever
 from src.knobs.knob_metadata import KNOB_TUNING_METADATA, IMPACT_TIERS
+from src.tuner.utils.logger_config import setup_logging, get_logger
 
+setup_logging()
+
+logger = get_logger(__name__)
+
+
+def _log_source_policy_exclusions(df: pd.DataFrame) -> None:
+    """Emit aggregated audit summary for source-stage policy exclusions."""
+    excluded_source = df[~df["eligible_for_autotuning"]]
+    if excluded_source.empty:
+        return
+
+    reason_counts = (
+        excluded_source["autotuning_exclusion_reason_code"]
+        .fillna("unspecified")
+        .value_counts()
+        .sort_index()
+    )
+    logger.warning(
+        "source_policy_exclusions total=%d reasons=%s",
+        len(excluded_source),
+        ", ".join(
+            f"{reason}:{count}" for reason, count in reason_counts.items()
+        ),
+    )
+
+
+import ast
+
+def _clean_enumvals(df: pd.DataFrame) -> pd.DataFrame:
+    """Remove environment-specific aliases and unsafe OS constraints from enums.
+    
+    This ensures that the tuner doesn't blindly sample values that are
+    essentially aliases (like 'on' -> 'pglz' for wal_compression) or
+    values known to crash most baseline UNIX systems (like 'io_uring').
+    """
+    df = df.copy()
+    
+    exclusions = {
+        "wal_compression": {"on"},
+        "io_method": {"io_uring", "posix"}
+    }
+    
+    for knob, ex_set in exclusions.items():
+        if knob in df["name"].values:
+            idx = df.index[df["name"] == knob].tolist()[0]
+            val = df.at[idx, "enumvals"]
+            if isinstance(val, str) and val.startswith("["):
+                try:
+                    lst = ast.literal_eval(val)
+                    lst = [x for x in lst if x not in ex_set]
+                    df.at[idx, "enumvals"] = str(lst)
+                except Exception:
+                    pass
+    return df
 
 def load_raw_knobs(csv_path: Optional[str] = None) -> pd.DataFrame:
     """
@@ -45,11 +105,13 @@ def load_raw_knobs(csv_path: Optional[str] = None) -> pd.DataFrame:
     """
     if csv_path and os.path.exists(csv_path):
         print(f"Loading raw knobs from {csv_path}")
-        return pd.read_csv(csv_path)
+        df = pd.read_csv(csv_path)
     else:
         print("Retrieving knobs from PostgreSQL...")
         retriever = PostgreSQLKnobRetriever()
-        return retriever.get_all_knobs_with_metadata()
+        df = retriever.get_all_knobs_with_metadata()
+
+    return _clean_enumvals(ensure_autotuning_policy_annotations(df))
 
 
 def add_tuning_metadata(df: pd.DataFrame) -> pd.DataFrame:
@@ -66,24 +128,47 @@ def add_tuning_metadata(df: pd.DataFrame) -> pd.DataFrame:
     pd.DataFrame
         Knobs with added tuning columns
     """
-    df["tuning_min"] = None
-    df["tuning_max"] = None
-    df["scale"] = "linear"
-    df["impact_tier"] = "extensive"
-    df["tuning_priority"] = 5
-    df["tuning_notes"] = ""
+    df_with_defaults = df.copy()
+    df_with_defaults["tuning_min"] = None
+    df_with_defaults["tuning_max"] = None
+    df_with_defaults["scale"] = "linear"
+    df_with_defaults["impact_tier"] = "extensive"
+    df_with_defaults["tuning_priority"] = 5
+    df_with_defaults["tuning_notes"] = ""
 
-    for knob_name, metadata in KNOB_TUNING_METADATA.items():
-        if knob_name in df["name"].values:
-            idx = df[df["name"] == knob_name].index[0]
-            df.at[idx, "tuning_min"] = metadata.tuning_min
-            df.at[idx, "tuning_max"] = metadata.tuning_max
-            df.at[idx, "scale"] = metadata.scale
-            df.at[idx, "impact_tier"] = metadata.impact_tier
-            df.at[idx, "tuning_priority"] = metadata.tuning_priority
-            df.at[idx, "tuning_notes"] = metadata.notes
+    metadata_rows = [
+        {
+            "name": knob_name,
+            "tuning_min_meta": metadata.tuning_min,
+            "tuning_max_meta": metadata.tuning_max,
+            "scale_meta": metadata.scale,
+            "impact_tier_meta": metadata.impact_tier,
+            "tuning_priority_meta": metadata.tuning_priority,
+            "tuning_notes_meta": metadata.notes,
+        }
+        for knob_name, metadata in KNOB_TUNING_METADATA.items()
+    ]
+    metadata_df = pd.DataFrame(metadata_rows)
 
-    return df
+    merged = df_with_defaults.merge(metadata_df, on="name", how="left")
+
+    merged["tuning_min"] = merged["tuning_min_meta"].combine_first(merged["tuning_min"])
+    merged["tuning_max"] = merged["tuning_max_meta"].combine_first(merged["tuning_max"])
+    merged["scale"] = merged["scale_meta"].combine_first(merged["scale"])
+    merged["impact_tier"] = merged["impact_tier_meta"].combine_first(merged["impact_tier"])
+    merged["tuning_priority"] = merged["tuning_priority_meta"].combine_first(merged["tuning_priority"])
+    merged["tuning_notes"] = merged["tuning_notes_meta"].combine_first(merged["tuning_notes"])
+
+    return merged.drop(
+        columns=[
+            "tuning_min_meta",
+            "tuning_max_meta",
+            "scale_meta",
+            "impact_tier_meta",
+            "tuning_priority_meta",
+            "tuning_notes_meta",
+        ]
+    )
 
 
 def filter_tunable_knobs(df: pd.DataFrame) -> pd.DataFrame:
@@ -91,9 +176,9 @@ def filter_tunable_knobs(df: pd.DataFrame) -> pd.DataFrame:
     Filter to knobs that are actually tunable.
     
     Criteria:
-    1. Not 'internal' context (cannot be changed)
-    2. Numeric (integer/real) or boolean type (easier to tune than strings)
-    3. Either has tuning metadata OR is runtime modifiable
+    1. Marked as eligible by source-stage autotuning policy classification
+    2. Numeric (integer/real), boolean, or enum type (or explicitly curated via metadata)
+    3. Passes bounds safety gate (curated metadata or bounded native max)
     
     Parameters
     ----------
@@ -105,15 +190,32 @@ def filter_tunable_knobs(df: pd.DataFrame) -> pd.DataFrame:
     pd.DataFrame
         Filtered to tunable knobs only
     """
-    tunable = df[df["context"] != "internal"].copy()
+    df = ensure_autotuning_policy_annotations(df)
+
+    tunable = df[df["eligible_for_autotuning"]].copy()
 
     has_metadata = tunable["name"].isin(KNOB_TUNING_METADATA.keys())
-    is_numeric_or_bool = tunable["vartype"].isin(["integer", "real", "bool"])
+    is_supported_vartype = tunable["vartype"].isin(SUPPORTED_AUTOTUNING_VARTYPES)
 
-    tunable = tunable[has_metadata | is_numeric_or_bool].copy()
+    tunable = tunable[has_metadata | is_supported_vartype].copy()
+
+    tunable, excluded_details = apply_bounds_safety_gate(tunable)
+    if not excluded_details.empty:
+        logger.warning(
+            "autotuning_bounds_exclusion reason_code=uncurated_intmax_sentinel count=%d",
+            len(excluded_details),
+        )
+        for _, row in excluded_details.iterrows():
+            logger.warning(
+                "  > knob=%s max_val=%s vartype=%s context=%s",
+                row["name"],
+                row["max_val"],
+                row["vartype"],
+                row["context"],
+            )
 
     tunable["requires_restart"] = tunable["context"] == "postmaster"
-    tunable["has_tuning_metadata"] = has_metadata
+    tunable["has_tuning_metadata"] = tunable["name"].isin(KNOB_TUNING_METADATA.keys())
 
     return tunable
 
@@ -140,7 +242,8 @@ def create_tier_dataframes(df: pd.DataFrame) -> Dict[str, pd.DataFrame]:
     core_knobs = IMPACT_TIERS["core"]
     tiers["core"] = df[df["name"].isin(core_knobs)].copy()
 
-    tiers["standard"] = df[df["has_tuning_metadata"]].copy()
+    standard_knobs = IMPACT_TIERS["standard"]
+    tiers["standard"] = df[df["name"].isin(standard_knobs)].copy()
 
     tiers["extensive"] = df.copy()
 
@@ -187,6 +290,8 @@ def preprocess_and_save_knobs(
     print(f"  Added metadata for {with_metadata_count} knobs")
 
     print("\n[3/4] Filtering to tunable knobs...")
+    _log_source_policy_exclusions(df_with_metadata)
+
     df_tunable = filter_tunable_knobs(df_with_metadata)
     print(f"  Filtered to {len(df_tunable)} tunable knobs")
     print(f"    - Requires restart: {df_tunable['requires_restart'].sum()}")

--- a/src/knobs/retrieval.py
+++ b/src/knobs/retrieval.py
@@ -25,6 +25,7 @@ from sqlalchemy.engine import Engine
 
 from src.config.database import get_db_config, DatabaseConfig
 from src.database.connection import get_connection, get_engine
+from src.knobs.policy import annotate_autotuning_policy
 
 
 class KnobCategory(Enum):
@@ -468,7 +469,7 @@ class PostgreSQLKnobRetriever:
             ["internal", "postmaster"]
         )
 
-        return all_params
+        return annotate_autotuning_policy(all_params)
 
     def save_all_knobs(self, filepath: str, include_metadata: bool = True) -> None:
         """

--- a/src/scripts/analyze_knobs.py
+++ b/src/scripts/analyze_knobs.py
@@ -115,7 +115,7 @@ def main():
     print("\n7. Exporting All Knobs:")
     print("-" * 23)
     output_path = os.path.join(
-        os.path.dirname(__file__), "..", "..", "data", "postgresql_all_knobs_demo.csv"
+        os.path.dirname(__file__), "..", "..", "data", "postgresql_all_knobs.csv"
     )
     output_path = os.path.normpath(output_path)
     retriever.save_all_knobs(output_path, include_metadata=True)

--- a/src/scripts/cleanup_instances.py
+++ b/src/scripts/cleanup_instances.py
@@ -6,6 +6,7 @@ Stops all running instances and optionally removes data directories.
 
 import argparse
 import logging
+import sys
 from pathlib import Path
 
 from src.tuner.utils import PostgresInstanceManager
@@ -33,15 +34,15 @@ def main():
         action='store_true',
         help='Force removal without confirmation'
     )
-    
+
     args = parser.parse_args()
-    
+
     base_dir = Path(args.base_dir)
-    
+
     if not base_dir.exists():
         print(f"No instances found at {base_dir}")
         return 0
-    
+
     # Confirm data removal
     if args.remove_data and not args.force:
         print(f"\n⚠️  WARNING: This will PERMANENTLY DELETE all data in {base_dir}")
@@ -49,19 +50,19 @@ def main():
         if response.lower() != 'yes':
             print("Aborted.")
             return 0
-    
+
     print(f"\nCleaning up instances in {base_dir}...")
-    
+
     # Create manager (will find existing instances)
     manager = PostgresInstanceManager(
         base_dir=base_dir,
         base_port=5432
     )
-    
+
     # Detect running instances by checking data directories
     worker_dirs = sorted(base_dir.glob('worker_*'))
     print(f"Found {len(worker_dirs)} instance directories")
-    
+
     # Attempt to stop each one
     for worker_dir in worker_dirs:
         worker_id = int(worker_dir.name.split('_')[1])
@@ -72,12 +73,12 @@ def main():
             'running': True
         })()
         manager.instances[worker_id] = instance_config
-    
+
     # Stop all
     print("\nStopping all instances...")
     manager.stop_all(mode='immediate')
     print("✓ All instances stopped")
-    
+
     # Remove data if requested
     if args.remove_data:
         print("\nRemoving data directories...")
@@ -85,7 +86,7 @@ def main():
         print("✓ Data directories removed")
     else:
         print("\nData directories preserved (use --remove-data to delete)")
-    
+
     print("\n✓ Cleanup complete!")
     return 0
 

--- a/src/tuner/config/knob_loader.py
+++ b/src/tuner/config/knob_loader.py
@@ -16,6 +16,7 @@ This approach provides:
 - Separation of data retrieval from optimization logic
 """
 
+import ast
 from pathlib import Path
 from typing import Dict, Any, List, Optional
 import pandas as pd
@@ -55,12 +56,81 @@ def parse_enumvals(enumvals_str: Any) -> Optional[List[str]]:
     if pd.isna(enumvals_str) or enumvals_str == "":
         return None
 
+    if isinstance(enumvals_str, list):
+        return [str(value) for value in enumvals_str]
+
     if isinstance(enumvals_str, str):
-        # Remove braces and split
-        clean = enumvals_str.strip("{}")
-        return [v.strip() for v in clean.split(",") if v.strip()]
+        try:
+            parsed = ast.literal_eval(enumvals_str)
+        except (ValueError, SyntaxError):
+            parsed = None
+
+        if isinstance(parsed, list):
+            return [str(value) for value in parsed]
+
+        if enumvals_str.startswith("{") and enumvals_str.endswith("}"):
+            clean = enumvals_str[1:-1]
+            return [value.strip().strip("\"'") for value in clean.split(",") if value.strip()]
+
+        return [enumvals_str]
 
     return None
+
+
+def _parse_numeric_bound(raw_value: Any, knob_type: KnobType) -> Optional[float | int]:
+    """Parse a numeric bound from CSV data if present."""
+    if pd.isna(raw_value):
+        return None
+
+    if knob_type == KnobType.REAL:
+        return float(raw_value)
+    return int(float(raw_value))
+
+
+def _resolve_numeric_bounds(
+    row: pd.Series,
+    knob_type: KnobType
+) -> tuple[Optional[float | int], Optional[float | int]]:
+    """Resolve effective numeric bounds by intersecting curated and native limits."""
+    native_min = _parse_numeric_bound(row.get("min_val"), knob_type)
+    native_max = _parse_numeric_bound(row.get("max_val"), knob_type)
+    tuning_min = _parse_numeric_bound(row.get("tuning_min"), knob_type)
+    tuning_max = _parse_numeric_bound(row.get("tuning_max"), knob_type)
+
+    min_candidates = [value for value in (native_min, tuning_min) if value is not None]
+    max_candidates = [value for value in (native_max, tuning_max) if value is not None]
+
+    min_value = max(min_candidates) if min_candidates else None
+    max_value = min(max_candidates) if max_candidates else None
+
+    if (
+        min_value is not None
+        and max_value is not None
+        and min_value > max_value
+    ):
+        min_value = native_min if native_min is not None else tuning_min
+        max_value = native_max if native_max is not None else tuning_max
+
+    return min_value, max_value
+
+
+INTEGER_STEP_OVERRIDES = {
+    "commit_timestamp_buffers": 16,
+    "multixact_member_buffers": 16,
+    "multixact_offset_buffers": 16,
+    "notify_buffers": 16,
+    "serializable_buffers": 16,
+    "subtransaction_buffers": 16,
+    "transaction_buffers": 16,
+}
+
+
+def _infer_integer_step(row: pd.Series, knob_type: KnobType) -> Optional[int]:
+    """Infer integer step alignment for knobs with discrete valid grids."""
+    if knob_type != KnobType.INTEGER:
+        return None
+
+    return INTEGER_STEP_OVERRIDES.get(str(row["name"]))
 
 
 def load_knob_space_from_csv(csv_path: str) -> KnobSpace:
@@ -96,17 +166,10 @@ def load_knob_space_from_csv(csv_path: str) -> KnobSpace:
         max_value = None
 
         if knob_type in [KnobType.INTEGER, KnobType.REAL]:
-            if pd.notna(row.get("tuning_min")):
-                min_value = row["tuning_min"]
-            elif pd.notna(row.get("min_val")):
-                min_value = float(row["min_val"]) if knob_type == KnobType.REAL else int(row["min_val"])
-
-            if pd.notna(row.get("tuning_max")):
-                max_value = row["tuning_max"]
-            elif pd.notna(row.get("max_val")):
-                max_value = float(row["max_val"]) if knob_type == KnobType.REAL else int(row["max_val"])
+            min_value, max_value = _resolve_numeric_bounds(row, knob_type)
 
         enumvals = parse_enumvals(row.get("enumvals"))
+        integer_step = _infer_integer_step(row, knob_type)
 
         default = row.get("boot_val") or row.get("value")
         if knob_type == KnobType.INTEGER and default is not None:
@@ -131,6 +194,7 @@ def load_knob_space_from_csv(csv_path: str) -> KnobSpace:
             default=default,
             unit=row.get("unit") if pd.notna(row.get("unit")) else None,
             enum_values=enumvals,
+            step=integer_step,
             description=row.get("description", ""),
             category=row.get("custom_category", "other"),
             restart_required=row.get("requires_restart", False),

--- a/src/tuner/config/knob_space.py
+++ b/src/tuner/config/knob_space.py
@@ -27,6 +27,9 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Union, Tuple
 from enum import Enum
 import numpy as np
+from src.tuner.utils.logger_config import get_logger
+
+logger = get_logger(__name__)
 
 
 class KnobType(Enum):
@@ -73,6 +76,8 @@ class KnobDefinition:
         Functional category (memory, planner, etc.)
     restart_required : bool
         Whether changing requires PostgreSQL restart
+    step : Optional[int]
+        Optional discrete step alignment for integer knobs
     """
 
     name: str
@@ -86,6 +91,51 @@ class KnobDefinition:
     description: str = ""
     category: str = "other"
     restart_required: bool = False
+    step: Optional[int] = None
+
+    def _normalize_integer(self, value: Any) -> int:
+        """Clamp and align integer values to the valid discrete grid."""
+        normalized = int(value)
+
+        if self.min_value is not None:
+            normalized = max(normalized, int(self.min_value))
+        if self.max_value is not None:
+            normalized = min(normalized, int(self.max_value))
+
+        if self.step and self.step > 1:
+            base = int(self.min_value) if self.min_value is not None else 0
+            offset = normalized - base
+            normalized = base + int(round(offset / self.step)) * self.step
+
+            if self.min_value is not None:
+                normalized = max(normalized, int(self.min_value))
+            if self.max_value is not None:
+                normalized = min(normalized, int(self.max_value))
+
+        return normalized
+
+    def normalize_value(self, value: Any) -> Any:
+        """Normalize a candidate value into this knob's valid domain."""
+        if self.knob_type == KnobType.INTEGER:
+            return self._normalize_integer(value)
+
+        if self.knob_type == KnobType.REAL:
+            normalized = float(value)
+            if self.min_value is not None:
+                normalized = max(normalized, float(self.min_value))
+            if self.max_value is not None:
+                normalized = min(normalized, float(self.max_value))
+            return normalized
+
+        if self.knob_type == KnobType.BOOLEAN:
+            return bool(value)
+
+        if self.knob_type == KnobType.ENUM:
+            if self.enum_values is None:
+                return value
+            return str(value)
+
+        return value
 
     def validate_value(self, value: Any) -> bool:
         """
@@ -108,6 +158,10 @@ class KnobDefinition:
                 return False
             if self.max_value is not None and value > self.max_value:
                 return False
+            if self.step and self.step > 1:
+                base = int(self.min_value) if self.min_value is not None else 0
+                if (int(value) - base) % self.step != 0:
+                    return False
             return True
 
         elif self.knob_type == KnobType.REAL:
@@ -147,13 +201,20 @@ class KnobDefinition:
             rng = np.random.default_rng()
 
         if self.knob_type == KnobType.INTEGER:
-            if self.scale == KnobScale.LOG:
+            if self.scale == KnobScale.LOG and self.min_value is not None and self.min_value > 0:
                 log_min = np.log(self.min_value)  # type: ignore
                 log_max = np.log(self.max_value)  # type: ignore
                 log_value = rng.uniform(log_min, log_max)
-                return int(np.exp(log_value))
-            else:
-                return rng.integers(self.min_value, self.max_value + 1)  # type: ignore
+                return self._normalize_integer(np.exp(log_value))
+
+            if self.step and self.step > 1:
+                min_value = int(self.min_value)  # type: ignore
+                max_value = int(self.max_value)  # type: ignore
+                num_steps = ((max_value - min_value) // self.step) + 1
+                step_index = int(rng.integers(0, num_steps))
+                return min_value + step_index * self.step
+
+            return int(rng.integers(self.min_value, self.max_value + 1))  # type: ignore
 
         elif self.knob_type == KnobType.REAL:
             if self.scale == KnobScale.LOG:
@@ -168,7 +229,7 @@ class KnobDefinition:
             return bool(rng.choice([True, False]))
 
         elif self.knob_type == KnobType.ENUM:
-            return rng.choice(self.enum_values)  # type: ignore
+            return str(rng.choice(self.enum_values))  # type: ignore
 
         return self.default
 
@@ -292,6 +353,122 @@ class KnobSpace:
 
         return (len(errors) == 0, errors)
 
+    def repair_config_dependencies(self, config: Dict[str, Any], worker_id: Optional[int] = None) -> Dict[str, Any]:
+        """Repair known cross-knob combinations that can make PostgreSQL unstartable."""
+        worker_logger = get_logger(__name__, worker_id=worker_id) if worker_id is not None else logger
+        repaired = dict(config)
+
+        wal_level = repaired.get("wal_level")
+        if wal_level == "minimal":
+            if repaired.get("archive_mode") in {"on", "always"}:
+                worker_logger.warning(
+                    "[REPAIR] Corrected 'archive_mode' from '%s' to 'off' "
+                    "because wal_level is 'minimal'",
+                    repaired["archive_mode"]
+                )
+                repaired["archive_mode"] = "off"
+
+            max_wal_senders = repaired.get("max_wal_senders")
+            if isinstance(
+                max_wal_senders,
+                (int, np.integer, float, np.floating)
+            ) and max_wal_senders > 0:
+                worker_logger.warning(
+                    "[REPAIR] Corrected 'max_wal_senders' from %s to 0 "
+                    "because wal_level is 'minimal'",
+                    repaired["max_wal_senders"]
+                )
+                repaired["max_wal_senders"] = 0
+
+            summarize_wal = repaired.get("summarize_wal")
+            if str(summarize_wal).lower() in {"on", "true", "1"}:
+                worker_logger.warning(
+                    "[REPAIR] Corrected 'summarize_wal' from '%s' to 'off' "
+                    "because wal_level is 'minimal'",
+                    repaired["summarize_wal"]
+                )
+                repaired["summarize_wal"] = "off"
+
+        # Handle huge_pages OS constraints
+        huge_pages = repaired.get("huge_pages")
+        if huge_pages in {"on", "try"}:
+            # huge_pages is not supported with sysv shared_memory_type
+            if repaired.get("shared_memory_type") == "sysv":
+                worker_logger.warning(
+                    "[REPAIR] Corrected 'shared_memory_type' from 'sysv' to 'mmap' "
+                    "because huge_pages is '%s'",
+                    huge_pages
+                )
+                repaired["shared_memory_type"] = "mmap"
+
+            # If huge_pages="on" in standard envs without configured huge pages,
+            # the process strictly crashes. Convert "on" to "try" to allow graceful
+            # fallback but retain performance if possible.
+            if huge_pages == "on":
+                worker_logger.warning(
+                    "[REPAIR] Corrected 'huge_pages' from 'on' to 'try' "
+                    "to allow graceful OS fallback"
+                )
+                repaired["huge_pages"] = "try"
+
+        # Handle max_worker_processes vs max_parallel_workers constraints
+        max_worker = repaired.get("max_worker_processes")
+        max_parallel = repaired.get("max_parallel_workers")
+        if (
+            isinstance(max_worker, (int, float, np.number)) and
+            isinstance(max_parallel, (int, float, np.number))
+        ):
+            if max_worker < max_parallel:
+                worker_logger.warning(
+                    "[REPAIR] Corrected 'max_parallel_workers' from %s to %s "
+                    "because it cannot exceed 'max_worker_processes'",
+                    max_parallel, max_worker
+                )
+                repaired["max_parallel_workers"] = int(max_worker)
+
+        # Handle min_wal_size vs max_wal_size constraint
+        min_wal = repaired.get("min_wal_size")
+        max_wal = repaired.get("max_wal_size")
+        if (
+            isinstance(min_wal, (int, float, np.number)) and
+            isinstance(max_wal, (int, float, np.number))
+        ):
+            if min_wal > max_wal:
+                new_min_wal = max(1, int(max_wal) // 2)  # Give it a reasonable gap
+                worker_logger.warning(
+                    "[REPAIR] Corrected 'min_wal_size' from %s to %s "
+                    "because it cannot exceed 'max_wal_size' (%s)",
+                    min_wal, new_min_wal, max_wal
+                )
+                repaired["min_wal_size"] = new_min_wal
+
+        # Handle connection slot constraints
+        max_conn = repaired.get("max_connections")
+        res_conn = repaired.get("reserved_connections", 0)
+        super_res = repaired.get("superuser_reserved_connections", 0)
+
+        if (
+            isinstance(max_conn, (int, float, np.number)) and
+            isinstance(res_conn, (int, float, np.number)) and
+            isinstance(super_res, (int, float, np.number))
+        ):
+            reserved_total = int(res_conn) + int(super_res)
+            if reserved_total >= int(max_conn):
+                new_max = reserved_total + 10  # Ensure at least 10 slots for regular users
+                worker_logger.warning(
+                    "[REPAIR] Corrected 'max_connections' from %s to %s "
+                    "because reserved slots (%s) consumed all capacity",
+                    max_conn, new_max, reserved_total
+                )
+                repaired["max_connections"] = new_max
+
+        # Ensure all modified numerical knobs still strictly conform to their bounds/steps
+        for k, v in repaired.items():
+            if k in self.knobs and self.knobs[k].knob_type in (KnobType.INTEGER, KnobType.REAL):
+                repaired[k] = self.knobs[k].normalize_value(v)
+
+        return repaired
+
     def sample_random_config(self, seed: Optional[int] = None) -> Dict[str, Any]:
         """
         Sample a random configuration.
@@ -312,7 +489,7 @@ class KnobSpace:
         for knob_name, knob_def in self.knobs.items():
             config[knob_name] = knob_def.sample_random_value(rng)
 
-        return config
+        return self.repair_config_dependencies(config)
 
     def sample_diverse_configs(
         self,
@@ -368,14 +545,14 @@ class KnobSpace:
             for i in range(num_samples):
                 u = rng.uniform(intervals[i], intervals[i + 1])
 
-                if knob_def.scale == KnobScale.LOG:
+                if knob_def.scale == KnobScale.LOG and knob_def.min_value is not None and knob_def.min_value > 0:
                     log_min = np.log(knob_def.min_value)  # type: ignore
                     log_max = np.log(knob_def.max_value)  # type: ignore
                     log_value = log_min + u * (log_max - log_min)
                     value = np.exp(log_value)
 
                     if knob_def.knob_type == KnobType.INTEGER:
-                        value = int(value)
+                        value = knob_def.normalize_value(value)
                     else:
                         value = float(value)
                 else:
@@ -384,7 +561,7 @@ class KnobSpace:
                         )  # type: ignore
 
                     if knob_def.knob_type == KnobType.INTEGER:
-                        value = int(value)
+                        value = knob_def.normalize_value(value)
                     else:
                         value = float(value)
 
@@ -428,7 +605,7 @@ class KnobSpace:
             for knob_name, _ in categorical_knobs:
                 config[knob_name] = categorical_samples[knob_name][i]
 
-            configs.append(config)
+            configs.append(self.repair_config_dependencies(config))
 
         return configs
 
@@ -437,6 +614,7 @@ class KnobSpace:
         config: Dict[str, Any],
         perturbation_factor: Tuple[float, float] = (0.8, 1.2),
         seed: Optional[int] = None,
+        worker_id: Optional[int] = None,
         exclude_knobs: Optional[List[str]] = None
     ) -> Dict[str, Any]:
         """
@@ -453,6 +631,8 @@ class KnobSpace:
             (min_factor, max_factor) for perturbation. Default (0.8, 1.2) means ±20%
         seed : Optional[int]
             Random seed
+        worker_id : Optional[int]
+            Worker ID for reproducibility
         exclude_knobs : Optional[List[str]]
             List of knob names to exclude from perturbation (keep unchanged)
             
@@ -478,18 +658,12 @@ class KnobSpace:
                         np.log(perturbation_factor[0]),
                         np.log(perturbation_factor[1]),
                     )
-                    new_value = int(np.exp(np.log(value) + log_factor))
+                    new_value = np.exp(np.log(value) + log_factor)
                 else:
                     factor = rng.uniform(perturbation_factor[0], perturbation_factor[1])
-                    new_value = int(value * factor)
+                    new_value = value * factor
 
-                # Ensuring valid range...
-                if knob_def.min_value is not None:
-                    new_value = max(new_value, knob_def.min_value)
-                if knob_def.max_value is not None:
-                    new_value = min(new_value, knob_def.max_value)
-
-                perturbed[knob_name] = new_value
+                perturbed[knob_name] = knob_def.normalize_value(new_value)
 
             elif knob_def.knob_type == KnobType.REAL:
                 if knob_def.scale == KnobScale.LOG and value > 0:
@@ -507,7 +681,7 @@ class KnobSpace:
                 if knob_def.max_value is not None:
                     new_value = min(new_value, knob_def.max_value)
 
-                perturbed[knob_name] = new_value
+                perturbed[knob_name] = knob_def.normalize_value(new_value)
 
             elif knob_def.knob_type == KnobType.BOOLEAN:
                 # For boolean: higher probability (30%) since only 2 values
@@ -529,14 +703,14 @@ class KnobSpace:
                     # This ensures we actually explore when we perturb
                     if knob_def.enum_values and len(knob_def.enum_values) > 1:
                         other_values = [v for v in knob_def.enum_values if v != value]
-                        perturbed[knob_name] = rng.choice(other_values)
+                        perturbed[knob_name] = str(rng.choice(other_values))
                     else:
                         # Fallback for degenerate case
                         perturbed[knob_name] = value
                 else:
                     perturbed[knob_name] = value
 
-        return perturbed
+        return self.repair_config_dependencies(perturbed, worker_id=worker_id)
 
     def get_default_config(self) -> Dict[str, Any]:
         """

--- a/src/tuner/config/tuner_config.py
+++ b/src/tuner/config/tuner_config.py
@@ -104,6 +104,20 @@ class PBTConfig:
     sysbench_table_size : int
         Number of rows per table for Sysbench workload.
         Default: 100000
+
+    dead_config_threshold : float
+        Score threshold below which a worker is considered dead and marked
+        for end-of-generation rescue logic.
+        Default: 6.0
+
+    dead_config_score : float
+        Score assigned to unrecoverable dead configurations (e.g., connection failures).
+        Default: 1.0
+
+    crash_score : float
+        Score assigned to crash/timeout style failures that are severe but potentially
+        less catastrophic than complete connection death.
+        Default: 5.0
     """
 
     population_size: int = 4
@@ -123,6 +137,9 @@ class PBTConfig:
     verbose: bool = True
     sysbench_tables: int = 10
     sysbench_table_size: int = 100000
+    dead_config_threshold: float = 6.0
+    dead_config_score: float = 1.0
+    crash_score: float = 5.0
 
     def __post_init__(self):
         """Validate configuration after initialization"""
@@ -165,6 +182,14 @@ class PBTConfig:
         if self.warmup_passes < 0:
             raise ValueError("warmup_passes cannot be negative")
 
+        if not 0.0 < self.dead_config_score < self.crash_score:
+            raise ValueError("dead_config_score must be > 0 and less than crash_score")
+
+        if not self.crash_score < self.dead_config_threshold < 100.0:
+            raise ValueError(
+                "dead_config_threshold must be greater than crash_score and less than 100"
+            )
+
     @property
     def num_workers_per_quantile(self) -> int:
         """
@@ -200,6 +225,9 @@ class PBTConfig:
             "verbose": self.verbose,
             "sysbench_tables": self.sysbench_tables,
             "sysbench_table_size": self.sysbench_table_size,
+            "dead_config_threshold": self.dead_config_threshold,
+            "dead_config_score": self.dead_config_score,
+            "crash_score": self.crash_score,
         }
 
     def __repr__(self) -> str:
@@ -213,7 +241,10 @@ class PBTConfig:
             f"(bottom {n} copy from top {n}),\n"
             f"  ready_interval={self.ready_interval},\n"
             f"  perturbation_factors={self.perturbation_factors},\n"
-            f"  num_parallel_workers={self.num_parallel_workers}\n"
+            f"  num_parallel_workers={self.num_parallel_workers},\n"
+            f"  dead_config_threshold={self.dead_config_threshold},\n"
+            f"  dead_config_score={self.dead_config_score},\n"
+            f"  crash_score={self.crash_score}\n"
             f")"
         )
 

--- a/src/tuner/core/evolution.py
+++ b/src/tuner/core/evolution.py
@@ -35,7 +35,6 @@ import logging
 import numpy as np
 
 from src.tuner.core.worker import Worker
-from src.tuner.utils.logger_config import WorkerLoggerAdapter
 
 logger = logging.getLogger(__name__)
 
@@ -43,7 +42,8 @@ logger = logging.getLogger(__name__)
 def truncation_selection(
     workers: List[Worker],
     exploit_quantile: float = 0.2,
-    require_ready: bool = True
+    require_ready: bool = True,
+    dead_config_threshold: float = 6.0,
 ) -> List[Tuple[int, int]]:
     """
     Identify which workers should exploit (copy from) which elite workers.
@@ -64,6 +64,11 @@ def truncation_selection(
     require_ready : bool
         If True, only consider ready workers for exploitation
         Default: True (prevents exploiting workers still warming up)
+
+    dead_config_threshold : float
+        Score threshold below which a worker is treated as a dead config.
+        Dead workers are always included in rescue (poor pool), bypassing
+        ready gating and quantile limits.
         
     Returns
     -------
@@ -81,25 +86,86 @@ def truncation_selection(
     - Avoids everyone converging to single best config
     - Matches original PBT paper    
     """
-    if require_ready:
-        eligible_workers = [w for w in workers if w.is_ready()]
-    else:
-        eligible_workers = workers
-
-    if len(eligible_workers) < 2:
+    if len(workers) < 2:
         return []
 
-    n_workers = len(eligible_workers)
-    quantile_size = max(1, int(n_workers * exploit_quantile))
+    dead_workers = [w for w in workers if w.performance_score < dead_config_threshold]
 
-    sorted_workers = sorted(
-        eligible_workers,
+    if require_ready:
+        ready_workers = [w for w in workers if w.is_ready()]
+    else:
+        ready_workers = workers
+
+    if len(ready_workers) < 2:
+        return []
+
+    quantile_size = max(1, int(len(ready_workers) * exploit_quantile))
+
+    ready_non_dead = [w for w in ready_workers if w.performance_score >= dead_config_threshold]
+    elite_candidates = ready_non_dead.copy()
+
+    if not elite_candidates:
+        elite_candidates = [w for w in workers if w.performance_score >= dead_config_threshold]
+        if require_ready and elite_candidates:
+            logger.warning(
+                "No ready non-dead workers available for elites; "
+                "falling back to non-dead workers regardless of readiness"
+            )
+
+    if not elite_candidates:
+        logger.warning("No non-dead workers available; skipping exploit-explore rescue")
+        return []
+
+    sorted_elites = sorted(
+        elite_candidates,
         key=lambda w: w.performance_score,
         reverse=True
     )
+    elite_workers = sorted_elites[:min(quantile_size, len(sorted_elites))]
 
-    elite_workers = sorted_workers[:quantile_size]
-    poor_workers = sorted_workers[-quantile_size:]
+    normal_poor_workers: List[Worker] = []
+    normal_quantile_size = 0
+    if ready_non_dead:
+        normal_quantile_size = quantile_size
+        sorted_ready_non_dead = sorted(
+            ready_non_dead,
+            key=lambda w: w.performance_score,
+            reverse=False
+        )
+        normal_poor_workers = sorted_ready_non_dead[:normal_quantile_size]
+
+    elite_worker_ids = {w.worker_id for w in elite_workers}
+    poor_workers: List[Worker] = []
+    seen_worker_ids = set()
+
+    target_poor_count = max(len(dead_workers), normal_quantile_size)
+    candidate_workers = dead_workers.copy()
+
+    if len(candidate_workers) < target_poor_count:
+        for worker in normal_poor_workers:
+            if worker.worker_id in {w.worker_id for w in candidate_workers}:
+                continue
+            candidate_workers.append(worker)
+            if len(candidate_workers) >= target_poor_count:
+                break
+
+    for worker in candidate_workers:
+        if worker.worker_id in seen_worker_ids:
+            continue
+        if worker.worker_id in elite_worker_ids:
+            continue
+        poor_workers.append(worker)
+        seen_worker_ids.add(worker.worker_id)
+
+    if not poor_workers:
+        return []
+
+    if dead_workers:
+        logger.info(
+            "Dead-config rescue candidates this generation: %d workers (threshold=%.2f)",
+            len(dead_workers),
+            dead_config_threshold
+        )
 
     worker_to_idx = {w.worker_id: i for i, w in enumerate(workers)}
     pairs = []
@@ -122,6 +188,7 @@ def execute_exploit_explore(
     perturbation_factors: Tuple[float, float] = (0.8, 1.2),
     current_generation: int = 0,
     require_ready: bool = True,
+    dead_config_threshold: float = 6.0,
     exclude_knobs: Optional[List[str]] = None
 ) -> int:
     """
@@ -147,6 +214,9 @@ def execute_exploit_explore(
     require_ready : bool
         Only exploit ready workers
         Default: True
+
+    dead_config_threshold : float
+        Score threshold used to force dead workers into exploit rescue pool.
     
     exclude_knobs : Optional[List[str]]
         Knobs to exclude from perturbation (keep constant)
@@ -184,7 +254,8 @@ def execute_exploit_explore(
     pairs = truncation_selection(
         workers=workers,
         exploit_quantile=exploit_quantile,
-        require_ready=require_ready
+        require_ready=require_ready,
+        dead_config_threshold=dead_config_threshold,
     )
 
     if not pairs:

--- a/src/tuner/core/population.py
+++ b/src/tuner/core/population.py
@@ -68,6 +68,12 @@ class PopulationConfig:
         Maximum number of generations before stopping
     early_stopping_patience : int
         Generations to wait without improvement before early stopping
+    dead_config_threshold : float
+        Score threshold below which workers are classified as dead configs
+        for end-of-generation rescue handling.
+    resample_min_change_ratio : float
+        Minimum fraction of knobs that should differ between old and fallback
+        resampled configs in all-dead rescue.
     """
     population_size: int = 8
     ready_interval: int = 3
@@ -76,6 +82,8 @@ class PopulationConfig:
     convergence_threshold: float = 0.5
     max_generations: int = 100
     early_stopping_patience: int = 10
+    dead_config_threshold: float = 6.0
+    resample_min_change_ratio: float = 0.6
 
 
 @dataclass
@@ -432,6 +440,165 @@ class Population:
 
         logger.info("Generation %s evaluation complete", self.current_generation)
 
+    @staticmethod
+    def _config_change_ratio(old_config: Dict[str, Any], new_config: Dict[str, Any]) -> float:
+        """Return fraction of knob entries whose values changed."""
+        all_keys = set(old_config.keys()) | set(new_config.keys())
+        if not all_keys:
+            return 0.0
+
+        changed = sum(1 for key in all_keys if old_config.get(key) != new_config.get(key))
+        return changed / len(all_keys)
+
+    def _choose_diverse_resample_config(
+        self,
+        previous_config: Dict[str, Any],
+        candidates: List[Dict[str, Any]],
+        min_change_ratio: float,
+    ) -> tuple[Dict[str, Any], float]:
+        """Pick and remove the most-diverse candidate from a shared candidate pool."""
+        if not candidates:
+            fallback = self.knob_space.sample_random_config()
+            return fallback, self._config_change_ratio(previous_config, fallback)
+
+        best_index = 0
+        best_ratio = -1.0
+        for index, candidate in enumerate(candidates):
+            ratio = self._config_change_ratio(previous_config, candidate)
+            if ratio > best_ratio:
+                best_ratio = ratio
+                best_index = index
+
+        selected = candidates.pop(best_index)
+        if best_ratio >= min_change_ratio:
+            return selected, best_ratio
+
+        # Fallback one-shot perturbation if all pool candidates are too similar.
+        perturbed = self.knob_space.perturb_config(
+            previous_config,
+            perturbation_factor=(0.5, 1.5),
+            seed=((self.current_generation + 1) * 1000) + len(previous_config),
+        )
+        perturbed_ratio = self._config_change_ratio(previous_config, perturbed)
+        if perturbed_ratio > best_ratio:
+            return perturbed, perturbed_ratio
+
+        return selected, best_ratio
+
+    def rescue_dead_workers(
+        self,
+        evaluate_fn: Callable[[Worker], tuple[PerformanceMetrics, float]],
+    ) -> int:
+        """Immediately rescue dead workers by exploiting alive configs.
+
+        Rescue flow:
+        1. Detect dead workers from failure-tagged metrics and low score.
+        2. If alive donors exist, clone an alive worker's config.
+        3. Otherwise, resample a fresh random config for next-generation escape.
+        4. Recover the worker's PostgreSQL instance.
+        """
+        dead_workers = [
+            worker
+            for worker in self.workers
+            if worker.metrics is not None
+            and worker.metrics.failure_type is not None
+            and worker.performance_score < self.config.dead_config_threshold
+        ]
+        if not dead_workers:
+            return 0
+
+        alive_workers = [
+            worker
+            for worker in self.workers
+            if worker.metrics is not None
+            and worker.metrics.failure_type is None
+            and worker.performance_score >= self.config.dead_config_threshold
+        ]
+        if not alive_workers:
+            logger.warning(
+                "Dead-config rescue fallback: no alive workers available; resampling %d dead workers for next generation",
+                len(dead_workers),
+            )
+
+            seed_base = (self.current_generation + 1) * 1000
+            candidate_pool_size = max(len(dead_workers) * 4, len(dead_workers))
+            lhs_candidates = self.knob_space.sample_diverse_configs(
+                num_samples=candidate_pool_size,
+                seed=seed_base,
+            )
+            min_change_ratio = max(0.0, min(1.0, self.config.resample_min_change_ratio))
+
+            resampled = 0
+            for dead_worker in dead_workers:
+                dead_logger = get_logger(__name__, worker_id=dead_worker.worker_id)
+                previous_config = dead_worker.get_config_copy()
+                selected_config, change_ratio = self._choose_diverse_resample_config(
+                    previous_config,
+                    lhs_candidates,
+                    min_change_ratio,
+                )
+                dead_worker.knob_config = selected_config
+                dead_worker.performance_score = 0.0
+                dead_worker.metrics = None
+
+                dead_worker.parent_id = None
+                dead_worker.generation_created = self.current_generation + 1
+                config_changed = dead_worker.knob_config != previous_config
+
+                if self.instance_manager is not None:
+                    if not self.instance_manager.recover_instance(dead_worker.worker_id):
+                        dead_logger.error(
+                            "[DEAD_CONFIG] Fallback resample could not recover worker instance"
+                        )
+                    else:
+                        dead_logger.info(
+                            "[DEAD_CONFIG] Recovered instance after all-dead fallback resample"
+                        )
+
+                dead_logger.info(
+                    "[DEAD_CONFIG] Resample outcome: changed_config=%s changed_ratio=%.3f",
+                    config_changed,
+                    change_ratio,
+                )
+
+                dead_logger.warning(
+                    "[DEAD_CONFIG] No alive donor available; resampled a fresh configuration for next generation"
+                )
+                resampled += 1
+
+            return resampled
+
+        alive_workers = sorted(alive_workers, key=lambda worker: worker.performance_score, reverse=True)
+
+        rescued = 0
+        for index, dead_worker in enumerate(dead_workers):
+            donor = alive_workers[index % len(alive_workers)]
+            dead_logger = get_logger(__name__, worker_id=dead_worker.worker_id)
+
+            dead_logger.warning(
+                "[DEAD_CONFIG] Triggering immediate rescue: exploit Worker-%d (score=%.4f)",
+                donor.worker_id,
+                donor.performance_score,
+            )
+
+            dead_worker.clone_from(donor, self.current_generation)
+
+            if self.instance_manager is not None:
+                if not self.instance_manager.recover_instance(dead_worker.worker_id):
+                    dead_logger.error(
+                        "[DEAD_CONFIG] Instance recovery failed during immediate rescue"
+                    )
+                    continue
+
+                rescued += 1
+                dead_logger.info(
+                    "[DEAD_CONFIG] Instance recovered. Will be re-evaluated in next generation."
+                )
+            else:
+                rescued += 1  # If no instance manager, just count as rescued
+
+        return rescued
+
     def update_metric_ranges_if_needed(self) -> None:
         """
         Update metric normalization ranges after initial exploration phase.
@@ -451,8 +618,13 @@ class Population:
             return
 
         all_metrics: List[PerformanceMetrics] = []
+        excluded_failure_metrics = 0
         for worker in self.workers:
-            all_metrics.extend(worker.performance_history)
+            for metric in worker.performance_history:
+                if metric.failure_type is None:
+                    all_metrics.append(metric)
+                else:
+                    excluded_failure_metrics += 1
 
         # Need samples from multiple generations to capture variability
         # Minimum: 2 generations worth of data (2 * population_size)
@@ -465,6 +637,12 @@ class Population:
                 len(all_metrics), min_samples_needed, self.current_generation
             )
             return
+
+        if excluded_failure_metrics > 0:
+            logger.debug(
+                "Excluded %d failure-tagged metrics from adaptive normalization updates",
+                excluded_failure_metrics
+            )
 
         logger.info(
             "Updating normalization ranges from %d observations across %d workers",
@@ -539,6 +717,7 @@ class Population:
             perturbation_factors=self.config.perturbation_factors,
             current_generation=self.current_generation,
             require_ready=require_ready,
+            dead_config_threshold=self.config.dead_config_threshold,
             exclude_knobs=exclude_knobs
         )
 
@@ -708,6 +887,10 @@ class Population:
                 logger.warning("Snapshot restoration requested but instance_manager not available")
 
         self.evaluate_generation(evaluate_fn, parallel=parallel, max_workers=max_workers)
+
+        rescued = self.rescue_dead_workers(evaluate_fn)
+        if rescued > 0:
+            logger.info("Immediate dead-config rescue recovered %d workers", rescued)
 
         self.update_metric_ranges_if_needed()
 

--- a/src/tuner/evaluator/evaluator.py
+++ b/src/tuner/evaluator/evaluator.py
@@ -31,6 +31,7 @@ from typing import Dict, Any, Optional, List, Union
 from pathlib import Path
 import json
 import logging
+import math
 import time
 import random
 import subprocess
@@ -39,6 +40,7 @@ from queue import Queue
 import yaml
 import numpy as np
 import psycopg2
+from psycopg2 import sql
 from psycopg2.extensions import connection as PostgresConnection, register_adapter, AsIs
 import psutil
 
@@ -60,7 +62,7 @@ from src.tuner.utils.restart_manager import (
 from src.tuner.utils.applicator import KnobApplicator, ApplicatorConfig
 from src.tuner.utils.logger_config import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 # Register numpy type adapters for psycopg2
 register_adapter(np.int64, lambda x: AsIs(int(x)))
@@ -93,6 +95,9 @@ class EvaluatorConfig:
         Batch restarts every N generations (default: 10)
     restart_config : Optional[RestartConfig]
         Configuration for restart manager (default: None = auto-detect)
+    vacuum_analyze_timeout_seconds : float
+        Per-worker timeout for post-workload VACUUM ANALYZE safety maintenance.
+        Prevents generation stalls when maintenance blocks or runs too long.
     """
     workload_type: WorkloadType
     metric_config: MetricConfig
@@ -105,6 +110,7 @@ class EvaluatorConfig:
     restart_config: Optional[RestartConfig] = None
     workload_seed: int = 42
     warmup_passes: int = 0
+    vacuum_analyze_timeout_seconds: float = 45.0
 
 
 class WorkloadExecutor:
@@ -216,7 +222,7 @@ class WorkloadExecutor:
             "SELECT count(*) FROM information_schema.tables "
             "WHERE table_schema = 'public' AND table_name LIKE 'sbtest%'"
         )
-        count = cursor.fetchone()[0]
+        count = cursor.fetchone()[0]  # type: ignore
         cursor.close()
         conn.close()
         return count >= self.num_tables
@@ -642,8 +648,6 @@ class Evaluator:
         self.workload_executor = workload_executor
         self.worker_id = worker_id or "Evaluator"
 
-        self.logger = logging.getLogger(__name__)
-
         self.restart_cost_model = RestartCostModel(
             base_restart_time=7.0,
             cache_warmup_ratio=0.1,
@@ -655,7 +659,7 @@ class Evaluator:
             rollback_on_error=False
         )
 
-        self.logger.debug(
+        logger.debug(
             "✓ Created Evaluator: workload=%s, duration=%ss",
             config.workload_type.value.upper(),
             config.measurement_duration
@@ -696,7 +700,7 @@ class Evaluator:
                 connection = get_connection(config=db_config or self.config.db_config)
                 connection.autocommit = False
                 if attempt > 1:
-                    self.logger.info("Connection established after %d attempts", attempt)
+                    logger.info("Connection established after %d attempts", attempt)
                 return connection
             except psycopg2.Error as e:
                 last_error = e
@@ -704,11 +708,13 @@ class Evaluator:
 
                 # Check if it's a recoverable error (instance still recovering)
                 if (
+                    "starting up" in error_msg or
                     "not yet accepting connections" in error_msg or
-                    "consistent recovery state" in error_msg
+                    "consistent recovery state" in error_msg or
+                    ("connection refused" in error_msg and "is the server running" in error_msg)
                 ):
                     if attempt < max_retries:
-                        self.logger.warning(
+                        logger.warning(
                             "Database recovering, retry %d/%d in %.1fs...",
                             attempt,
                             max_retries,
@@ -718,10 +724,10 @@ class Evaluator:
                         continue
 
                 # Non-recoverable error or last attempt
-                self.logger.error("Failed to connect to PostgreSQL: %s", e)
+                logger.error("Failed to connect to PostgreSQL: %s", e)
                 raise
 
-        self.logger.error("Failed to connect after %d attempts: %s", max_retries, last_error)
+        logger.error("Failed to connect after %d attempts: %s", max_retries, last_error)
         raise last_error  # type: ignore
 
     def disconnect(
@@ -746,13 +752,13 @@ class Evaluator:
                     worker_logger = get_logger(__name__, worker_id=worker_id)
                     worker_logger.debug("Disconnected from PostgreSQL")
                 else:
-                    self.logger.debug("Disconnected from PostgreSQL")
+                    logger.debug("Disconnected from PostgreSQL")
             except Exception as e:
                 if worker_id is not None:
                     worker_logger = get_logger(__name__, worker_id=worker_id)
                     worker_logger.warning("Error closing connection: %s", e)
                 else:
-                    self.logger.warning("Error closing connection: %s", e)
+                    logger.warning("Error closing connection: %s", e)
 
     def apply_configuration(
         self,
@@ -800,9 +806,9 @@ class Evaluator:
         restart_occurred = False
 
         # Create worker logger for consistent [Worker-X] formatting and colors
-        logger = (
+        worker_logger = (
             get_logger(__name__, worker_id=worker_id)
-            if worker_id is not None else self.logger
+            if worker_id is not None else logger
         )
 
         try:
@@ -812,7 +818,7 @@ class Evaluator:
 
             # If restart-required params changed, check if we should restart this generation
             if result.restart_required and len(result.restart_required) > 0:
-                logger.info(
+                worker_logger.info(
                     "Restart required for %d parameters: %s",
                     len(result.restart_required),
                     list(result.restart_required)
@@ -823,19 +829,23 @@ class Evaluator:
 
                 if should_restart:
                     if restart_manager:
-                        logger.info(
+                        worker_logger.info(
                             "Restarting (generation %d is restart interval)",
                             generation
                         )
                         restart_occurred = self._perform_restart(
                             connection, restart_manager, worker_log_id, worker_id=worker_id
                         )
+                        if not restart_occurred:
+                            raise ConnectionError(
+                                "PostgreSQL restart failed; worker marked as dead-config candidate"
+                            )
                     else:
-                        logger.warning(
+                        worker_logger.warning(
                             "Restart needed but restart_manager not configured"
                         )
                 else:
-                    logger.info(
+                    worker_logger.info(
                         "Deferring restart (will restart at generation %d)",
                         ((generation // restart_interval) + 1) * restart_interval
                         if generation is not None else restart_interval
@@ -844,9 +854,13 @@ class Evaluator:
                 restart_occurred = self._perform_restart(
                     connection, restart_manager, worker_log_id, worker_id=worker_id
                 )
+                if not restart_occurred:
+                    raise ConnectionError(
+                        "Forced PostgreSQL restart failed; worker marked as dead-config candidate"
+                    )
 
         except Exception as e:
-            logger.error("Failed to apply configuration: %s", e)
+            worker_logger.error("Failed to apply configuration: %s", e)
             raise
 
         return restart_occurred
@@ -878,12 +892,12 @@ class Evaluator:
             True if restart succeeded
         """
         # Create worker logger for consistent [Worker-X] formatting and colors
-        logger = (
+        worker_logger = (
             get_logger(__name__, worker_id=worker_id)
-            if worker_id is not None else self.logger
+            if worker_id is not None else logger
         )
 
-        logger.info("Restarting PostgreSQL instance...")
+        worker_logger.info("Restarting PostgreSQL instance...")
 
         try:
             # Close connection before restart
@@ -895,7 +909,7 @@ class Evaluator:
 
             # Restart the instance
             if restart_manager.restart():
-                logger.info("Restart successful")
+                worker_logger.info("Restart successful")
 
                 # Reset statistics after restart
                 try:
@@ -906,17 +920,17 @@ class Evaluator:
                     cursor.close()
                     temp_conn.commit()
                     temp_conn.close()
-                    logger.debug("Reset PostgreSQL statistics")
+                    worker_logger.debug("Reset PostgreSQL statistics")
                 except Exception as e:
-                    logger.warning("Failed to reset statistics: %s", e)
+                    worker_logger.warning("Failed to reset statistics: %s", e)
 
                 return True
             else:
-                logger.error("Restart failed")
+                worker_logger.error("Restart failed")
                 return False
 
         except Exception as e:
-            logger.error("Restart failed with exception: %s", e)
+            worker_logger.error("Restart failed with exception: %s", e)
             return False
 
     def _verify_configuration(
@@ -946,9 +960,9 @@ class Evaluator:
             Parameter name -> verification status
         """
         # Create worker logger for consistent [Worker-X] formatting and colors
-        logger = (
+        worker_logger = (
             get_logger(__name__, worker_id=worker_id)
-            if worker_id is not None else self.logger
+            if worker_id is not None else logger
         )
         verification = {}
         mismatches = []
@@ -960,34 +974,55 @@ class Evaluator:
                 try:
                     # Query current value
                     cursor.execute(
-                        "SELECT setting, unit FROM pg_settings WHERE name = %s",
+                        "SELECT setting, unit, vartype FROM pg_settings WHERE name = %s",
                         (param_name,)
                     )
                     result = cursor.fetchone()
 
                     if not result:
-                        self.logger.warning(
+                        worker_logger.warning(
                             "[%s] Parameter '%s' not found in pg_settings",
                             worker_log_id, param_name
                         )
                         verification[param_name] = False
                         continue
 
-                    current_value_str, unit = result
+                    current_value_str, unit, vartype = result
 
                     # Convert current value to comparable type
                     if isinstance(expected_value, bool):
                         current_value = current_value_str.lower() in ('on', 'true', '1')
                         match = current_value == expected_value
                     elif isinstance(expected_value, (int, float)):
-                        # Convert both to float for consistent comparison
                         current_value = float(current_value_str)
                         expected_float = float(expected_value)
-                        # Use tolerance for floating-point comparison
-                        match = abs(current_value - expected_float) < 0.01
+
+                        # pg_settings may coerce or quantize numeric settings on apply.
+                        # Compare by PostgreSQL vartype semantics, not a fixed tiny delta.
+                        if vartype == 'integer':
+                            current_int = int(round(current_value))
+                            expected_int = int(round(expected_float))
+                            current_value = current_int
+                            match = current_int == expected_int
+                        else:
+                            abs_tolerance = max(0.01, abs(expected_float) * 1e-6)
+                            match = math.isclose(
+                                current_value,
+                                expected_float,
+                                rel_tol=1e-6,
+                                abs_tol=abs_tolerance,
+                            )
                     else:
                         current_value = current_value_str
-                        match = str(current_value) == str(expected_value)
+                        # `wal_compression` became an enum on new versions of postgres (on -> pglz)
+                        if (
+                            param_name == "wal_compression" and
+                            str(expected_value).lower() in ("on", "true")
+                            and str(current_value).lower() in ("on", "pglz")
+                        ):
+                            match = True
+                        else:
+                            match = str(current_value) == str(expected_value)
 
                     verification[param_name] = match
 
@@ -997,7 +1032,7 @@ class Evaluator:
                         )
 
                 except Exception as e:
-                    logger.warning(
+                    worker_logger.warning(
                         "Failed to verify parameter '%s': %s",
                         param_name, e
                     )
@@ -1010,20 +1045,20 @@ class Evaluator:
             total_count = len(verification)
 
             if verified_count == total_count:
-                logger.debug(
+                worker_logger.debug(
                     "Configuration verified: %d/%d parameters correct",
                     verified_count, total_count
                 )
             else:
-                logger.warning(
+                worker_logger.warning(
                     "Configuration mismatch: %d/%d parameters verified",
                     verified_count, total_count
                 )
                 for mismatch in mismatches:
-                    logger.warning("  %s", mismatch)
+                    worker_logger.warning("  %s", mismatch)
 
         except Exception as e:
-            logger.error(
+            worker_logger.error(
                 "Configuration verification failed: %s",
                 e
             )
@@ -1054,7 +1089,7 @@ class Evaluator:
             cursor.close()
             return int(result[0]) if result else None  # type: ignore
         except psycopg2.Error as e:
-            self.logger.warning("Failed to get PostgreSQL PID: %s", e)
+            logger.warning("Failed to get PostgreSQL PID: %s", e)
             return None
 
     def _get_postmaster_pid(self, port: int, worker_id: Optional[int] = None) -> Optional[int]:
@@ -1094,7 +1129,7 @@ class Evaluator:
                                     proc.info['pid'], port
                                 )
                             else:
-                                self.logger.debug(
+                                logger.debug(
                                     "Found postmaster PID %d for port %d", 
                                     proc.info['pid'], port
                                 )
@@ -1103,9 +1138,9 @@ class Evaluator:
                 except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
                     continue
 
-            self.logger.warning("Could not find PostgreSQL postmaster for port %d", port)
+            logger.warning("Could not find PostgreSQL postmaster for port %d", port)
         except Exception as e:
-            self.logger.warning("Error finding postmaster PID: %s", e)
+            logger.warning("Error finding postmaster PID: %s", e)
 
         return None
 
@@ -1147,13 +1182,13 @@ class Evaluator:
                     len(processes), len(children), postmaster_pid
                 )
             else:
-                self.logger.debug(
+                logger.debug(
                     "Found %d PostgreSQL processes (1 postmaster + %d backends) for PID %d",
                     len(processes), len(children), postmaster_pid
                 )
 
         except (psutil.NoSuchProcess, psutil.AccessDenied) as e:
-            self.logger.warning("Failed to get PostgreSQL processes: %s", e)
+            logger.warning("Failed to get PostgreSQL processes: %s", e)
 
         return processes
 
@@ -1186,7 +1221,7 @@ class Evaluator:
         using PostgreSQL's built-in statistics (more accurate than psutil on Windows).
         """
         if not connection or connection.closed:
-            self.logger.warning("Connection not available for system metrics collection")
+            logger.warning("Connection not available for system metrics collection")
             return {
                 'memory_utilization': 0.0,
                 'cache_hit_ratio': 0.0
@@ -1225,7 +1260,7 @@ class Evaluator:
                                 memory_mb, memory_pct, len(postgres_processes)
                             )
                         else:
-                            self.logger.debug(
+                            logger.debug(
                                 "Memory: %.1fMB (%.1f%%) across %d processes",
                                 memory_mb, memory_pct, len(postgres_processes)
                             )
@@ -1233,7 +1268,7 @@ class Evaluator:
                         metrics['memory_utilization'] = 0.0
 
                 except Exception as e:
-                    self.logger.warning("Failed to collect memory metrics: %s", e)
+                    logger.warning("Failed to collect memory metrics: %s", e)
                     metrics['memory_utilization'] = 0.0
             else:
                 metrics['memory_utilization'] = 0.0
@@ -1253,7 +1288,7 @@ class Evaluator:
                 result = cursor.fetchone()
                 metrics['cache_hit_ratio'] = float(result[0] or 0.0)  # type: ignore
             except psycopg2.Error as e:
-                self.logger.warning("Failed to query cache hit ratio: %s", e)
+                logger.warning("Failed to query cache hit ratio: %s", e)
                 metrics['cache_hit_ratio'] = 0.0
             finally:
                 cursor.close()
@@ -1268,35 +1303,119 @@ class Evaluator:
         worker_id: Optional[int] = None
     ) -> None:
         """
-        Run VACUUM ANALYZE after DML-heavy workloads to prevent table bloat.
+        Run bounded post-workload maintenance after DML-heavy workloads.
         
-        Only executes for OLTP and mixed workloads that contain
-        UPDATE/DELETE/INSERT operations which create dead tuples.
+        Full-database VACUUM ANALYZE is too expensive for short sysbench-style
+        generations and frequently times out while scanning toast/system tables.
+        Instead, analyze only user tables that were actually modified.
         """
         # Skip for read-only workloads (OLAP, TPC-H)
         if self.config.workload_type.value in ('olap', 'tpch'):
             return
         
-        logger = (
+        worker_logger = (
             get_logger(__name__, worker_id=worker_id)
-            if worker_id is not None else self.logger
+            if worker_id is not None else logger
         )
-        
+
+        timeout_seconds = max(0.0, float(self.config.vacuum_analyze_timeout_seconds))
+        if timeout_seconds <= 0:
+            worker_logger.debug("Skipping post-workload VACUUM ANALYZE (timeout disabled)")
+            return
+
         try:
             conn = get_connection(config=db_config)
             conn.autocommit = True  # VACUUM cannot run inside a transaction
             cursor = conn.cursor()
-            
+
+            statement_timeout_ms = int(timeout_seconds * 1000)
+            lock_timeout_ms = max(1000, statement_timeout_ms // 4)
+            cursor.execute("SET statement_timeout = %s", (statement_timeout_ms,))
+            cursor.execute("SET lock_timeout = %s", (lock_timeout_ms,))
+
+            cursor.execute(
+                """
+                SELECT schemaname, relname
+                FROM pg_stat_user_tables
+                WHERE n_mod_since_analyze > 0 OR n_dead_tup > 0
+                ORDER BY n_mod_since_analyze DESC, n_dead_tup DESC
+                """
+            )
+            tables = cursor.fetchall() or []
+
+            if not tables:
+                worker_logger.debug("Skipping post-workload maintenance (no modified user tables)")
+                cursor.close()
+                conn.close()
+                return
+
+            worker_logger.debug(
+                "Running post-workload VACUUM ANALYZE on %d modified tables (statement_timeout=%sms, lock_timeout=%sms)",
+                len(tables),
+                statement_timeout_ms,
+                lock_timeout_ms,
+            )
+
             start = time.time()
-            cursor.execute("VACUUM ANALYZE")
+            for schema_name, table_name in tables:
+                table_start = time.time()
+                try:
+                    cursor.execute(
+                        sql.SQL("VACUUM ANALYZE {}.{}").format(
+                            sql.Identifier(schema_name),
+                            sql.Identifier(table_name),
+                        )
+                    )
+                    worker_logger.debug(
+                        "VACUUM ANALYZE completed for %s.%s in %.2fs",
+                        schema_name,
+                        table_name,
+                        time.time() - table_start,
+                    )
+                except Exception as table_error:
+                    worker_logger.warning(
+                        "Post-workload maintenance failed for %s.%s: %s",
+                        schema_name,
+                        table_name,
+                        table_error,
+                    )
+
             elapsed = time.time() - start
-            
-            logger.debug("VACUUM ANALYZE completed in %.2fs", elapsed)
+
+            worker_logger.debug("Post-workload VACUUM ANALYZE completed in %.2fs", elapsed)
             cursor.close()
             conn.close()
-            
+
         except Exception as e:
-            logger.warning("Post-workload VACUUM ANALYZE failed: %s", e)
+            worker_logger.warning("Post-workload VACUUM ANALYZE failed: %s", e)
+
+    def _ensure_benchmark_ready(
+        self,
+        db_config: DatabaseConfig,
+        worker_logger: Optional[logging.Logger] = None,
+    ) -> None:
+        """Validate benchmark state before execution and repair it if needed."""
+        if not isinstance(self.workload_executor, BenchmarkExecutor):
+            return
+
+        worker_logger = worker_logger or logger
+
+        try:
+            benchmark_ready = self.workload_executor.validate(db_config)
+        except Exception as e:
+            worker_logger.warning("Benchmark validation raised %s; attempting prepare()", e)
+            benchmark_ready = False
+
+        if benchmark_ready:
+            return
+
+        worker_logger.warning("Benchmark state invalid; running prepare() before workload execution")
+        self.workload_executor.prepare(db_config)
+
+        if not self.workload_executor.validate(db_config):
+            raise RuntimeError("Benchmark validation still failing after prepare()")
+
+        worker_logger.info("Benchmark state re-prepared successfully")
 
     def evaluate_worker(
         self,
@@ -1421,6 +1540,7 @@ class Evaluator:
                         worker_logger.debug("Failed to capture initial stats: %s", e)
 
                 if isinstance(self.workload_executor, BenchmarkExecutor):
+                    self._ensure_benchmark_ready(worker.db_config, worker_logger=worker_logger)
                     metrics = self.workload_executor.execute(
                         db_config=worker.db_config,
                         worker_id=worker.worker_id,
@@ -1474,7 +1594,7 @@ class Evaluator:
 
             except Exception as e:
                 worker_logger.error("Workload execution failed: %s", e)
-                metrics = PerformanceMetrics()
+                raise RuntimeError(f"Workload execution failed: {e}") from e
 
             system_metrics = self.collect_system_metrics(
                 connection,

--- a/src/tuner/evaluator/metrics.py
+++ b/src/tuner/evaluator/metrics.py
@@ -77,6 +77,9 @@ class PerformanceMetrics:
         Total MB written to disk
     cache_hit_ratio : float
         Buffer cache hit ratio (0.0 to 1.0)
+    failure_type : Optional[str]
+        Optional failure classification for degraded/crashed evaluations.
+        None means healthy evaluation.
     """
 
     latency_p50: float = 0.0
@@ -86,7 +89,7 @@ class PerformanceMetrics:
 
     throughput: float = 0.0
     throughput_unit: str = "TPS"
-    
+
     total_queries: int = 0
     total_time: float = 0.0
 
@@ -98,8 +101,9 @@ class PerformanceMetrics:
     io_write_mb: float = 0.0
 
     cache_hit_ratio: float = 0.0
+    failure_type: Optional[str] = None
 
-    def to_dict(self) -> Dict[str, float]:
+    def to_dict(self) -> Dict[str, float | str | None]:
         """Convert metrics to dictionary"""
         return {
             "latency_p50": self.latency_p50,
@@ -115,6 +119,7 @@ class PerformanceMetrics:
             "io_read_mb": self.io_read_mb,
             "io_write_mb": self.io_write_mb,
             "cache_hit_ratio": self.cache_hit_ratio,
+            "failure_type": self.failure_type,
         }
 
     def __repr__(self) -> str:
@@ -129,6 +134,7 @@ class PerformanceMetrics:
             f"  Errors: {self.error_rate*100:.2f}%\n"
             f"Memory: {self.memory_utilization*100:.1f}%\n"
             f"  Cache Hit: {self.cache_hit_ratio*100:.1f}%\n"
+            f"  Failure Type: {self.failure_type}\n"
             f")"
         )
 

--- a/src/tuner/main.py
+++ b/src/tuner/main.py
@@ -42,6 +42,7 @@ from pathlib import Path
 from typing import Optional, Dict, Any, Tuple, List
 from datetime import datetime
 import numpy as np
+import psycopg2
 
 from src.config.database import DatabaseConfig
 from src.tuner.utils.snapshot_manager import SnapshotManager, SnapshotConfig
@@ -250,6 +251,7 @@ class PBTTuner:
             convergence_threshold=0.05,
             max_generations=self.pbt_config.num_generations,
             early_stopping_patience=10,
+            dead_config_threshold=self.pbt_config.dead_config_threshold,
         )
 
         self.population = Population(
@@ -349,9 +351,10 @@ class PBTTuner:
         Tuple[PerformanceMetrics, float]
             (metrics, score)
         """
+        worker_logger = get_logger(__name__, worker_id=worker.worker_id)
+
         try:
             self.evaluator.worker_id = f"Worker-{worker.worker_id}"
-            worker_logger = get_logger(__name__, worker_id=worker.worker_id)
 
             metrics, score, restart_occurred = self.evaluator.evaluate_worker(
                 worker,
@@ -386,23 +389,84 @@ class PBTTuner:
 
             return metrics, score
 
-        except (ConnectionError, TimeoutError, RuntimeError) as e:
-            worker_logger = get_logger(__name__, worker_id=worker.worker_id)
-            worker_logger.error("Evaluation failed: %s", e)
-            fallback_metrics = PerformanceMetrics(
-                latency_p50=1000.0,
-                latency_p95=2000.0,
-                latency_p99=3000.0,
-                throughput=1.0,
-                memory_utilization=1.0,
-                io_read_mb=0.0,
-                io_write_mb=0.0,
-                cache_hit_ratio=0.0,
-                error_rate=1.0,
-                total_queries=0,
-                total_time=1.0,
+        except (ConnectionError, psycopg2.Error) as e:
+            if self.instance_manager is not None:
+                recovered = self.instance_manager.recover_instance(worker.worker_id)
+                if recovered:
+                    worker_logger.info(
+                        "[DEAD_CONFIG] Immediate instance recovery succeeded after connection failure"
+                    )
+                else:
+                    worker_logger.error(
+                        "[DEAD_CONFIG] Immediate instance recovery failed after connection failure"
+                    )
+
+            return self._build_failure_result(
+                worker_logger=worker_logger,
+                reason="connection",
+                exception=e,
+                failure_type="crash_dead",
+                score=self.pbt_config.dead_config_score,
             )
-            return fallback_metrics, 0.0
+
+        except TimeoutError as e:
+            return self._build_failure_result(
+                worker_logger=worker_logger,
+                reason="timeout",
+                exception=e,
+                failure_type="crash_timeout",
+                score=self.pbt_config.crash_score,
+            )
+
+        except RuntimeError as e:
+            return self._build_failure_result(
+                worker_logger=worker_logger,
+                reason="runtime",
+                exception=e,
+                failure_type="crash_runtime",
+                score=self.pbt_config.crash_score,
+            )
+
+        except Exception as e:
+            worker_logger.error(
+                "Unexpected error evaluating worker %s: %s",
+                worker.worker_id,
+                e,
+                exc_info=True
+            )
+            return self._build_failure_result(
+                worker_logger=worker_logger,
+                reason="unexpected",
+                exception=e,
+                failure_type="crash_unexpected",
+                score=self.pbt_config.crash_score,
+            )
+
+    def _build_failure_result(
+        self,
+        worker_logger: logging.Logger,
+        reason: str,
+        exception: Exception,
+        failure_type: str,
+        score: float,
+    ) -> Tuple[PerformanceMetrics, float]:
+        """Build standardized fallback metrics and score for failed worker evaluations."""
+        worker_logger.warning("[DEAD_CONFIG] Evaluation failed (%s): %s", reason, exception)
+        fallback_metrics = PerformanceMetrics(
+            latency_p50=9999.0,
+            latency_p95=9999.0,
+            latency_p99=9999.0,
+            throughput=0.0,
+            memory_utilization=1.0,
+            io_read_mb=0.0,
+            io_write_mb=0.0,
+            cache_hit_ratio=0.0,
+            error_rate=1.0,
+            total_queries=0,
+            total_time=1.0,
+            failure_type=failure_type,
+        )
+        return fallback_metrics, score
 
     def run_generation(self, generation: int) -> Dict[str, Any]:
         """
@@ -451,6 +515,24 @@ class PBTTuner:
             'converged': result.converged,
             'restart_count': self.restart_count,
             'timestamp': datetime.now().isoformat(),
+            'worker_scores': [
+                {
+                    'worker_id': w.worker_id,
+                    'score': (
+                        float(w.performance_score)
+                        if w.performance_score is not None else None
+                    ),
+                    'metrics': w.metrics.to_dict() if w.metrics else None,
+                }
+                for w in self.population.workers
+            ],
+            'worker_configs': [
+                {
+                    'worker_id': w.worker_id,
+                    'config': convert_numpy_types(w.knob_config),
+                }
+                for w in self.population.workers
+            ],
         }
 
         self.generation_history.append(gen_summary)
@@ -531,6 +613,7 @@ class PBTTuner:
             user=self.db_config.user,
             password=self.db_config.password
         )
+        self.population.instance_manager = self.instance_manager
         self.logger.info(
             "✓ Initialized %d workers with dedicated instances\n",
             len(self.population.workers)

--- a/src/tuner/utils/applicator.py
+++ b/src/tuner/utils/applicator.py
@@ -295,7 +295,7 @@ class KnobApplicator:
                     unit=row[3],
                     min_val=row[4],
                     max_val=row[5],
-                    enumvals=row[6].split(',') if row[6] else None,
+                    enumvals=row[6] if isinstance(row[6], list) else (row[6].split(',') if isinstance(row[6], str) else None),
                     boot_val=row[7],
                     reset_val=row[8]
                 )

--- a/src/tuner/utils/instance_manager.py
+++ b/src/tuner/utils/instance_manager.py
@@ -172,10 +172,23 @@ class PostgresInstanceManager:
                 )
 
                 if self._is_instance_running(data_dir):
-                    logger.debug("Instance already running, skipping start")
-                else:
-                    self._start_instance_internal(data_dir)
-                    time.sleep(2)  # Give PostgreSQL time to start
+                    logger.debug(
+                        "Stopping reused instance before startup to clear persisted overrides"
+                    )
+                    subprocess.run(
+                        [self.pg_ctl, '-D', str(data_dir), 'stop', '-m', 'fast'],
+                        capture_output=True,
+                        text=True,
+                        timeout=30,
+                        check=False,
+                    )
+                    time.sleep(1)
+
+                self._reset_persisted_overrides(data_dir)
+                self._kill_stale_port_holder(port)
+                self._start_instance_internal(data_dir)
+
+                self._wait_for_instance_ready(port)
 
                 if self.template_db_config:
                     self._ensure_postgres_user_exists(port)
@@ -220,6 +233,86 @@ class PostgresInstanceManager:
             self.instances[worker_id] = instance
 
         return list(self.instances.values())
+
+    def _reset_persisted_overrides(self, data_dir: Path) -> None:
+        """Clear persisted ALTER SYSTEM overrides before reusing an instance.
+
+        Reused worker data directories can carry forward extreme values in
+        postgresql.auto.conf from prior runs. Clearing that file forces startup
+        back to the safe base configuration in postgresql.conf.
+        """
+        auto_conf = data_dir / 'postgresql.auto.conf'
+        if not auto_conf.exists():
+            return
+
+        backup_path = data_dir / 'postgresql.auto.conf.pre_reuse_backup'
+        shutil.copy2(auto_conf, backup_path)
+
+        with open(auto_conf, 'w', encoding='utf-8') as handle:
+            handle.write("# Cleared before instance reuse to remove stale ALTER SYSTEM overrides.\n")
+
+        logger.debug(
+            "Cleared persisted overrides in %s (backup at %s)",
+            auto_conf,
+            backup_path,
+        )
+
+    def _wait_for_instance_ready(
+        self,
+        port: int,
+        max_attempts: int = 15,
+        delay_seconds: float = 2.0,
+    ) -> None:
+        """Wait until a PostgreSQL instance accepts local connections.
+
+        This is primarily used in the reused-instance path where start is async
+        and fixed sleeps are not reliable under load.
+        """
+        current_user = getpass.getuser()
+
+        last_error: Optional[Exception] = None
+        for attempt in range(1, max_attempts + 1):
+            test_configs = [
+                DatabaseConfig(
+                    host='localhost',
+                    port=str(port),
+                    dbname='postgres',
+                    user=current_user,
+                    password=''
+                )
+            ]
+
+            if self.template_db_config and self.template_db_config.user != current_user:
+                test_configs.append(
+                    DatabaseConfig(
+                        host='localhost',
+                        port=str(port),
+                        dbname=self.template_db_config.dbname,
+                        user=self.template_db_config.user,
+                        password=self.template_db_config.password or ''
+                    )
+                )
+
+            for test_config in test_configs:
+                try:
+                    conn = get_connection(config=test_config)
+                    conn.close()
+                    if attempt > 1:
+                        logger.debug(
+                            "Instance on port %d became ready after %d attempts",
+                            port,
+                            attempt,
+                        )
+                    return
+                except Exception as e:
+                    last_error = e
+
+            time.sleep(delay_seconds)
+
+        raise RuntimeError(
+            f"Instance on port {port} did not become ready after "
+            f"{max_attempts} attempts: {last_error}"
+        )
     
     def _is_valid_instance(self, data_dir: Path, expected_port: int) -> bool:
         """
@@ -756,10 +849,11 @@ unix_socket_directories = '/tmp'
         
         try:
             result = subprocess.run(
-                [self.pg_ctl, '-D', str(instance.data_dir), 'stop', '-m', mode],
+                [self.pg_ctl, '-D', str(instance.data_dir), 'stop', '-m', mode],  # type: ignore
                 capture_output=True,
                 text=True,
-                timeout=30
+                timeout=30,
+                check=False,
             )
             if result.returncode not in [0, 1]:  # 1 = not running
                 logger.warning("pg_ctl stop returned %d: %s", result.returncode, result.stderr)
@@ -784,7 +878,39 @@ unix_socket_directories = '/tmp'
                 success = False
         
         return success
-    
+
+    def recover_instance(self, worker_id: int) -> bool:
+        """Recover a worker instance from potentially bad persisted config.
+
+        This is designed for dead-config rescue workflow where a sampled
+        configuration prevented startup.
+        """
+        if worker_id not in self.instances:
+            logger.error("No instance configured for worker-%d", worker_id)
+            return False
+
+        instance = self.instances[worker_id]
+
+        self.stop_instance(worker_id, mode='immediate')
+        self._kill_stale_port_holder(instance.port)
+        self._reset_persisted_overrides(instance.data_dir)
+
+        try:
+            self._start_instance_internal(instance.data_dir)
+            self._wait_for_instance_ready(instance.port)
+            self._initialize_schema(instance.port, instance.data_dir)
+            instance.running = True
+            logger.info(
+                "Recovered instance for worker-%d on port %d",
+                worker_id,
+                instance.port,
+            )
+            return True
+        except Exception as e:
+            instance.running = False
+            logger.error("Failed to recover instance for worker-%d: %s", worker_id, e)
+            return False
+
     def stop_all(self, mode: str = 'fast') -> bool:
         """Stop all running instances."""
         logger.info("Stopping all %d instances...", len(self.instances))

--- a/src/tuner/utils/restart_manager.py
+++ b/src/tuner/utils/restart_manager.py
@@ -246,6 +246,8 @@ class PostgresRestartManager:
         if self.config.method == 'auto':
             self.config.method = self._detect_restart_method()
 
+        self._startup_log_offset: Optional[int] = None
+
         self.logger.debug(
             "Initialized PostgresRestartManager with method: %s, data_dir: %s",
             self.config.method,
@@ -555,6 +557,9 @@ class PostgresRestartManager:
             time.sleep(5)
             self.logger.debug("Waited 5 seconds after stop for cleanup")
 
+            logfile = Path(self.config.data_dir) / 'logfile'
+            self._startup_log_offset = logfile.stat().st_size if logfile.exists() else 0
+
             # Start PostgreSQL without waiting for pg_ctl to complete
             # On Windows, pg_ctl with -l flag blocks until server is ready, which takes too long
             # We'll issue the start command and immediately proceed to connection validation
@@ -635,6 +640,15 @@ class PostgresRestartManager:
                 return True
             except psycopg2.OperationalError as e:
                 self.logger.debug("Connection attempt %d failed: %s", attempt + 1, str(e)[:100])
+
+                startup_fatal = self._read_startup_fatal_error()
+                if startup_fatal:
+                    self.logger.error(
+                        "Detected PostgreSQL startup-fatal condition during restart validation: %s",
+                        startup_fatal,
+                    )
+                    return False
+
                 if attempt < self.config.max_retries - 1:
                     time.sleep(self.config.retry_delay)
                 continue
@@ -648,6 +662,46 @@ class PostgresRestartManager:
 
         self.logger.error("Could not connect after %d attempts", self.config.max_retries)
         return False
+
+    def _read_startup_fatal_error(self) -> Optional[str]:
+        """Return a fatal startup error line from the PostgreSQL logfile if present.
+
+        This enables fail-fast behavior when PostgreSQL rejects an invalid
+        configuration at startup (instead of waiting all connection retries).
+        """
+        if not self.config.data_dir:
+            return None
+
+        logfile = Path(self.config.data_dir) / 'logfile'
+        if not logfile.exists():
+            return None
+
+        try:
+            with logfile.open('r', encoding='utf-8', errors='ignore') as handle:
+                if self._startup_log_offset is not None:
+                    handle.seek(min(self._startup_log_offset, logfile.stat().st_size))
+                lines = handle.readlines()[-300:]
+
+            for line in reversed(lines):
+                text = line.strip()
+                upper = text.upper()
+
+                if "FATAL:" not in upper:
+                    continue
+
+                # Emitted during shutdown, not startup validation.
+                if "TERMINATING CONNECTION DUE TO ADMINISTRATOR COMMAND" in upper:
+                    continue
+
+                # Ignore transient startup-state noise that should be retried.
+                if "STARTING UP" in upper or "CONSISTENT RECOVERY STATE" in upper:
+                    continue
+
+                return text
+        except Exception as e:
+            self.logger.debug("Could not inspect startup logfile for fatal errors: %s", e)
+
+        return None
 
     def _validate_restart(self) -> bool:
         """


### PR DESCRIPTION
## Summary

This PR delivers a comprehensive hardening pass across the PBT tuning pipeline, addressing reliability issues discovered during extended tuning runs at larger scale factors. The changes span from the lowest layer (knob definitions and PostgreSQL configuration safety) through the evaluation engine, up to the population-level evolutionary strategy.

## Motivation

Extended multi-generation tuning runs exposed several classes of failure:
- **PostgreSQL crashes** from unsafe knob combinations (e.g., memory overcommit, `huge_pages="on"` without OS support, `max_parallel_workers` exceeding `max_worker_processes`).
- **Silent evaluation failures** where crashed workers returned zero-populated metrics, corrupting normalization baselines and allowing broken configs to survive selection.
- **Stale state leaks** via `postgresql.auto.conf` persisting `ALTER SYSTEM` settings across generations.
- **Unbounded query execution** in TPC-H, where pathological configs caused indefinite hangs.
- **Uncurated knob bounds** letting dangerous parameters (WAL, vacuum, memory SLRUs) explore unsafe regions.

## Changes

### Knob Space & Configuration Safety
- **Autotuning policy exclusion engine** — Centralized exclusion rules filtering out non-performance knobs (logging, replication, security, encoding) before tier assignment.
- **Curated tuning metadata** for 39 extensive-tier knobs — Safe bounds for background writer, WAL/checkpoint, vacuum cost, autovacuum, memory/buffer SLRUs, I/O, query planner, and vacuum freezing parameters.
- **`repair_config_dependencies()`** — Post-generation constraint repair ensuring memory budgets stay within safe OS limits, worker/WAL/connection slot invariants hold, and `huge_pages` gracefully falls back.

### Evaluation Hardening
- **Failure-typed metrics** — `PerformanceMetrics.failure_type` classifies crashed/degraded evaluations, enabling downstream filtering.
- **Benchmark state validation** — `_ensure_benchmark_ready()` auto-repairs invalid benchmark state before workload execution.
- **Targeted post-workload maintenance** — VACUUM ANALYZE now scans only modified user tables with statement/lock timeouts, replacing the previous full-database scan that frequently timed out.
- **Workload failures now raise** `RuntimeError` instead of silently returning empty metrics.

### Population & Evolution
- **Dead-config rescue** — `rescue_dead_workers()` detects workers with failure-tagged metrics below `dead_config_threshold`, clones healthy donor configs, and recovers PostgreSQL instances. Falls back to diverse LHS resampling when no alive donors exist.
- **Failure isolation from normalization** — Failure-tagged metrics are excluded from adaptive normalization range updates.
- **Per-worker metrics in generation history** — Full metrics dicts embedded in `gen_summary` for downstream fANOVA analysis and trajectory visualization.

### Infrastructure
- **`postgresql.auto.conf` clearing** on instance restart to prevent stale `ALTER SYSTEM` settings from leaking across generations.
- **Consolidated restart workflow** to eliminate redundant instance stops.

### TPC-H Fixes
- **Scale-factor-aware `statement_timeout`** (5 min × SF) to prevent indefinite query hangs from pathological configs.
- **All-or-nothing power test** — Any single query failure immediately breaks execution and returns fatally penalized metrics, preventing reward hacking via partial completion.

### Housekeeping
- Minor `.gitignore` and script import cleanups.

## Testing

These changes have been validated through multi-generation PBT runs across varying Sysbench number of tables/number of rows, as well as TPC-H scale factors, confirming that crashed workers are promptly rescued, unsafe configurations are repaired before application, and normalization baselines remain uncontaminated by failure metrics.