### PR TITLE
feat(evaluation): add reproducible baseline comparison suite and tuning robustness fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ notes/
 code-snippets/
 
 # Research papers and PDFs
-Papers/
+papers/
 *.pdf
 research/
 
@@ -112,6 +112,7 @@ results/**/pbt_results_*.json
 results/**/best_config*.json
 results/**/intermediate_*.json
 results/**/*.html
+results/oltp/comparisons/
 
 # Postgres Snapshots generated during execution
 pg_snapshots/

--- a/docker/build_dbgen.sh
+++ b/docker/build_dbgen.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# build_dbgen.sh
+# Compiles the TPC-H reference implementation (dbgen) from the official
+# TPC-H Tools repository and installs it to /opt/tpch/.
+#
+# Called during `docker build` — do not run interactively.
+# ─────────────────────────────────────────────────────────────────────────────
+set -euo pipefail
+
+TPCH_DIR="/opt/tpch"
+REPO_URL="https://github.com/electrum/tpch-dbgen.git"
+
+echo "[build_dbgen] Cloning TPC-H dbgen repository..."
+git clone --depth=1 "${REPO_URL}" "${TPCH_DIR}"
+
+echo "[build_dbgen] Compiling dbgen..."
+cd "${TPCH_DIR}"
+
+# Build only dbgen. The upstream make default also builds qgen, which is
+# not required by this project and currently fails for POSTGRESQL defines.
+make DATABASE=POSTGRESQL MACHINE=LINUX WORKLOAD=TPCH dbgen
+
+echo "[build_dbgen] dbgen compiled successfully."
+echo "[build_dbgen] Binary: ${TPCH_DIR}/dbgen"
+
+# Verify the binary works
+"${TPCH_DIR}/dbgen" -h 2>&1 | head -3 || true
+
+echo "[build_dbgen] Done."

--- a/docker/eval.Dockerfile
+++ b/docker/eval.Dockerfile
@@ -1,0 +1,51 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# PBT Evaluation Image
+# ─────────────────────────────────────────────────────────────────────────────
+# Builds a PostgreSQL image with sysbench and TPC-H dbgen pre-installed,
+# ready for resource-constrained comparative benchmark evaluation.
+#
+# Build:
+#   docker build -f docker/eval.Dockerfile -t pbt-eval docker/
+#
+# Build with specific PG version:
+#   docker build --build-arg PG_VERSION=18 -f docker/eval.Dockerfile -t pbt-eval docker/
+# ─────────────────────────────────────────────────────────────────────────────
+
+ARG PG_VERSION=18
+FROM postgres:${PG_VERSION}
+
+LABEL org.opencontainers.image.title="pbt-eval" \
+    org.opencontainers.image.description="PostgreSQL evaluation image for PBT comparative benchmarking" \
+    org.opencontainers.image.source="https://github.com/Data-Vanta/ai-database-optimization"
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    # Sysbench OLTP benchmark
+    sysbench \
+    # TPC-H dbgen build dependencies
+    build-essential \
+    gcc \
+    make \
+    git \
+    # Utility tools used by evaluation scripts
+    curl \
+    ca-certificates \
+    procps \
+    && rm -rf /var/lib/apt/lists/*
+
+# Compile from the official TPC-H Tools repository.
+COPY build_dbgen.sh /tmp/build_dbgen.sh
+RUN chmod +x /tmp/build_dbgen.sh && /tmp/build_dbgen.sh
+
+# A small script that executes all 22 TPC-H queries sequentially.
+COPY run_power_test.sh /opt/tpch/run_power_test.sh
+RUN chmod +x /opt/tpch/run_power_test.sh
+
+# Template config that evaluation scripts augment via ALTER SYSTEM.
+# Intentionally minimal — the runner applies the actual knob configs.
+RUN echo "log_min_duration_statement = -1" >> /usr/share/postgresql/postgresql.conf.sample && \
+    echo "shared_preload_libraries = ''" >> /usr/share/postgresql/postgresql.conf.sample
+
+HEALTHCHECK --interval=5s --timeout=5s --start-period=30s --retries=12 \
+    CMD pg_isready -U "${POSTGRES_USER:-postgres}" -d "${POSTGRES_DB:-eval}" || exit 1
+
+EXPOSE 5432

--- a/docker/run_power_test.sh
+++ b/docker/run_power_test.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# run_power_test.sh
+# TPC-H Power Test: executes all 22 queries sequentially against the
+# PostgreSQL instance running in the evaluation container.
+#
+# Output format (parsed by docker_env._parse_tpch_output):
+#   Query 1: 2.345s
+#   Query 2: 0.892s
+#   ...
+#   Query 22: 1.234s
+# ─────────────────────────────────────────────────────────────────────────────
+set -euo pipefail
+
+TPCH_DIR="/opt/tpch"
+QUERIES_DIR="${TPCH_DIR}/queries"
+PG_USER="${POSTGRES_USER:-postgres}"
+PG_DB="${POSTGRES_DB:-eval}"
+
+if [ ! -d "${QUERIES_DIR}" ]; then
+    echo "ERROR: TPC-H query directory not found: ${QUERIES_DIR}" >&2
+    exit 1
+fi
+
+echo "Starting TPC-H Power Test (22 queries) …"
+echo ""
+
+TOTAL_START=$(date +%s%N)
+
+for q in $(seq 1 22); do
+    QUERY_FILE="${QUERIES_DIR}/${q}.sql"
+    if [ ! -f "${QUERY_FILE}" ]; then
+        echo "WARNING: Query file missing: ${QUERY_FILE}" >&2
+        continue
+    fi
+
+    START=$(date +%s%N)
+    psql -U "${PG_USER}" -d "${PG_DB}" \
+         -v ON_ERROR_STOP=1 \
+         --no-psqlrc \
+         -q \
+         -f "${QUERY_FILE}" \
+         > /dev/null 2>&1
+    END=$(date +%s%N)
+
+    # Duration in seconds with 3 decimal places
+    DURATION_MS=$(( (END - START) / 1000000 ))
+    DURATION_S=$(awk "BEGIN {printf \"%.3f\", ${DURATION_MS}/1000}")
+    echo "Query ${q}: ${DURATION_S}s"
+done
+
+TOTAL_END=$(date +%s%N)
+TOTAL_MS=$(( (TOTAL_END - TOTAL_START) / 1000000 ))
+TOTAL_S=$(awk "BEGIN {printf \"%.3f\", ${TOTAL_MS}/1000}")
+
+echo ""
+echo "Power Test total: ${TOTAL_S}s"

--- a/docs/EVALUATION_RUNBOOK.md
+++ b/docs/EVALUATION_RUNBOOK.md
@@ -1,0 +1,161 @@
+# Evaluation Reproducibility Runbook
+
+> Last reviewed: 2026-04-17
+
+See also: [Documentation Index](./README.md)
+
+This runbook defines the canonical workflow for reproducing comparative
+`default vs tuned` evaluation results from a saved tuning session.
+
+## Scope
+
+Use this runbook for:
+
+- Re-running evaluation after a tuning session
+- Generating reviewer-ready comparison JSON artifacts
+- Verifying reproducibility assumptions (seed handling, environment capture)
+
+## Prerequisites
+
+- Python environment with dev dependencies installed:
+
+```bash
+pip install -r requirements-dev.txt
+```
+
+- A completed tuning session JSON file (for example):
+
+`results/olap/pbt_runs/extensive/tuning_sessions/pbt_results_YYYYMMDD_HHMM.json`
+
+- Docker daemon running for isolated evaluation (recommended)
+
+## Canonical Commands
+
+### Option A: Docker-Isolated Evaluation (Recommended)
+
+```bash
+python -m src.evaluation \
+  --session results/olap/pbt_runs/extensive/tuning_sessions/pbt_results_YYYYMMDD_HHMM.json \
+  --repetitions 10 \
+  --seed 50000
+```
+
+### Option B: Bare-Metal Fallback (Reduced Isolation)
+
+```bash
+python -m src.evaluation \
+  --session results/olap/pbt_runs/extensive/tuning_sessions/pbt_results_YYYYMMDD_HHMM.json \
+  --repetitions 10 \
+  --seed 50000 \
+  --no-docker
+```
+
+### Option C: Explicit Sysbench Runtime Overrides
+
+```bash
+python -m src.evaluation \
+  --session results/oltp/pbt_runs/core/tuning_sessions/pbt_results_YYYYMMDD_HHMM.json \
+  --repetitions 8 \
+  --sysbench-tables 16 \
+  --sysbench-table-size 200000 \
+  --sysbench-duration 90 \
+  --sysbench-warmup-seconds 15
+```
+
+### Option D: Explicit TPC-H Runtime Overrides
+
+```bash
+python -m src.evaluation \
+  --session results/olap/pbt_runs/extensive/tuning_sessions/pbt_results_YYYYMMDD_HHMM.json \
+  --repetitions 8 \
+  --tpch-scale-factor 1.0 \
+  --tpch-warmup-passes 2
+```
+
+### Option E: One-Command Repro Script
+
+```bash
+./scripts/run_repro_eval.sh --session results/olap/pbt_runs/extensive/tuning_sessions/pbt_results_YYYYMMDD_HHMM.json --repetitions 10
+```
+
+`run_repro_eval.sh` is a convenience-only passthrough. Argument validation,
+defaults, and CLI contract are defined only in `python -m src.evaluation`.
+
+When omitted, `--seed` defaults to `50000`.
+
+## Output Location
+
+By default, evaluation outputs are written to:
+
+- `results/oltp/comparisons/{tier}/` for OLTP workloads
+- `results/olap/comparisons/{tier}/` for OLAP workloads
+- `results/mixed/comparisons/{tier}/` for mixed or unknown workloads
+
+Within the selected output directory, artifacts are split as:
+
+- Comparison JSON: `comparison_{timestamp}.json`
+- Session HTML log: `logs/evaluation_{timestamp}.html`
+
+The `{tier}` segment is inferred from `tuning_session.knob_tier` in the
+session JSON, with a fallback to the tier segment in the session path
+(`.../pbt_runs/{tier}/...`). If neither source is available, the fallback
+tier is `unknown`.
+
+Override this with `--output-dir <path>` when needed.
+
+## Reproducibility Checklist
+
+For each run, verify the generated comparison JSON includes:
+
+- `comparison_metadata.repetitions`
+- `comparison_metadata.evaluation_environment`
+- `comparison_metadata.resource_constraints`
+- `comparison_metadata.reproducibility.python_version`
+- `comparison_metadata.reproducibility.postgres_version`
+- `comparison_metadata.reproducibility.docker_image` (when Docker mode is used)
+- `comparison_metadata.reproducibility.python_package_versions`
+- `comparison_metadata.reproducibility.benchmark_binary_paths`
+
+## Random Seed Handling and Deterministic Limits
+
+### Tuning stage (`src/tuner`)
+
+- Tuning CLI exposes `--random-seed` (default: `42`) in `src/tuner/main.py`.
+- Population initialization and perturbation sampling use deterministic seed
+  propagation from the global seed.
+
+### Evaluation stage (`src/evaluation`)
+
+- Each default/tuned run pair uses an identical deterministic workload seed.
+  Repetition `i` uses `base_seed + i - 1` for both configurations.
+- Statistical bootstrap uses a fixed RNG seed (`42`) in
+  `src/evaluation/statistics.py` for deterministic confidence interval
+  computation.
+
+## Statistical Endpoint Policy
+
+- Primary endpoint: `score` tested at $\alpha = 0.05$ (no family correction).
+- Secondary endpoint family: benchmark latency endpoint + throughput +
+  memory utilization.
+  - Sysbench secondary latency endpoint: `latency_p95`.
+  - TPC-H secondary latency endpoint: `latency_p99`.
+- Secondary p-values use Holm correction.
+
+### Practical limits
+
+Even with fixed seeds, full determinism is not guaranteed due to:
+
+- OS scheduling and process timing noise
+- PostgreSQL background activity
+- Storage and cache effects
+- Bare-metal resource contention
+
+Docker isolation materially reduces this variance and is recommended for
+publication-facing comparisons.
+
+## Failure Triage
+
+- Docker unavailable: rerun with `--no-docker` and mark output as reduced-isolation.
+- Missing benchmark binaries (`sysbench`/`psql`): install system packages and rerun.
+- Session file missing fields: validate the tuning session JSON first.
+- Runtime mismatch: compare reproducibility metadata between baseline and rerun.

--- a/scripts/run_repro_eval.sh
+++ b/scripts/run_repro_eval.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly LOCAL_PYTHON=".venv/bin/python"
+PYTHON_BIN="python3"
+
+if [[ -x "$LOCAL_PYTHON" ]]; then
+  PYTHON_BIN="$LOCAL_PYTHON"
+fi
+
+exec "$PYTHON_BIN" -m src.evaluation "$@"

--- a/src/analysis/data_loader.py
+++ b/src/analysis/data_loader.py
@@ -15,10 +15,11 @@ from typing import Any, Dict, List, Tuple
 import pandas as pd
 
 from src.utils.metrics import (
-    MetricConfig, 
-    PerformanceMetrics, 
+    MetricConfig,
+    PerformanceMetrics,
     create_metric_config
 )
+from src.utils.rescoring import rescore_metrics_globally
 from src.tuner.config.knob_loader import get_knob_space
 from src.tuner.config.knob_space import HARDWARE_RELATIVE_SPECS
 from src.utils.logger import get_logger
@@ -261,14 +262,17 @@ def load_pbt_results(
         )
 
     # 2. Global Rescoring
-    workload = metadata_list[0].get('workload_type', default_workload_type)
-    global_metric_config = create_metric_config(workload)
-    
-    # Scale ranges across ALL sessions (0 padding tightly bounds the range)
-    logger.info("Computing global bounds across all tuning sessions...")
-    global_metric_config.update_ranges(valid_metrics, padding_factor=0.0)
-
-    global_scores = [global_metric_config.compute_score(m) for m in valid_metrics]
+    workload = str(metadata_list[0].get('workload_type', default_workload_type))
+    global_metric_config, global_scores, rescoring_metadata = rescore_metrics_globally(
+        valid_metrics,
+        workload=workload,
+        padding_factor=0.0,
+    )
+    logger.info(
+        "Computed global ranges via shared rescoring utility: latency=%s calibrated=%s",
+        rescoring_metadata["latency_metric"],
+        rescoring_metadata["ranges_calibrated"],
+    )
 
     # 3. DataFrame Post-Processing
     df = pd.DataFrame(raw_configs)

--- a/src/benchmarks/sysbench/executor.py
+++ b/src/benchmarks/sysbench/executor.py
@@ -2,6 +2,8 @@ import subprocess
 import re
 from typing import Optional
 
+import psycopg2
+
 from src.config.database import DatabaseConfig
 from src.database.connection import get_connection
 from src.utils.logger import get_logger
@@ -57,6 +59,18 @@ class SysbenchExecutor(BenchmarkExecutor):
             "Preparing %d sysbench tables (%d rows each) on %s:%s...",
             self.tables, self.table_size, db_config.host, db_config.port,
         )
+
+        # Cross-benchmark safety: ensure TPC-H leftovers do not survive into
+        # a Sysbench prepare fallback path after snapshot restore failure.
+        cleanup_conn = get_connection(config=db_config)
+        cleanup_conn.autocommit = True
+        cleanup_cursor = cleanup_conn.cursor()
+        try:
+            self._drop_existing_public_tables(cleanup_cursor, logger)
+        finally:
+            cleanup_cursor.close()
+            cleanup_conn.close()
+
         cmd = self._build_base_cmd(db_config)
         subprocess.run(
             cmd + ["cleanup"],
@@ -75,53 +89,74 @@ class SysbenchExecutor(BenchmarkExecutor):
             cursor.close()
             conn.close()
             logger.debug("Successfully executed post-prepare VACUUM ANALYZE on all sbtest tables.")
-        except Exception as e:
+        except (RuntimeError, psycopg2.Error, OSError, ValueError) as e:
             logger.warning("Failed to post-vacuum sysbench tables: %s", e)
 
         logger.info("Sysbench prepare complete.")
 
     def validate(self, db_config: DatabaseConfig) -> bool:
-        """Return True if all required sbtest tables exist AND have expected rows."""
+        """Return True only when schema shape matches the configured Sysbench profile."""
         logger = get_logger(__name__)
+        conn = None
+        cursor = None
         try:
             conn = get_connection(config=db_config)
             cursor = conn.cursor()
 
-            # First check if all tables exist
+            # Schema must match the expected table set exactly.
             cursor.execute(
-                "SELECT count(*) FROM information_schema.tables "
+                "SELECT table_name FROM information_schema.tables "
                 "WHERE table_schema = 'public' AND table_name LIKE 'sbtest%'"
             )
-            count = cursor.fetchone()[0]  # type: ignore
+            found_tables = {str(row[0]) for row in cursor.fetchall()}
+            expected_tables = {f"sbtest{i}" for i in range(1, self.tables + 1)}
 
-            if count < self.tables:
-                logger.debug("Sysbench tables missing (found %d, expected %d)", count, self.tables)
-                cursor.close()
-                conn.close()
+            if found_tables != expected_tables:
+                missing_tables = sorted(expected_tables - found_tables)
+                extra_tables = sorted(found_tables - expected_tables)
+                logger.debug(
+                    "Sysbench table layout mismatch "
+                    "(missing=%s, extra=%s, expected_count=%d, found_count=%d)",
+                    missing_tables,
+                    extra_tables,
+                    len(expected_tables),
+                    len(found_tables),
+                )
                 return False
 
-            # Then check if they're actually populated (just sample table 1).
+            # Validate table cardinality against the configured profile.
             cursor.execute("SELECT max(id) FROM sbtest1")
             max_id = cursor.fetchone()[0]  # type: ignore
 
-            # Sysbench insert might not be exactly equal to table_size if there were errors
-            # during prepare, but it should be close or equal
-            if max_id is None or max_id < (self.table_size * 0.9):
+            # max(id) grows over time due delete+insert churn. Estimate table cardinality
+            # using row count to detect profile mismatches (e.g., standard -> rapid).
+            cursor.execute("SELECT count(*) FROM sbtest1")
+            row_count = cursor.fetchone()[0]  # type: ignore
+
+            lower_bound = int(self.table_size * 0.9)
+            upper_bound = int(self.table_size * 1.1)
+            if row_count is None or row_count < lower_bound or row_count > upper_bound:
                 logger.debug(
-                    "Sysbench tables exist but are empty/underpopulated "
-                    "(max id %s, expected ~%d)", max_id, self.table_size
+                    "Sysbench row cardinality mismatch "
+                    "(row_count=%s, max_id=%s, expected~%d, bounds=[%d,%d])",
+                    row_count,
+                    max_id,
+                    self.table_size,
+                    lower_bound,
+                    upper_bound,
                 )
-                cursor.close()
-                conn.close()
                 return False
 
-            cursor.close()
-            conn.close()
             return True
 
-        except Exception as e:
+        except (RuntimeError, psycopg2.Error, OSError, ValueError) as e:
             logger.debug("Sysbench validation failed: %s", e)
             return False
+        finally:
+            if cursor is not None:
+                cursor.close()
+            if conn is not None:
+                conn.close()
 
     def execute(
         self,

--- a/src/benchmarks/tpch/executor.py
+++ b/src/benchmarks/tpch/executor.py
@@ -124,8 +124,7 @@ class TPCHExecutor(BenchmarkExecutor):
             cursor = conn.cursor()
 
             logger.debug("[TPC-H] Dropping old schema if exists...")
-            for table_name in self.TABLES_DROP_ORDER:
-                cursor.execute(f"DROP TABLE IF EXISTS {table_name} CASCADE")
+            self._drop_existing_public_tables(cursor, logger)
 
             logger.debug("[TPC-H] Creating schema (8 tables)...")
             schema_sql = SCHEMA_SQL.read_text()
@@ -169,6 +168,19 @@ class TPCHExecutor(BenchmarkExecutor):
 
         finally:
             conn.close()
+
+    def _drop_existing_public_tables(
+        self,
+        cursor,
+        logger: logging.Logger,
+        log_prefix: str = "[TPC-H]",
+    ) -> None:
+        """Drop all public tables before loading TPC-H data."""
+        super()._drop_existing_public_tables(
+            cursor,
+            logger,
+            log_prefix=log_prefix,
+        )
 
     @staticmethod
     def _strip_trailing_delimiter(file_obj):

--- a/src/evaluation/__main__.py
+++ b/src/evaluation/__main__.py
@@ -1,0 +1,282 @@
+"""
+evaluate_tuning — CLI entry point
+===================================
+
+Run as a module:
+
+    python -m src.evaluation --session <path> [OPTIONS]
+
+Examples:
+
+    # Standard comparison: Docker containers, 5 repetitions, auto-detect benchmark
+    python -m src.evaluation \\
+        --session results/olap/pbt_runs/extensive/tuning_sessions/pbt_results_20260326_2115.json
+
+    # Ten repetitions for tighter confidence intervals
+    python -m src.evaluation \\
+        --session results/olap/pbt_runs/extensive/tuning_sessions/pbt_results_20260326_2115.json \\
+        --repetitions 10
+
+    # Override benchmark type (normally auto-detected from session)
+    python -m src.evaluation \\
+        --session results/oltp/pbt_runs/standard/tuning_sessions/pbt_results_20260402_1559.json \\
+        --benchmark sysbench
+
+    # Bare-metal fallback (no Docker — reduced isolation)
+    python -m src.evaluation \\
+        --session results/olap/pbt_runs/extensive/tuning_sessions/pbt_results_20260326_2115.json \\
+        --no-docker
+
+    # Custom output directory
+    python -m src.evaluation \\
+        --session results/olap/pbt_runs/extensive/tuning_sessions/pbt_results_20260326_2115.json \\
+        --output-dir /tmp/eval_results
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from src.evaluation.exceptions import EvaluationError
+from src.evaluation.runner import ComparisonRunner
+from src.evaluation.types import ComparisonConfig
+from src.utils.logger import setup_logging, get_logger
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m src.evaluation",
+        description=(
+            "Compare a PBT-tuned PostgreSQL configuration against the default\n"
+            "PostgreSQL settings using statistically rigorous repeated benchmarks.\n\n"
+            "Results are saved to results/{workload}/comparisons/{tier}/comparison_{ts}.json\n"
+            "and logs to results/{workload}/comparisons/{tier}/logs/evaluation_{ts}.html"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Statistical methodology:\n"
+            "  - Wilcoxon signed-rank test (non-parametric, paired)\n"
+            "  - Bootstrap 95% CI on paired median differences (10,000 resamples)\n"
+            "  - Holm correction for secondary endpoints (latency/throughput/memory)\n"
+            "  - Paired Cohen's d effect size\n"
+            "  - Both mean ± std and median ± IQR reported\n\n"
+            "Examples:\n"
+            "  python -m src.evaluation \\\n"
+            "    --session results/olap/pbt_runs/extensive/tuning_sessions/"
+            "pbt_results_20260326_2115.json\n\n"
+            "  python -m src.evaluation \\\n"
+            "    --session results/oltp/pbt_runs/standard/tuning_sessions/"
+            "pbt_results_20260402_1559.json \\\n"
+            "    --repetitions 10 --benchmark sysbench\n"
+        ),
+    )
+
+    parser.add_argument(
+        "--session",
+        required=True,
+        metavar="PATH",
+        type=Path,
+        help=(
+            "Path to the PBT tuning session results JSON file.\n"
+            "e.g. results/olap/pbt_runs/extensive/tuning_sessions/pbt_results_20260326_2115.json"
+        ),
+    )
+
+    bench_grp = parser.add_argument_group("benchmark options")
+    bench_grp.add_argument(
+        "--benchmark",
+        metavar="TYPE",
+        choices=["sysbench", "tpch"],
+        default=None,
+        help=(
+            "Benchmark type: 'sysbench' or 'tpch'. "
+            "Auto-detected from the tuning session when not specified."
+        ),
+    )
+    bench_grp.add_argument(
+        "--repetitions",
+        metavar="N",
+        type=int,
+        default=5,
+        help="Number of independent runs per configuration (default: 5).",
+    )
+    bench_grp.add_argument(
+        "--tpch-scale-factor",
+        metavar="F",
+        type=float,
+        default=None,
+        help=(
+            "TPC-H scale factor. "
+            "Auto-detected from session when not specified."
+        ),
+    )
+    bench_grp.add_argument(
+        "--sysbench-duration",
+        metavar="S",
+        type=int,
+        default=None,
+        help=(
+            "Sysbench measurement duration in seconds. "
+            "Auto-detected from session when not specified."
+        ),
+    )
+    bench_grp.add_argument(
+        "--sysbench-tables",
+        metavar="N",
+        type=int,
+        default=None,
+        help=(
+            "Number of sysbench tables. "
+            "Auto-detected from session when not specified."
+        ),
+    )
+    bench_grp.add_argument(
+        "--sysbench-table-size",
+        metavar="N",
+        type=int,
+        default=None,
+        help=(
+            "Rows per sysbench table. "
+            "Auto-detected from session when not specified."
+        ),
+    )
+    bench_grp.add_argument(
+        "--sysbench-warmup-seconds",
+        metavar="S",
+        type=int,
+        default=None,
+        help=(
+            "Sysbench warmup duration in seconds. "
+            "Auto-detected from session when not specified."
+        ),
+    )
+    bench_grp.add_argument(
+        "--tpch-warmup-passes",
+        metavar="N",
+        type=int,
+        default=None,
+        help=(
+            "TPC-H warmup passes before measurement. "
+            "Auto-detected from session when not specified."
+        ),
+    )
+    bench_grp.add_argument(
+        "--seed",
+        metavar="N",
+        type=int,
+        default=50_000,
+        help=(
+            "Base deterministic seed for paired runs (default: 50000). "
+            "Each repetition uses base_seed + run_number - 1 for both default and tuned runs."
+        ),
+    )
+
+    env_grp = parser.add_argument_group("environment options")
+    env_grp.add_argument(
+        "--no-docker",
+        action="store_true",
+        default=False,
+        help=(
+            "Use bare-metal evaluation instead of Docker containers.\n"
+            "WARNING: No resource isolation — results may be noisy."
+        ),
+    )
+    env_grp.add_argument(
+        "--docker-image",
+        metavar="IMAGE",
+        default="pbt-eval",
+        help="Docker image name/tag for evaluation containers (default: pbt-eval).",
+    )
+
+    out_grp = parser.add_argument_group("output options")
+    out_grp.add_argument(
+        "--output-dir",
+        metavar="PATH",
+        type=Path,
+        default=None,
+        help=(
+            "Override the base output directory for evaluation artifacts.\n"
+            "Default: comparison JSON in results/{workload}/comparisons/{tier}/\n"
+            "and HTML logs in results/{workload}/comparisons/{tier}/logs/"
+        ),
+    )
+
+    parser.add_argument(
+        "--verbose",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        default="INFO",
+        help="Console log level (default: INFO).",
+    )
+    parser.add_argument(
+        "-v",
+        action="store_true",
+        default=False,
+        help="Shortcut for --log-level DEBUG.",
+    )
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """
+    CLI entry point for the evaluate_tuning module.
+
+    Args:
+        argv: Argument list (defaults to sys.argv[1:]).
+
+    Returns:
+        Exit code: 0 on success, 1 on failure.
+    """
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    log_level = "DEBUG" if args.v else args.verbose
+    setup_logging(verbosity=log_level)
+    logger = get_logger("evaluate_tuning")
+
+    if args.repetitions < 2:
+        parser.error("--repetitions must be at least 2 (need paired observations for Wilcoxon).")
+    if args.repetitions < 5:
+        logger.warning(
+            "Running only %d repetitions. Wilcoxon signed-rank requires "
+            "N ≥ 5 for p < 0.05 (two-sided). Consider --repetitions 5.",
+            args.repetitions,
+        )
+
+    config = ComparisonConfig(
+        tuning_session_path=args.session,
+        benchmark=args.benchmark,  # None when not specified → auto-detect
+        repetitions=args.repetitions,
+        scale_factor=args.tpch_scale_factor,
+        sysbench_duration=args.sysbench_duration,
+        sysbench_tables=args.sysbench_tables,
+        sysbench_table_size=args.sysbench_table_size,
+        sysbench_warmup_seconds=args.sysbench_warmup_seconds,
+        tpch_warmup_passes=args.tpch_warmup_passes,
+        pair_seed=args.seed,
+        use_docker=not args.no_docker,
+        docker_image=args.docker_image,
+        output_dir=args.output_dir,
+    )
+
+    try:
+        runner = ComparisonRunner(config)
+        runner.run()   # Summary printed internally by runner._print_summary()
+        logger.info("Evaluation complete. Exit 0.")
+        return 0
+
+    except EvaluationError as exc:
+        logger.error("Evaluation failed: %s", exc)
+        return 1
+    except KeyboardInterrupt:
+        logger.info("Interrupted by user.")
+        return 130
+    except Exception as exc:  # broad catch intentional: CLI must not crash with traceback
+        logger.exception("Unexpected error during evaluation: %s", exc)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/evaluation/exceptions.py
+++ b/src/evaluation/exceptions.py
@@ -1,0 +1,48 @@
+"""
+Exceptions for the evaluate_tuning module.
+==========================================
+
+Domain-specific exception hierarchy. All exceptions derive from
+`EvaluationError` so callers can catch the full domain with a
+single clause while still distinguishing specific failure modes.
+"""
+
+
+class EvaluationError(Exception):
+    """Base exception for all evaluation failures."""
+
+
+class TuningSessionLoadError(EvaluationError):
+    """
+    Raised when a PBT tuning session results file cannot be loaded.
+
+    Covers missing files, malformed JSON, and missing required fields
+    (best_configuration, worker_resources, tuning_session).
+    """
+
+
+class DockerEnvironmentError(EvaluationError):
+    """
+    Raised when the Docker evaluation environment cannot be set up.
+
+    Covers Docker daemon not running, image build failures, and
+    resource-limit configuration errors.
+    """
+
+
+class BenchmarkExecutionError(EvaluationError):
+    """
+    Raised when a benchmark run fails inside an evaluation container.
+
+    Covers sysbench/TPC-H execution errors, PostgreSQL failures inside
+    the container, and result-parsing failures.
+    """
+
+
+class KnobApplicationError(EvaluationError):
+    """
+    Raised when a tuned knob configuration cannot be applied.
+
+    Covers ALTER SYSTEM failures, pg_ctl restart timeouts, and
+    configuration verification mismatches inside a container.
+    """

--- a/src/evaluation/loader.py
+++ b/src/evaluation/loader.py
@@ -1,0 +1,291 @@
+"""
+Tuning Session Loader
+=====================
+
+Loads and validates PBT tuning session result JSON files, extracting
+the best knob configuration, resource constraints, and benchmark metadata
+needed to drive a comparative evaluation.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Optional
+
+from src.utils.logger import get_logger
+from src.evaluation.exceptions import TuningSessionLoadError
+from src.evaluation.types import TuningSessionData, WorkerResources
+
+logger = get_logger(__name__)
+
+# Fields that MUST be present in the results JSON
+_REQUIRED_TOP_LEVEL = {"best_configuration", "worker_resources", "tuning_session"}
+_REQUIRED_BEST_CONFIG = {"knobs", "score"}
+_REQUIRED_WORKER_RES = {"ram_bytes", "cpu_cores", "disk_type"}
+
+
+def load_tuning_session(path: Path) -> TuningSessionData:
+    """
+    Load a PBT tuning session results JSON and extract evaluation inputs.
+
+    Parses the following fields from the results file:
+
+        best_configuration.knobs   → best knob config
+        best_configuration.score   → best composite score
+        worker_resources           → CPU / RAM / disk constraints
+        system_info                → original hardware snapshot
+        tuning_session             → PBT metadata (tier, benchmark, etc.)
+
+    Args:
+        path: Path to a `pbt_results_{timestamp}.json` file produced by
+            `src/tuner/main.py`.
+
+    Returns:
+        TuningSessionData populated with all fields required to run an
+        evaluation.
+
+    Raises:
+        TuningSessionLoadError: If the file does not exist, contains invalid
+            JSON, or is missing any required field.
+    """
+    path = Path(path)
+    logger.info("Loading tuning session from: %s", path)
+
+    logger.debug("  Checking if correct tuning session file exists...")
+    if not path.exists():
+        raise TuningSessionLoadError(
+            f"Tuning session file not found: {path}\n"
+            "    Expected path: results/{{workload}}/pbt_runs/{{tier}}/tuning_sessions/"
+            "pbt_results_{{timestamp}}.json"
+        )
+
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            data: dict[str, Any] = json.load(fh)
+    except json.JSONDecodeError as exc:
+        raise TuningSessionLoadError(
+            f"Failed to parse JSON from {path}: {exc}"
+        ) from exc
+    except OSError as exc:
+        raise TuningSessionLoadError(
+            f"Cannot read file {path}: {exc}"
+        ) from exc
+
+    if not isinstance(data, dict):
+        raise TuningSessionLoadError(
+            f"Expected a JSON object at root, got {type(data).__name__}"
+        )
+    logger.debug("  ➤ Correct session file exist.")
+
+    logger.debug("  Checking if required fields are present...")
+    _assert_fields(data, _REQUIRED_TOP_LEVEL, context="root")
+
+    best_config = data["best_configuration"]
+    _assert_fields(best_config, _REQUIRED_BEST_CONFIG, context="best_configuration")
+
+    best_knobs: dict[str, Any] = best_config["knobs"]
+    best_score: float = float(best_config["score"])
+
+    if not isinstance(best_knobs, dict) or not best_knobs:
+        raise TuningSessionLoadError(
+            "best_configuration.knobs must be a non-empty dict"
+        )
+
+    wr_raw = data["worker_resources"]
+    _assert_fields(wr_raw, _REQUIRED_WORKER_RES, context="worker_resources")
+    logger.debug("  ➤ Required fields are present.")
+
+    logger.debug("  Checking if worker resources are valid...")
+    worker_resources = WorkerResources(
+        ram_bytes=int(wr_raw["ram_bytes"]),
+        cpu_cores=int(wr_raw["cpu_cores"]),
+        disk_type=str(wr_raw["disk_type"]),
+    )
+
+    if worker_resources.ram_bytes <= 0:
+        raise TuningSessionLoadError(
+            f"worker_resources.ram_bytes must be positive, got {worker_resources.ram_bytes}"
+        )
+    if worker_resources.cpu_cores <= 0:
+        raise TuningSessionLoadError(
+            f"worker_resources.cpu_cores must be positive, got {worker_resources.cpu_cores}"
+        )
+    logger.debug("  ➤ Worker resources are valid.")
+
+    logger.debug("  Inferring tuning session metadata...")
+    ts_meta: dict[str, Any] = data["tuning_session"]
+    timestamp = ts_meta.get("timestamp")
+    session_id = str(timestamp) if timestamp is not None else path.stem
+
+    try:
+        benchmark, workload_type = _infer_benchmark_and_workload(ts_meta, path)
+    except TuningSessionLoadError as exc:
+        raise TuningSessionLoadError(
+            f"Failed to infer benchmark and workload type: {exc}"
+        ) from exc
+    logger.debug("  ➤ Benchmark and workload type inferred successfully.")
+
+    logger.debug("  Processing system info and tuning config...")
+    system_info: dict[str, Any] = data.get("system_info", {})
+    if not system_info:
+        logger.warning(
+            "  ➤ system_info missing from %s — hardware provenance will be incomplete",
+            path.name
+        )
+
+    tuning_config = _normalize_tuning_config(ts_meta)
+
+    logger.debug("  ➤ System info and tuning config processed successfully.")
+
+    logger.info(
+        "➤ Loaded tuning session: timestamp=%s benchmark=%s workload=%s "
+        "best_score=%.2f knobs=%d resources=(cpu=%d ram=%.1fGB)",
+        timestamp,
+        benchmark,
+        workload_type,
+        best_score,
+        len(best_knobs),
+        worker_resources.cpu_cores,
+        worker_resources.ram_bytes / (1024 ** 3),
+    )
+
+    return TuningSessionData(
+        best_knobs=best_knobs,
+        best_score=best_score,
+        worker_resources=worker_resources,
+        system_info=system_info,
+        tuning_config=tuning_config,
+        benchmark=benchmark,
+        workload_type=workload_type,
+        session_id=session_id,
+    )
+
+
+def _assert_fields(
+    obj: dict[str, Any],
+    required: set[str],
+    context: str,
+) -> None:
+    """Raise TuningSessionLoadError if any required field is missing."""
+    missing = required - set(obj.keys())
+    if missing:
+        raise TuningSessionLoadError(
+            f"Missing required field(s) in '{context}': {sorted(missing)}"
+        )
+
+
+def _infer_benchmark_and_workload(
+    ts_meta: dict[str, Any],
+    path: Path
+) -> tuple[str, str]:
+    """
+    Infer the benchmark type and workload type from tuning_session metadata or the file path.
+    """
+    benchmark = ts_meta.get("benchmark_name")
+    workload_type = ts_meta.get("workload_type")
+    if workload_type:
+        workload_type = str(workload_type).lower()
+
+    if not workload_type:
+        logger.warning(
+            "  ➤ workload type not found in session metadata, falling back to "
+            "path to infer workload type"
+        )
+        path_str = str(path).lower()
+        if "olap" in path_str or "tpch" in path_str:
+            workload_type = "olap"
+        elif "oltp" in path_str or "sysbench" in path_str:
+            workload_type = "oltp"
+        elif "mixed" in path_str:
+            workload_type = "mixed"
+        else:
+            raise TuningSessionLoadError(
+                f"Couldn't infer workload type from path: {path}"
+            )
+
+    if not benchmark:
+        if workload_type == "oltp" or workload_type == "mixed":
+            benchmark = "sysbench"
+        elif workload_type == "olap":
+            benchmark = "tpch"
+        else:
+            raise TuningSessionLoadError(
+                f"Unknown workload type: {workload_type}"
+            )
+
+        logger.warning(
+            "  ➤ benchmark name not found in session metadata, used workload"
+            " type to infer benchmark: %s",
+            benchmark
+        )
+
+    return benchmark, workload_type
+
+
+def _normalize_tuning_config(ts_meta: dict[str, Any]) -> dict[str, Any]:
+    """
+    Normalize runtime tuning metadata into canonical evaluation keys.
+
+    This keeps evaluation backward-compatible with historical session files
+    while allowing a stable precedence chain of:
+    CLI override -> session metadata -> benchmark defaults.
+    """
+    config: dict[str, Any] = {
+        k: v for k, v in ts_meta.items()
+        if k not in {"benchmark_name", "workload_type", "timestamp"}
+    }
+
+    def _as_int(value: Any) -> Optional[int]:
+        if value is None:
+            return None
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    def _as_float(value: Any) -> Optional[float]:
+        if value is None:
+            return None
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    # Canonical benchmark runtime parameter keys for evaluation.
+    scale_factor = _as_float(config.get("scale_factor"))
+    if scale_factor is not None:
+        config["scale_factor"] = scale_factor
+
+    sysbench_duration = _as_int(
+        config.get("sysbench_duration_seconds")
+        or config.get("sysbench_duration")
+        or config.get("evaluation_duration")
+        or config.get("measurement_duration")
+    )
+    if sysbench_duration is not None:
+        config["sysbench_duration_seconds"] = sysbench_duration
+
+    sysbench_warmup = _as_int(
+        config.get("sysbench_warmup_seconds")
+        or config.get("warmup_duration")
+    )
+    if sysbench_warmup is not None:
+        config["sysbench_warmup_seconds"] = sysbench_warmup
+
+    tpch_warmup_passes = _as_int(
+        config.get("tpch_warmup_passes")
+        or config.get("warmup_passes")
+    )
+    if tpch_warmup_passes is not None:
+        config["tpch_warmup_passes"] = tpch_warmup_passes
+
+    sysbench_tables = _as_int(config.get("sysbench_tables"))
+    if sysbench_tables is not None:
+        config["sysbench_tables"] = sysbench_tables
+
+    sysbench_table_size = _as_int(config.get("sysbench_table_size"))
+    if sysbench_table_size is not None:
+        config["sysbench_table_size"] = sysbench_table_size
+
+    return config

--- a/src/evaluation/runner.py
+++ b/src/evaluation/runner.py
@@ -1,0 +1,921 @@
+"""
+Comparison Runner — Core Orchestrator
+======================================
+
+Drives the end-to-end comparative evaluation pipeline:
+
+1. Load the PBT tuning session → extract best knobs + resource constraints.
+2. Create a DatabaseEnvironment (Docker or bare-metal) via EnvironmentFactory.
+3. Run N repetitions with the **default** PostgreSQL configuration,
+   each in a fresh container (Docker) or a re-initialized instance (bare-metal).
+4. Run N repetitions with the **tuned** configuration the same way.
+5. Compute non-parametric statistical comparison (Wilcoxon, bootstrap CI,
+   primary endpoint at alpha, Holm-corrected secondary endpoints, Cohen's d).
+6. Write the full result to `results/{workload}/comparisons/{tier}`.
+7. Print a formatted summary table to stdout.
+
+Fresh-per-run strategy
+----------------------
+Every repetition, regardless of configuration type, starts from a
+clean-slate database with its own container/instance. This prevents
+cache warming, index bloat, and other state-accumulation effects from
+leaking between measurements — the most rigorous isolation achievable
+without hardware-level separation.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import platform
+import re
+import shutil
+import time
+from datetime import datetime, timezone
+from importlib import metadata as importlib_metadata
+from pathlib import Path
+from typing import Any
+
+from src.config.database import get_db_config
+from src.utils.environments import EnvironmentFactory, DatabaseEnvironment
+from src.utils.hardware_info import WorkerResources as RuntimeWorkerResources
+from src.utils.logger import add_html_file_logging, get_evaluation_banner, get_logger
+from src.utils.metrics import PerformanceMetrics, create_metric_config
+from src.utils.rescoring import rescore_metrics_globally
+from src.benchmarks.sysbench.executor import SysbenchExecutor
+from src.benchmarks.tpch.executor import TPCHExecutor
+from src.tuner.evaluator.executor import BenchmarkExecutor
+from src.tuner.config import get_knob_space
+from src.evaluation.exceptions import DockerEnvironmentError
+from src.evaluation.loader import load_tuning_session
+from src.evaluation.statistics import compute_comparison_statistics
+from src.evaluation.types import (
+    ComparisonConfig,
+    ComparisonResult,
+    RunResult,
+    TuningSessionData,
+    WorkerResources,
+)
+
+LOGGER = get_logger(__name__)
+
+
+class ComparisonRunner:
+    """
+    Orchestrates the full default-vs-tuned benchmark comparison.
+
+    Args:
+        config: ``ComparisonConfig`` specifying the tuning session path,
+            benchmark parameters, repetition count, and output directory.
+
+    Example::
+
+        runner = ComparisonRunner(ComparisonConfig(
+            tuning_session_path=Path(
+                "results/olap/pbt_runs/extensive/tuning_sessions/"
+                "pbt_results_20260326_2115.json"
+            ),
+            repetitions=5,
+        ))
+        result = runner.run()
+        print(f"Overall improvement: {result.statistics.overall_improvement_pct:+.1f}%")
+    """
+
+    def __init__(self, config: ComparisonConfig) -> None:
+        self.config = config
+        self.base_db_config = get_db_config()
+        self.timestamp = datetime.now(tz=timezone.utc).strftime("%Y%m%d_%H%M%S")
+        self._session_log_path: Path | None = None
+
+    def run(self) -> ComparisonResult:
+        """
+        Execute the full comparison pipeline and return the result.
+
+        Returns:
+            ComparisonResult containing all run data, statistics, and the
+            path where the JSON result was saved.
+
+        Raises:
+            TuningSessionLoadError: If the session JSON is invalid.
+            DockerEnvironmentError: If Docker is required but unavailable.
+            EvaluationError: If a benchmark run fails fatally.
+        """
+        session = load_tuning_session(self.config.tuning_session_path)
+
+        benchmark = self.config.benchmark or session.benchmark
+        if benchmark not in {"sysbench", "tpch"}:
+            raise ValueError(
+                f"Unsupported benchmark '{benchmark}'. Expected 'sysbench' or 'tpch'."
+            )
+
+        effective_params = self._resolve_effective_benchmark_params(session, benchmark)
+        self.config = dataclasses.replace(
+            self.config,
+            benchmark=benchmark,
+            scale_factor=float(effective_params["scale_factor"]),
+            sysbench_duration=int(effective_params["sysbench_duration"]),
+            sysbench_tables=int(effective_params["sysbench_tables"]),
+            sysbench_table_size=int(effective_params["sysbench_table_size"]),
+            sysbench_warmup_seconds=int(effective_params["sysbench_warmup_seconds"]),
+            tpch_warmup_passes=int(effective_params["tpch_warmup_passes"]),
+        )
+
+        self._validate_docker_prerequisites()
+
+        output_dir = self._resolve_output_dir_for(session)
+        log_path = self._resolve_log_output_path(output_dir)
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        self._session_log_path = add_html_file_logging(log_path)
+
+        banner = get_evaluation_banner(
+            session_name=self.config.tuning_session_path.name,
+            benchmark=benchmark,
+            repetitions=self.config.repetitions,
+            env_type="Docker" if self.config.use_docker else "bare-metal",
+        )
+        LOGGER.info("\n%s", banner)
+        LOGGER.info("  HTML Log: %s", self._session_log_path)
+        if benchmark == "sysbench":
+            LOGGER.info(
+                "  Effective Sysbench params: tables=%d table_size=%d duration=%ds warmup=%ds",
+                self.config.sysbench_tables,
+                self.config.sysbench_table_size,
+                self.config.sysbench_duration,
+                self.config.sysbench_warmup_seconds,
+            )
+        else:
+            LOGGER.info(
+                "  Effective TPC-H params: scale_factor=%.2f warmup_passes=%d",
+                self.config.scale_factor,
+                self.config.tpch_warmup_passes,
+            )
+
+        tuned_knobs = self._resolve_tuned_knobs(session)
+
+        executor = self._create_executor()
+
+        LOGGER.info(
+            "Running paired default/tuned comparisons for %d repetitions...",
+            self.config.repetitions
+        )
+        default_runs, tuned_runs = self._run_paired_comparisons(
+            tuned_knobs=tuned_knobs,
+            session=session,
+            executor=executor,
+        )
+
+        all_runs = sorted(
+            [*default_runs, *tuned_runs],
+            key=lambda r: (r.run_number, r.order_in_pair, r.config_type),
+        )
+        _, rescored_scores, scoring_metadata = rescore_metrics_globally(
+            [r.metrics for r in all_runs],
+            benchmark=benchmark,
+            padding_factor=0.0,
+        )
+        for run, score in zip(all_runs, rescored_scores, strict=True):
+            run.score = score
+
+        LOGGER.info("\n── Statistical analysis ──")
+        statistics = compute_comparison_statistics(
+            default_runs,
+            tuned_runs,
+            benchmark=benchmark,
+        )
+
+        result = ComparisonResult(
+            default_runs=default_runs,
+            tuned_runs=tuned_runs,
+            tuned_knobs=tuned_knobs,
+            statistics=statistics,
+            config=self.config,
+            session_data=session,
+            timestamp=self.timestamp,
+            log_path=self._session_log_path,
+            scoring_metadata=scoring_metadata,
+        )
+
+        output_path = self._save_result(result)
+        result.output_path = output_path
+        self._print_summary(result)
+
+        return result
+
+    @staticmethod
+    def _missing_docker_image_help(image_name: str) -> str:
+        """Build a concise remediation message for missing evaluation images."""
+        return (
+            f"Docker image '{image_name}' is not available locally and pull failed. "
+            "Build the evaluation image first with:\n"
+            f"  docker build -f docker/eval.Dockerfile -t {image_name} docker/\n"
+            "Or rerun with --no-docker (reduced isolation)."
+        )
+
+    def _validate_docker_prerequisites(self) -> None:
+        """Fail fast when Docker evaluation prerequisites are unavailable."""
+        if not self.config.use_docker:
+            return
+
+        image_name = self.config.docker_image
+
+        try:
+            import docker  # local import keeps non-Docker paths lightweight
+        except ImportError as exc:
+            raise DockerEnvironmentError(
+                "Docker evaluation requested, but the Docker SDK is unavailable. "
+                "Install dependencies with: pip install -r requirements.txt"
+            ) from exc
+
+        client = None
+        try:
+            client = docker.from_env(timeout=30)
+            client.ping()
+
+            try:
+                client.images.get(image_name)
+                return
+            except docker.errors.ImageNotFound:
+                LOGGER.info(
+                    "Docker image '%s' not found locally; attempting to pull once...",
+                    image_name,
+                )
+                try:
+                    client.images.pull(image_name)
+                    LOGGER.info("Pulled Docker image '%s'.", image_name)
+                    return
+                except (docker.errors.ImageNotFound, docker.errors.APIError) as exc:
+                    raise DockerEnvironmentError(
+                        self._missing_docker_image_help(image_name)
+                    ) from exc
+
+        except docker.errors.DockerException as exc:
+            raise DockerEnvironmentError(
+                "Docker evaluation requested, but Docker daemon is unavailable. "
+                "Start Docker or rerun with --no-docker."
+            ) from exc
+        finally:
+            if client is not None:
+                client.close()
+
+    def _create_executor(self) -> BenchmarkExecutor:
+        """
+        Create the appropriate BenchmarkExecutor for the configured benchmark.
+
+        This executor serves dual purpose: it is passed to the EnvironmentFactory
+        as the `schema_provider` (so environment setup can validate/prepare the
+        schema), and it is used directly to execute benchmark measurements.
+        """
+        if self.config.benchmark == "tpch":
+            return TPCHExecutor(scale_factor=float(self.config.scale_factor or 1.0))
+        return SysbenchExecutor(
+            tables=int(self.config.sysbench_tables or 10),
+            table_size=int(self.config.sysbench_table_size or 100_000),
+        )
+
+    def _resolve_effective_benchmark_params(
+        self,
+        session: TuningSessionData,
+        benchmark: str,
+    ) -> dict[str, float | int]:
+        """
+        Resolve effective benchmark runtime parameters using strict precedence.
+
+        Precedence order:
+            1. CLI overrides from ComparisonConfig
+            2. Session metadata from tuning_session
+            3. Benchmark defaults
+        """
+        defaults: dict[str, float | int] = {
+            "scale_factor": 1.0,
+            "sysbench_duration": 60,
+            "sysbench_tables": 10,
+            "sysbench_table_size": 100_000,
+            "sysbench_warmup_seconds": 30,
+            "tpch_warmup_passes": 1,
+        }
+        session_cfg = session.tuning_config
+
+        def _pick_int(cli_value: Any, session_keys: list[str], default_value: int) -> int:
+            if cli_value is not None:
+                return int(cli_value)
+            for key in session_keys:
+                val = session_cfg.get(key)
+                if val is not None:
+                    try:
+                        return int(val)
+                    except (TypeError, ValueError):
+                        LOGGER.warning(
+                            "Ignoring invalid integer value for session key '%s': %r",
+                            key,
+                            val,
+                        )
+            return default_value
+
+        def _pick_float(cli_value: Any, session_keys: list[str], default_value: float) -> float:
+            if cli_value is not None:
+                return float(cli_value)
+            for key in session_keys:
+                val = session_cfg.get(key)
+                if val is not None:
+                    try:
+                        return float(val)
+                    except (TypeError, ValueError):
+                        LOGGER.warning(
+                            "Ignoring invalid float value for session key '%s': %r",
+                            key,
+                            val,
+                        )
+            return default_value
+
+        resolved = {
+            "scale_factor": _pick_float(
+                self.config.scale_factor,
+                ["scale_factor"],
+                float(defaults["scale_factor"]),
+            ),
+            "sysbench_duration": _pick_int(
+                self.config.sysbench_duration,
+                ["sysbench_duration_seconds", "sysbench_duration", "evaluation_duration"],
+                int(defaults["sysbench_duration"]),
+            ),
+            "sysbench_tables": _pick_int(
+                self.config.sysbench_tables,
+                ["sysbench_tables"],
+                int(defaults["sysbench_tables"]),
+            ),
+            "sysbench_table_size": _pick_int(
+                self.config.sysbench_table_size,
+                ["sysbench_table_size"],
+                int(defaults["sysbench_table_size"]),
+            ),
+            "sysbench_warmup_seconds": _pick_int(
+                self.config.sysbench_warmup_seconds,
+                ["sysbench_warmup_seconds", "warmup_duration"],
+                int(defaults["sysbench_warmup_seconds"]),
+            ),
+            "tpch_warmup_passes": _pick_int(
+                self.config.tpch_warmup_passes,
+                ["tpch_warmup_passes", "warmup_passes"],
+                int(defaults["tpch_warmup_passes"]),
+            ),
+        }
+
+        if benchmark == "tpch":
+            # Keep sysbench fields resolved for metadata completeness.
+            resolved["sysbench_duration"] = int(resolved["sysbench_duration"])
+        return resolved
+
+    def _build_environment(
+        self,
+        executor: BenchmarkExecutor,
+        worker_resources: WorkerResources,
+    ) -> DatabaseEnvironment:
+        """
+        Create an evaluation environment via EnvironmentFactory.
+
+        Each call creates a fresh environment so every benchmark repetition
+        starts from a clean-slate database.
+        """
+        return EnvironmentFactory.create(
+            schema_provider=executor,
+            use_docker=self.config.use_docker,
+            db_config=self.base_db_config,
+            worker_resources=worker_resources,
+            run_id=f"eval_{self.timestamp}",
+            container_prefix="eval-worker",
+            image_name=self.config.docker_image,
+        )
+
+    def _resolve_tuned_knobs(self, session: TuningSessionData) -> dict[str, Any]:
+        """
+        Resolve tuned knob values from serialized fractions to absolute values.
+
+        Tuning sessions persist hardware-relative knobs as fractions so they can
+        transfer across machines. Evaluation must convert them back to absolute
+        PostgreSQL values for the local worker resource constraints.
+        """
+        LOGGER.debug("Resolving tuned knobs for evaluation session...")
+        tier = self._resolve_tier_slug_from_session(session, self.config.tuning_session_path)
+        if tier == "unknown":
+            LOGGER.warning(
+                "➤ Could not infer knob tier for session %s; "
+                "applying stored knob values as-is.",
+                self.config.tuning_session_path.name,
+            )
+            return dict(session.best_knobs)
+
+        try:
+            knob_space = get_knob_space(tier)
+        except Exception as exc:
+            LOGGER.warning(
+                "Failed to load knob space for tier '%s': %s. Applying stored knob values as-is.",
+                tier,
+                exc,
+            )
+            return dict(session.best_knobs)
+
+        runtime_resources = RuntimeWorkerResources(
+            ram_bytes=session.worker_resources.ram_bytes,
+            cpu_cores=session.worker_resources.cpu_cores,
+            disk_type=session.worker_resources.disk_type,
+        )
+        knob_space.resolve_hardware_ranges(runtime_resources)
+        resolved = knob_space.fractions_to_config(session.best_knobs)
+
+        LOGGER.debug(
+            "➤ Resolved tuned knobs from fractional representation using tier=%s.",
+            tier,
+        )
+        return resolved
+
+    def _run_paired_comparisons(
+        self,
+        tuned_knobs: dict[str, Any],
+        session: TuningSessionData,
+        executor: BenchmarkExecutor,
+    ) -> tuple[list[RunResult], list[RunResult]]:
+        """
+        Execute strict paired runs where each pair shares one deterministic seed.
+
+        For pair i, both default and tuned runs use seed = pair_seed_base + i - 1.
+        """
+        default_runs: list[RunResult] = []
+        tuned_runs: list[RunResult] = []
+        failed_pairs = 0
+
+        for run_number in range(1, self.config.repetitions + 1):
+            pair_seed = self.config.pair_seed + run_number - 1
+            LOGGER.info(
+                "[Pair %d/%d] seed=%d",
+                run_number,
+                self.config.repetitions,
+                pair_seed,
+            )
+
+            try:
+                default_run = self._run_single(
+                    config_type="default",
+                    knobs={},
+                    run_number=run_number,
+                    pair_seed=pair_seed,
+                    order_in_pair=1,
+                    session=session,
+                    executor=executor,
+                )
+                tuned_run = self._run_single(
+                    config_type="tuned",
+                    knobs=tuned_knobs,
+                    run_number=run_number,
+                    pair_seed=pair_seed,
+                    order_in_pair=2,
+                    session=session,
+                    executor=executor,
+                )
+            except Exception as exc:
+                failed_pairs += 1
+                LOGGER.warning("➤ Pair %d failed: %s", run_number, exc)
+                if failed_pairs > self.config.repetitions // 2:
+                    raise RuntimeError(
+                        "More than half of run pairs failed "
+                        f"({failed_pairs}/{self.config.repetitions})."
+                    ) from exc
+                continue
+
+            default_runs.append(default_run)
+            tuned_runs.append(tuned_run)
+
+            LOGGER.info(
+                "➤ Pair %d complete: default(score=%.2f,p95=%.1f,tps=%.1f,mem=%.1f%%) | "
+                "tuned(score=%.2f,p95=%.1f,tps=%.1f,mem=%.1f%%)",
+                run_number,
+                default_run.score,
+                default_run.metrics.latency_p95,
+                default_run.metrics.throughput,
+                default_run.metrics.memory_utilization * 100.0,
+                tuned_run.score,
+                tuned_run.metrics.latency_p95,
+                tuned_run.metrics.throughput,
+                tuned_run.metrics.memory_utilization * 100.0,
+            )
+
+        if not default_runs or not tuned_runs:
+            raise RuntimeError("All paired runs failed.")
+        if len(default_runs) != len(tuned_runs):
+            raise RuntimeError(
+                "Paired comparison integrity violation: default/tuned lengths differ."
+            )
+
+        LOGGER.info(
+            "➤ Paired execution complete: %d successful pairs / %d requested.",
+            len(default_runs),
+            self.config.repetitions,
+        )
+        return default_runs, tuned_runs
+
+    def _run_single(
+        self,
+        config_type: str,
+        knobs: dict[str, Any],
+        run_number: int,
+        pair_seed: int,
+        order_in_pair: int,
+        session: TuningSessionData,
+        executor: BenchmarkExecutor,
+    ) -> RunResult:
+        """
+        Execute one benchmark repetition in a fresh environment.
+
+        Lifecycle per run:
+        1. Create fresh environment → setup_instances(1, force_recreate=True) \\
+           (this also initializes the schema via the executor/schema_provider)
+        2. Apply tuned knobs if config_type == "tuned"
+        3. Execute benchmark measurement
+        4. Tear down environment (stop + cleanup)
+        """
+        benchmark_name = self.config.benchmark or session.benchmark
+        run_started = time.monotonic()
+        env = self._build_environment(executor, session.worker_resources)
+
+        try:
+            env.setup_instances(num_workers=1, force_recreate=True)
+            active_config = env.get_db_config(worker_id=0)
+
+            if knobs:
+                env.apply_knobs(worker_id=0, knobs=knobs)
+
+            if benchmark_name == "tpch":
+                metrics = executor.execute(
+                    db_config=active_config,
+                    warmup_passes=int(self.config.tpch_warmup_passes or 1),
+                )
+            else:
+                metrics = executor.execute(
+                    db_config=active_config,
+                    duration=int(self.config.sysbench_duration or 60),
+                    warmup=int(self.config.sysbench_warmup_seconds or 30),
+                    random_seed=pair_seed,
+                )
+
+            metrics.memory_utilization = env.collect_memory_utilization(worker_id=0)
+
+            score = _metrics_to_score(metrics, benchmark_name)
+
+            return RunResult(
+                config_type=config_type,
+                run_number=run_number,
+                pair_seed=pair_seed,
+                order_in_pair=order_in_pair,
+                metrics=metrics,
+                score=score,
+                duration_seconds=time.monotonic() - run_started,
+                container_id=env.run_id,
+            )
+        finally:
+            # Always tear down, even on failure
+            try:
+                env.stop_all()
+            except Exception as stop_exc:
+                LOGGER.debug("Error stopping environment: %s", stop_exc)
+            try:
+                env.cleanup(remove_data=True)
+            except Exception as cleanup_exc:
+                LOGGER.debug("Error cleaning up environment: %s", cleanup_exc)
+
+    def _save_result(self, result: ComparisonResult) -> Path:
+        """
+        Serialize the ComparisonResult to JSON and write to disk.
+
+        Output path: ``results/{workload}/comparisons/{tier}/comparison_{timestamp}.json``
+
+        Args:
+            result: The fully populated ComparisonResult.
+
+        Returns:
+            Path to the written file.
+        """
+        output_dir = self._resolve_output_dir(result)
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        output_path = output_dir / f"comparison_{result.timestamp}.json"
+        payload = _serialize_result(result)
+
+        with output_path.open("w", encoding="utf-8") as fh:
+            json.dump(payload, fh, indent=2, default=str)
+
+        LOGGER.info("Results saved to: %s", output_path)
+        return output_path
+
+    def _resolve_output_dir(self, result: ComparisonResult) -> Path:
+        """Determine the output directory, creating it if necessary."""
+        return self._resolve_output_dir_for(result.session_data)
+
+    def _resolve_output_dir_for(
+        self,
+        session_data: TuningSessionData,
+    ) -> Path:
+        """Determine the output directory for this evaluation session."""
+        if self.config.output_dir:
+            return self.config.output_dir
+
+        # Auto-detect workload from session or path
+        workload = session_data.workload_type.lower()
+        if workload not in ("oltp", "olap", "mixed"):
+            workload = "mixed"
+
+        tier = self._resolve_tier_slug_from_session(session_data, self.config.tuning_session_path)
+        return Path("results") / workload / "comparisons" / tier
+
+    def _resolve_log_output_path(self, output_dir: Path, timestamp: str | None = None) -> Path:
+        """Return the HTML log artifact path for this evaluation invocation."""
+        effective_ts = timestamp or self.timestamp
+        return output_dir / "logs" / f"evaluation_{effective_ts}.html"
+
+    def _resolve_tier_slug(self, result: ComparisonResult) -> str:
+        """Infer knob tier slug from a computed result object."""
+        return self._resolve_tier_slug_from_session(
+            result.session_data,
+            result.config.tuning_session_path,
+        )
+
+    def _resolve_tier_slug_from_session(
+        self,
+        session_data: TuningSessionData,
+        session_path: Path,
+    ) -> str:
+        """Infer knob tier slug from session metadata, then from session path."""
+        metadata_tier = _sanitize_tier_name(
+            session_data.tuning_config.get("knob_tier")
+            or session_data.tuning_config.get("tier")
+        )
+        if metadata_tier:
+            return metadata_tier
+
+        parts = session_path.parts
+        try:
+            pbt_runs_idx = parts.index("pbt_runs")
+        except ValueError:
+            return "unknown"
+
+        if pbt_runs_idx + 1 >= len(parts):
+            return "unknown"
+
+        path_tier = _sanitize_tier_name(parts[pbt_runs_idx + 1])
+        return path_tier or "unknown"
+
+    def _print_summary(self, result: ComparisonResult) -> None:
+        """Print a formatted comparison summary table to stdout."""
+        stats = result.statistics
+
+        # Header
+        print("\n" + "═" * 68)
+        print("  EVALUATION SUMMARY")
+        print(f"  Session : {result.config.tuning_session_path.name}")
+        benchmark_name = result.config.benchmark or result.session_data.benchmark
+        print(f"  Benchmark: {benchmark_name.upper()}")
+        print(f"  Reps    : {result.config.repetitions}")
+        print(f"  Env     : {'Docker' if result.config.use_docker else 'bare-metal'}")
+        if benchmark_name == "sysbench":
+            print(
+                "  Params  : "
+                f"tables={result.config.sysbench_tables}, "
+                f"table_size={result.config.sysbench_table_size}, "
+                f"duration={result.config.sysbench_duration}s, "
+                f"warmup={result.config.sysbench_warmup_seconds}s"
+            )
+        else:
+            print(
+                "  Params  : "
+                f"scale_factor={result.config.scale_factor}, "
+                f"warmup_passes={result.config.tpch_warmup_passes}"
+            )
+        print("═" * 68)
+
+        # Per-metric table
+        header = (
+            f"  {'Metric':<18} {'Default':>10} {'Tuned':>10} {'Δ%':>9} "
+            f"{'p (adj)':>9} {'Cohen d':>8} {'Sig':>4}"
+        )
+        print(header)
+        print("  " + "─" * 66)
+
+        for mc in stats.metrics:
+            d_val = mc.default.median
+            t_val = mc.tuned.median
+            imp = mc.improvement_pct
+            star = "✓" if mc.significant else " "
+            print(
+                f"  {mc.metric_name:<18} "
+                f"{d_val:>10.3f} "
+                f"{t_val:>10.3f} "
+                f"{imp:>+9.1f}% "
+                f"{mc.p_value_corrected:>9.4f} "
+                f"{mc.cohens_d:>8.2f} "
+                f"{star:>4}"
+            )
+
+        print("  " + "─" * 66)
+        print(f"\n  Overall improvement : {stats.overall_improvement_pct:+.1f}%")
+        ci_lo, ci_hi = stats.overall_improvement_ci
+        print(f"  Bootstrap 95% CI   : [{ci_lo:+.1f}%, {ci_hi:+.1f}%]")
+        print(f"  Alpha              : {stats.alpha:.4f}")
+        print(f"  Primary endpoint   : {stats.primary_endpoint}")
+        print(f"  Primary significant: {'yes' if stats.primary_significant else 'no'}")
+        print("  Statistical test   : Wilcoxon signed-rank (paired, two-sided)")
+        print(
+            "  Secondary endpoints: "
+            f"{', '.join(stats.secondary_endpoints) or 'none'} "
+            f"({stats.secondary_correction_method} corrected)"
+        )
+        n_pairs = stats.n_pairs
+        print(f"  Paired sample size : N={n_pairs}")
+        if stats.power_warning:
+            print(f"  Power note         : {stats.power_warning}")
+        if result.scoring_metadata:
+            print(
+                "  Rescoring mode     : "
+                f"{result.scoring_metadata.get('mode')} "
+                f"(latency={result.scoring_metadata.get('latency_metric')})"
+            )
+        print(f"  Significant metrics: {', '.join(stats.significant_metrics) or 'none'}")
+        if result.output_path:
+            print(f"\n  Results written to : {result.output_path}")
+        if result.log_path:
+            print(f"  Session log written: {result.log_path}")
+        print("═" * 68 + "\n")
+
+
+def _metrics_to_score(metrics: PerformanceMetrics, benchmark: str) -> float:
+    """
+    Compute a composite score using the same workload-specific metric model
+    used by the tuning loop.
+
+    This keeps evaluation score interpretation aligned with PBT optimization
+    semantics (weights and normalization behavior per workload type).
+    """
+    if metrics.throughput <= 0.0 or metrics.error_rate >= 1.0:
+        return 0.0
+
+    if benchmark == "tpch":
+        metric_config = create_metric_config("olap")
+    elif benchmark == "sysbench":
+        metric_config = create_metric_config("oltp")
+    else:
+        metric_config = create_metric_config("mixed")
+
+    return metric_config.compute_score(metrics)
+
+
+def _extract_pg_major(pg_version_str: str) -> str:
+    """
+    Extract the major PostgreSQL version number from version strings.
+
+    Examples:
+        "PostgreSQL 16.2" → "16"
+        "PostgreSQL 18.3" → "18"
+        "unknown"         → "16"
+    """
+    m = re.search(r"(\d+)\.\d+", pg_version_str)
+    return m.group(1) if m else "16"
+
+
+def _sanitize_tier_name(raw_tier: Any) -> str | None:
+    """Normalize tier names into stable path-safe slugs."""
+    if raw_tier is None:
+        return None
+
+    tier = str(raw_tier).strip().lower()
+    if not tier:
+        return None
+
+    slug = re.sub(r"[^a-z0-9_-]+", "_", tier).strip("_")
+    return slug or None
+
+
+# ---------------------------------------------------------------------------
+# Serialization
+# ---------------------------------------------------------------------------
+
+def _serialize_result(result: ComparisonResult) -> dict[str, Any]:
+    """Convert ComparisonResult to a plain JSON-serialisable dict."""
+
+    def _pkg_version(package_name: str) -> str:
+        try:
+            return importlib_metadata.version(package_name)
+        except importlib_metadata.PackageNotFoundError:
+            return "not-installed"
+
+    def _snap(s: PerformanceMetrics) -> dict[str, Any]:
+        return {
+            "latency_p50": s.latency_p50,
+            "latency_p95": s.latency_p95,
+            "latency_p99": s.latency_p99,
+            "throughput": s.throughput,
+            "error_rate": s.error_rate,
+            "memory_utilization": s.memory_utilization,
+            "total_queries": s.total_queries,
+            "total_time": s.total_time,
+        }
+
+    def _run(r: RunResult) -> dict[str, Any]:
+        return {
+            "config_type": r.config_type,
+            "run_number": r.run_number,
+            "pair_seed": r.pair_seed,
+            "order_in_pair": r.order_in_pair,
+            "score": r.score,
+            "duration_seconds": r.duration_seconds,
+            "container_id": r.container_id,
+            "metrics": _snap(r.metrics),
+        }
+
+    def _stat_sum(s) -> dict[str, Any]:
+        return {
+            "mean": s.mean, "std": s.std,
+            "median": s.median,
+            "iqr_lower": s.iqr_lower, "iqr_upper": s.iqr_upper,
+            "values": s.values,
+        }
+
+    def _metric_cmp(mc) -> dict[str, Any]:
+        return {
+            "metric_name": mc.metric_name,
+            "default": _stat_sum(mc.default),
+            "tuned": _stat_sum(mc.tuned),
+            "improvement_pct": mc.improvement_pct,
+            "improvement_ci": list(mc.improvement_ci),
+            "p_value": mc.p_value,
+            "p_value_corrected": mc.p_value_corrected,
+            "cohens_d": mc.cohens_d,
+            "significant": mc.significant,
+            "higher_is_better": mc.higher_is_better,
+            "endpoint_role": mc.endpoint_role,
+            "correction_method": mc.correction_method,
+        }
+
+    wr = result.session_data.worker_resources
+    cfg = result.config
+    benchmark_name = cfg.benchmark or result.session_data.benchmark
+
+    return {
+        "comparison_metadata": {
+            "timestamp": result.timestamp,
+            "tuning_session_path": str(result.config.tuning_session_path),
+            "evaluation_log_path": str(result.log_path) if result.log_path else None,
+            "benchmark": benchmark_name,
+            "repetitions": cfg.repetitions,
+            "pair_seed_base": cfg.pair_seed,
+            "benchmark_parameters": {
+                "scale_factor": cfg.scale_factor,
+                "sysbench_tables": cfg.sysbench_tables,
+                "sysbench_table_size": cfg.sysbench_table_size,
+                "sysbench_duration": cfg.sysbench_duration,
+                "sysbench_warmup_seconds": cfg.sysbench_warmup_seconds,
+                "tpch_warmup_passes": cfg.tpch_warmup_passes,
+            },
+            "evaluation_environment": "docker" if cfg.use_docker else "bare-metal",
+            "resource_constraints": {
+                "ram_bytes": wr.ram_bytes,
+                "cpu_cores": wr.cpu_cores,
+                "disk_type": wr.disk_type,
+            },
+            "reproducibility": {
+                "python_version": platform.python_version(),
+                "postgres_version": str(result.session_data.system_info.get("pg_version", "unknown")),
+                "docker_image": cfg.docker_image if cfg.use_docker else None,
+                "benchmark_binary_paths": {
+                    "sysbench": shutil.which("sysbench") or "not-found",
+                    "psql": shutil.which("psql") or "not-found",
+                },
+                "python_package_versions": {
+                    "docker": _pkg_version("docker"),
+                    "psycopg2-binary": _pkg_version("psycopg2-binary"),
+                    "numpy": _pkg_version("numpy"),
+                    "scipy": _pkg_version("scipy"),
+                },
+            },
+        },
+        "tuned_knobs": result.tuned_knobs,
+        "default_runs": [_run(r) for r in result.default_runs],
+        "tuned_runs": [_run(r) for r in result.tuned_runs],
+        "statistics": {
+            "metrics": [_metric_cmp(mc) for mc in result.statistics.metrics],
+            "alpha": result.statistics.alpha,
+            "primary_endpoint": result.statistics.primary_endpoint,
+            "primary_significant": result.statistics.primary_significant,
+            "secondary_endpoints": result.statistics.secondary_endpoints,
+            "secondary_correction_method": result.statistics.secondary_correction_method,
+            "correction_method": result.statistics.correction_method,
+            "n_pairs": result.statistics.n_pairs,
+            "power_warning": result.statistics.power_warning,
+            "significant_metrics": result.statistics.significant_metrics,
+            "overall_improvement_pct": result.statistics.overall_improvement_pct,
+            "overall_improvement_ci": list(result.statistics.overall_improvement_ci),
+        },
+        "scoring_metadata": result.scoring_metadata,
+        "session_info": {
+            "session_id": result.session_data.session_id,
+            "workload_type": result.session_data.workload_type,
+            "best_score_during_tuning": result.session_data.best_score,
+        },
+        "system_info": result.session_data.system_info,
+    }

--- a/src/evaluation/statistics.py
+++ b/src/evaluation/statistics.py
@@ -1,0 +1,389 @@
+"""
+Statistical Analysis for Comparative Evaluation
+================================================
+
+Non-parametric statistical framework for comparing default vs tuned
+PostgreSQL configurations across N repeated benchmark runs.
+
+Methodology (justified for small N=5):
+    - Wilcoxon signed-rank test (primary): non-parametric, paired,
+      no normality assumption — appropriate for N ≥ 5.
+    - Bootstrap CI (10,000 resamples): robust confidence intervals on
+      paired median differences without distributional assumptions.
+    - Holm correction for secondary endpoints only: controls family-wise
+      error rate while preserving sensitivity for the primary endpoint.
+    - Paired Cohen's d: standardized effect size so reviewers can judge
+      practical significance, not just statistical significance.
+    - Both mean ± std AND median ± IQR reported for comparability with
+      literature that uses either convention.
+
+References:
+    Demšar, J. (2006). Statistical Comparisons of Classifiers over
+        Multiple Data Sets. JMLR 7, 1–30.
+    Wilcoxon, F. (1945). Individual Comparisons by Ranking Methods.
+        Biometrics Bulletin, 1(6), 80–83.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Callable
+
+import numpy as np
+import scipy.stats as stats
+
+from src.utils.logger import get_logger
+from src.evaluation.types import (
+    ComparisonStatistics,
+    MetricComparison,
+    RunResult,
+    StatSummary,
+)
+
+LOGGER = get_logger(__name__)
+
+_PRIMARY_ENDPOINT = "score"
+_SECONDARY_ENDPOINT_BASE = ("throughput", "memory_utilization")
+
+# Number of bootstrap resamples for CI estimation
+_N_BOOTSTRAP = 10_000
+
+# Family-wise significance level before correction
+_ALPHA = 0.05
+
+
+def compute_comparison_statistics(
+    default_runs: list[RunResult],
+    tuned_runs: list[RunResult],
+    benchmark: str,
+    alpha: float = _ALPHA,
+) -> ComparisonStatistics:
+    """
+    Compute full statistical comparison between default and tuned runs.
+
+    Pairs runs strictly by run_number/pair_seed so each repetition shares
+    identical workload seed and execution protocol. Uses a primary endpoint
+    (score) at alpha, and Holm-corrected secondary endpoints.
+
+    Args:
+        default_runs: RunResult list for the default (untuned) configuration.
+        tuned_runs: RunResult list for the tuned configuration.
+
+    Returns:
+        ComparisonStatistics with per-metric Wilcoxon tests, bootstrap CIs,
+        Cohen's d, a primary endpoint at alpha, and Holm-corrected
+        secondary endpoint significance flags.
+
+    Raises:
+        ValueError: If run lists are empty or have inconsistent run_numbers.
+    """
+    if not default_runs or not tuned_runs:
+        raise ValueError("Both default_runs and tuned_runs must be non-empty.")
+
+    default_sorted = sorted(default_runs, key=lambda r: r.run_number)
+    tuned_sorted = sorted(tuned_runs, key=lambda r: r.run_number)
+
+    if len(default_sorted) != len(tuned_sorted):
+        raise ValueError(
+            "Paired run count mismatch: default and tuned runs must have equal length."
+        )
+
+    default_pair_keys = [(r.run_number, r.pair_seed) for r in default_sorted]
+    tuned_pair_keys = [(r.run_number, r.pair_seed) for r in tuned_sorted]
+    if default_pair_keys != tuned_pair_keys:
+        raise ValueError(
+            "Paired run mismatch: default and tuned run pairs are not aligned."
+        )
+
+    n = len(default_sorted)
+
+    latency_endpoint = "latency_p99" if benchmark == "tpch" else "latency_p95"
+    secondary_endpoints = (latency_endpoint, *_SECONDARY_ENDPOINT_BASE)
+
+    metric_comparisons: list[MetricComparison] = []
+
+    primary_extractor = _build_extractor(_PRIMARY_ENDPOINT)
+    primary_default = [primary_extractor(r) for r in default_sorted]
+    primary_tuned = [primary_extractor(r) for r in tuned_sorted]
+    primary_metric = _compare_metric(
+        metric_name=_PRIMARY_ENDPOINT,
+        default_vals=primary_default,
+        tuned_vals=primary_tuned,
+        higher_is_better=True,
+        endpoint_role="primary",
+        alpha=alpha,
+    )
+    _apply_significance(
+        metrics=[primary_metric],
+        adjusted_p_values=[primary_metric.p_value],
+        alpha=alpha,
+        correction_method=None,
+    )
+    metric_comparisons.append(primary_metric)
+
+    secondary_metrics: list[MetricComparison] = []
+    lower_is_better_metrics = {latency_endpoint, "memory_utilization"}
+    for metric_name in secondary_endpoints:
+        higher_is_better = metric_name not in lower_is_better_metrics
+        extractor = _build_extractor(metric_name)
+        default_vals = [extractor(r) for r in default_sorted]
+        tuned_vals = [extractor(r) for r in tuned_sorted]
+
+        mc = _compare_metric(
+            metric_name=metric_name,
+            default_vals=default_vals,
+            tuned_vals=tuned_vals,
+            higher_is_better=higher_is_better,
+            endpoint_role="secondary",
+            alpha=alpha,
+        )
+        secondary_metrics.append(mc)
+
+    secondary_adjusted = _holm_adjusted_pvalues([mc.p_value for mc in secondary_metrics])
+    _apply_significance(
+        metrics=secondary_metrics,
+        adjusted_p_values=secondary_adjusted,
+        alpha=alpha,
+        correction_method="holm",
+    )
+    metric_comparisons.extend(secondary_metrics)
+
+    for mc in metric_comparisons:
+        LOGGER.debug(
+            "Metric '%s' (%s): improvement=%.1f%% p=%.4f p_adj=%.4f cohen_d=%.2f significant=%s",
+            mc.metric_name,
+            mc.endpoint_role,
+            mc.improvement_pct,
+            mc.p_value,
+            mc.p_value_corrected,
+            mc.cohens_d,
+            mc.significant,
+        )
+
+    significant_metrics = [
+        mc.metric_name for mc in metric_comparisons if mc.significant
+    ]
+
+    power_warning = _build_power_warning(n)
+
+    # Overall improvement uses the score metric
+    score_mc = next(mc for mc in metric_comparisons if mc.metric_name == _PRIMARY_ENDPOINT)
+
+    return ComparisonStatistics(
+        metrics=metric_comparisons,
+        significant_metrics=significant_metrics,
+        overall_improvement_pct=score_mc.improvement_pct,
+        overall_improvement_ci=score_mc.improvement_ci,
+        n_pairs=n,
+        correction_method="holm_secondary",
+        power_warning=power_warning,
+        alpha=alpha,
+        primary_endpoint=_PRIMARY_ENDPOINT,
+        secondary_endpoints=list(secondary_endpoints),
+        primary_significant=score_mc.significant,
+        secondary_correction_method="holm",
+    )
+
+
+def _compare_metric(
+    metric_name: str,
+    default_vals: list[float],
+    tuned_vals: list[float],
+    higher_is_better: bool,
+    endpoint_role: str,
+    alpha: float,
+) -> MetricComparison:
+    """Build a MetricComparison for one metric."""
+    d_arr = np.array(default_vals, dtype=float)
+    t_arr = np.array(tuned_vals, dtype=float)
+
+    if higher_is_better:
+        differences = t_arr - d_arr          # throughput/score: tuned > default = good
+    else:
+        differences = d_arr - t_arr          # latency: default > tuned = good
+
+    p_value = _wilcoxon_p(differences)
+
+    ci_lower, ci_upper = _bootstrap_ci_median(differences)
+
+    baseline_median = float(np.median(d_arr))
+    if baseline_median == 0.0:
+        improvement_pct = 0.0
+    else:
+        improvement_pct = (float(np.median(differences)) / abs(baseline_median)) * 100.0
+
+    # Convert CI from absolute difference to percentage
+    if baseline_median != 0.0:
+        ci_pct = (ci_lower / abs(baseline_median) * 100.0,
+                  ci_upper / abs(baseline_median) * 100.0)
+    else:
+        ci_pct = (0.0, 0.0)
+
+    cohens_d = _paired_cohens_d(differences)
+
+    return MetricComparison(
+        metric_name=metric_name,
+        default=_stat_summary(default_vals),
+        tuned=_stat_summary(tuned_vals),
+        improvement_pct=improvement_pct,
+        improvement_ci=ci_pct,
+        p_value=p_value,
+        p_value_corrected=p_value,
+        cohens_d=cohens_d,
+        significant=p_value < alpha,
+        higher_is_better=higher_is_better,
+        endpoint_role=endpoint_role,
+        correction_method=None,
+    )
+
+
+def _apply_significance(
+    metrics: list[MetricComparison],
+    adjusted_p_values: list[float],
+    alpha: float,
+    correction_method: str | None,
+) -> None:
+    """Apply corrected p-values and significance flags to metric comparisons."""
+    for mc, p_adj in zip(metrics, adjusted_p_values, strict=True):
+        mc.p_value_corrected = p_adj
+        mc.significant = p_adj < alpha
+        mc.correction_method = correction_method
+
+
+def _wilcoxon_p(differences: np.ndarray) -> float:
+    """
+    Wilcoxon signed-rank test p-value (two-sided) on paired differences.
+
+    Falls back to 1.0 if all differences are zero (no effect) or if
+    scipy raises (e.g. n < 5 after zero-tie removal).
+    """
+    nonzero = differences[differences != 0.0]
+    if len(nonzero) == 0:
+        return 1.0  # No difference at all
+    try:
+        _, p = stats.wilcoxon(nonzero, alternative="two-sided", zero_method="wilcox")
+        return float(p)  # type: ignore
+    except ValueError:
+        return 1.0  # scipy requires at least 1 nonzero difference; already checked above
+
+
+def _bootstrap_ci_median(
+    differences: np.ndarray,
+    n_bootstrap: int = _N_BOOTSTRAP,
+    confidence: float = 0.95,
+) -> tuple[float, float]:
+    """
+    Bootstrap 95% confidence interval on the median of paired differences.
+
+    Resamples with replacement from the observed differences, computes
+    the median of each resample, and returns the (alpha/2, 1-alpha/2)
+    percentiles of the bootstrap distribution.
+
+    Args:
+        differences: 1-D array of paired differences (tuned - default or
+            default - tuned for inverse metrics).
+        n_bootstrap: Number of bootstrap resamples (default 10,000).
+        confidence: Confidence level (default 0.95 → 95% CI).
+
+    Returns:
+        (lower_bound, upper_bound) of the CI in the same units as
+        `differences`.
+    """
+    rng = np.random.default_rng(seed=42)  # Fixed seed for reproducibility
+    n = len(differences)
+
+    resamples = rng.choice(differences, size=(n_bootstrap, n), replace=True)
+    bootstrap_medians = np.median(resamples, axis=1)
+
+    alpha = 1.0 - confidence
+    lower = float(np.percentile(bootstrap_medians, alpha / 2 * 100))
+    upper = float(np.percentile(bootstrap_medians, (1 - alpha / 2) * 100))
+    return lower, upper
+
+
+def _paired_cohens_d(differences: np.ndarray) -> float:
+    """
+    Paired Cohen's d = mean(differences) / std(differences).
+
+    Interpreted as: 0.2 = small, 0.5 = medium, 0.8 = large effect.
+    Returns 0.0 when std is zero (perfectly consistent effect).
+    """
+    mean_diff = float(np.mean(differences))
+    std_diff = float(np.std(differences, ddof=1))
+    if std_diff == 0.0:
+        return 0.0 if mean_diff == 0.0 else math.copysign(float("inf"), mean_diff)
+    return mean_diff / std_diff
+
+
+def _stat_summary(values: list[float]) -> StatSummary:
+    """Compute mean, std, median, and IQR for a list of values."""
+    arr = np.array(values, dtype=float)
+    return StatSummary(
+        mean=float(np.mean(arr)),
+        std=float(np.std(arr, ddof=1)) if len(arr) > 1 else 0.0,
+        median=float(np.median(arr)),
+        iqr_lower=float(np.percentile(arr, 25)),
+        iqr_upper=float(np.percentile(arr, 75)),
+        values=list(values),
+    )
+
+
+def _build_extractor(metric_name: str) -> Callable[[RunResult], float]:
+    """Return a function that extracts the named metric from a RunResult."""
+    extractors: dict[str, Callable[[RunResult], float]] = {
+        "score": lambda r: r.score,
+        "latency_p95": lambda r: r.metrics.latency_p95,
+        "latency_p99": lambda r: r.metrics.latency_p99,
+        "throughput": lambda r: r.metrics.throughput,
+        "memory_utilization": lambda r: r.metrics.memory_utilization,
+    }
+    if metric_name not in extractors:
+        raise ValueError(
+            f"Unknown metric '{metric_name}'. "
+            f"Valid options: {sorted(extractors)}"
+        )
+    return extractors[metric_name]
+
+
+def _holm_adjusted_pvalues(p_values: list[float]) -> list[float]:
+    """
+    Compute Holm-adjusted p-values and return them in original metric order.
+
+    Holm step-down controls FWER while being less conservative than Bonferroni.
+    """
+    m = len(p_values)
+    if m == 0:
+        return []
+
+    indexed = sorted(enumerate(p_values), key=lambda item: item[1])
+    adjusted_sorted: list[float] = []
+
+    running_max = 0.0
+    for i, (_, p) in enumerate(indexed):
+        factor = m - i
+        adjusted = min(1.0, p * factor)
+        running_max = max(running_max, adjusted)
+        adjusted_sorted.append(running_max)
+
+    adjusted_original = [1.0] * m
+    for (original_idx, _), p_adj in zip(indexed, adjusted_sorted, strict=True):
+        adjusted_original[original_idx] = p_adj
+
+    return adjusted_original
+
+
+def _build_power_warning(n_pairs: int) -> str | None:
+    """Return a warning message when the paired sample size is low."""
+    if n_pairs >= 8:
+        return None
+    if n_pairs == 5:
+        return (
+            "Low statistical power at N=5: minimum possible two-sided Wilcoxon "
+            "p-value is 0.0625, so p<0.05 cannot be reached even before correction."
+        )
+
+    min_possible_p = min(1.0, 2.0 / (2.0 ** n_pairs))
+    return (
+        f"Low statistical power at N={n_pairs}: minimum possible two-sided "
+        f"Wilcoxon p-value is {min_possible_p:.4f}."
+    )

--- a/src/evaluation/types.py
+++ b/src/evaluation/types.py
@@ -1,0 +1,235 @@
+"""
+Type definitions for the evaluate_tuning module.
+=================================================
+
+All public dataclasses used across the module live here to avoid
+circular imports. Import order: types → exceptions → everything else.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+from src.utils.hardware_info import WorkerResources
+from src.utils.metrics import PerformanceMetrics
+
+
+@dataclass
+class ComparisonConfig:
+    """
+    Full configuration for a comparative benchmark evaluation.
+
+    Attributes:
+        tuning_session_path: Path to the PBT results JSON file.
+        benchmark: Benchmark type — `"sysbench"` or `"tpch"`.
+            `None` (default) to auto-detect from the tuning session.
+        repetitions: Number of independent runs per configuration.
+            Default 5, consistent with OtterTune/CDBTune methodology.
+        scale_factor: TPC-H scale factor.
+            None means resolve from session metadata or benchmark default.
+        sysbench_duration: Sysbench measurement duration in seconds.
+            None means resolve from session metadata or benchmark default.
+        sysbench_tables: Number of sysbench tables.
+            None means resolve from session metadata or benchmark default.
+        sysbench_table_size: Rows per sysbench table.
+            None means resolve from session metadata or benchmark default.
+        sysbench_warmup_seconds: Sysbench warmup duration in seconds.
+            None means resolve from session metadata or benchmark default.
+        tpch_warmup_passes: Number of warmup passes before TPC-H measurement.
+            None means resolve from session metadata or benchmark default.
+        pair_seed: Base deterministic seed used to build run-pair seeds.
+        use_docker: If True (default), use Docker containers for isolation.
+            Falls back to bare-metal when False.
+        docker_image: Name/tag of the Docker image to build and run.
+        output_dir: Override the default output directory. If None, saves
+            comparison JSON to results/{workload}/comparisons/{tier} and
+            HTML logs to results/{workload}/comparisons/{tier}/logs.
+    """
+    tuning_session_path: Path
+    benchmark: Optional[str] = None
+    repetitions: int = 5
+    scale_factor: Optional[float] = None
+    sysbench_duration: Optional[int] = None
+    sysbench_tables: Optional[int] = None
+    sysbench_table_size: Optional[int] = None
+    sysbench_warmup_seconds: Optional[int] = None
+    tpch_warmup_passes: Optional[int] = None
+    pair_seed: int = 50_000
+    use_docker: bool = True
+    docker_image: str = "pbt-eval"
+    output_dir: Optional[Path] = None
+
+
+@dataclass
+class TuningSessionData:
+    """
+    Parsed content of a PBT tuning session results JSON file.
+
+    Attributes:
+        best_knobs: Best discovered knob configuration (name → value).
+        best_score: Composite score of the best configuration.
+        worker_resources: CPU/RAM/disk constraints from the tuning run.
+        system_info: Original hardware information dict.
+        tuning_config: PBT configuration metadata (tier, generations, etc.).
+        benchmark: Benchmark used during tuning ("sysbench" or "tpch").
+        workload_type: Workload type string ("OLTP", "OLAP", or "MIXED").
+        session_id: Timestamp-based session identifier.
+    """
+    best_knobs: dict[str, Any]
+    best_score: float
+    worker_resources: WorkerResources
+    system_info: dict[str, Any]
+    tuning_config: dict[str, Any]
+    benchmark: str
+    workload_type: str
+    session_id: str
+
+
+
+@dataclass
+class RunResult:
+    """
+    Result from a single benchmark run (one repetition, one config type).
+
+    Attributes:
+        config_type: "default" or "tuned".
+        run_number: 1-based repetition index.
+        pair_seed: Deterministic workload seed used by both pair members.
+        order_in_pair: Position in pair execution order (1 or 2).
+        metrics: Raw performance snapshot from this run.
+        score: Composite performance score in [0, 100].
+        duration_seconds: Total wall-clock time for this run including
+            container setup, benchmark, and teardown.
+        container_id: Docker container ID (or "bare-metal").
+    """
+    config_type: str
+    run_number: int
+    pair_seed: int
+    order_in_pair: int
+    metrics: PerformanceMetrics
+    score: float
+    duration_seconds: float
+    container_id: str = "bare-metal"
+
+
+@dataclass
+class StatSummary:
+    """
+    Statistical summary for a collection of scalar measurements.
+
+    Attributes:
+        mean: Arithmetic mean.
+        std: Sample standard deviation.
+        median: Median.
+        iqr_lower: 25th percentile.
+        iqr_upper: 75th percentile.
+        values: Raw values (needed for bootstrap resampling).
+    """
+    mean: float
+    std: float
+    median: float
+    iqr_lower: float
+    iqr_upper: float
+    values: list[float] = field(default_factory=list)
+
+
+@dataclass
+class MetricComparison:
+    """
+    Statistical comparison for a single performance metric.
+
+    Attributes:
+        metric_name: Human-readable name (e.g. "score", "latency_p95_ms").
+        default: Summary statistics for the default configuration.
+        tuned: Summary statistics for the tuned configuration.
+        improvement_pct: Median-based percent improvement.
+            Positive = tuned is better; negative = tuned is worse.
+            For latency, improvement = (default - tuned) / default × 100.
+            For throughput/score, improvement = (tuned - default) / default × 100.
+        improvement_ci: Bootstrap 95% CI on the paired median difference (lower, upper).
+        p_value: Wilcoxon signed-rank test p-value (two-sided, paired).
+        p_value_corrected: Corrected p-value for endpoint family control.
+        cohens_d: Paired Cohen's d effect size.
+        significant: True if the endpoint is statistically significant.
+        higher_is_better: True for throughput/score; False for latency/error_rate.
+        endpoint_role: "primary" or "secondary".
+        correction_method: Name of correction used for this metric (if any).
+    """
+    metric_name: str
+    default: StatSummary
+    tuned: StatSummary
+    improvement_pct: float
+    improvement_ci: tuple[float, float]
+    p_value: float
+    p_value_corrected: float
+    cohens_d: float
+    significant: bool
+    higher_is_better: bool
+    endpoint_role: str = "secondary"
+    correction_method: Optional[str] = None
+
+
+@dataclass
+class ComparisonStatistics:
+    """
+    Full statistical comparison between default and tuned configurations.
+
+    Attributes:
+        metrics: Per-metric statistical comparisons.
+        significant_metrics: Names of metrics that pass significance thresholds.
+        overall_improvement_pct: Score-based overall improvement percentage.
+        overall_improvement_ci: Bootstrap 95% CI on the score improvement.
+        n_pairs: Number of paired runs used in statistical tests.
+        correction_method: Summary name of correction strategy.
+        power_warning: Optional low-power warning for small sample sizes.
+        alpha: Significance level used for primary and secondary tests.
+        primary_endpoint: Primary endpoint name.
+        secondary_endpoints: Secondary endpoint names subject to correction.
+        primary_significant: Whether the primary endpoint is significant.
+        secondary_correction_method: Secondary family correction method.
+    """
+    metrics: list[MetricComparison]
+    significant_metrics: list[str]
+    overall_improvement_pct: float
+    overall_improvement_ci: tuple[float, float]
+    n_pairs: int = 0
+    correction_method: str = "bonferroni"
+    power_warning: Optional[str] = None
+    alpha: float = 0.05
+    primary_endpoint: str = "score"
+    secondary_endpoints: list[str] = field(default_factory=list)
+    primary_significant: bool = False
+    secondary_correction_method: str = "holm"
+
+
+@dataclass
+class ComparisonResult:
+    """
+    Complete output of one comparative benchmark evaluation.
+
+    This is the object serialized to the comparison_{timestamp}.json file.
+
+    Attributes:
+        default_runs: All N repetitions with the default configuration.
+        tuned_runs: All N repetitions with the tuned configuration.
+        tuned_knobs: The knob configuration that was evaluated.
+        statistics: Full non-parametric statistical comparison.
+        config: The ComparisonConfig used to produce this result.
+        session_data: Parsed metadata from the tuning session.
+        timestamp: ISO-8601 timestamp when the comparison was run.
+        output_path: Path where the JSON result was saved.
+        log_path: Path where the HTML session log was saved.
+        scoring_metadata: Rescoring provenance and normalization ranges.
+    """
+    default_runs: list[RunResult]
+    tuned_runs: list[RunResult]
+    tuned_knobs: dict[str, Any]
+    statistics: ComparisonStatistics
+    config: ComparisonConfig
+    session_data: TuningSessionData
+    timestamp: str
+    output_path: Optional[Path] = None
+    log_path: Optional[Path] = None
+    scoring_metadata: Optional[dict[str, Any]] = None

--- a/src/tuner/core/evolution.py
+++ b/src/tuner/core/evolution.py
@@ -405,7 +405,9 @@ def get_population_statistics(workers: List[Worker]) -> dict:
 
 def check_convergence(
     workers: List[Worker],
-    convergence_threshold: float = 0.01
+    convergence_threshold: float = 0.01,
+    dead_config_threshold: float = 0.0,
+    min_valid_workers: int = 2,
 ) -> bool:
     """
     Check if population has converged (all workers similar performance).
@@ -423,11 +425,35 @@ def check_convergence(
     convergence_threshold : float
         Maximum allowed standard deviation for convergence
         Default: 0.01 (very tight convergence)
+
+    dead_config_threshold : float
+        Minimum score considered a healthy, non-dead worker.
+        Workers below this threshold are excluded from convergence checks.
+
+    min_valid_workers : int
+        Minimum number of healthy workers required to evaluate convergence.
+        Convergence is not meaningful with fewer than this count.
         
     Returns
     -------
     bool
         True if converged, False otherwise
     """
-    stats = get_population_statistics(workers)
+    valid_workers = [
+        worker
+        for worker in workers
+        if worker.metrics is not None
+        and worker.metrics.failure_type is None
+        and worker.performance_score >= dead_config_threshold
+    ]
+
+    if len(valid_workers) < min_valid_workers:
+        logger.debug(
+            "Skipping convergence check: %d valid workers (minimum=%d)",
+            len(valid_workers),
+            min_valid_workers,
+        )
+        return False
+
+    stats = get_population_statistics(valid_workers)
     return stats['std'] < convergence_threshold

--- a/src/tuner/core/population.py
+++ b/src/tuner/core/population.py
@@ -518,13 +518,24 @@ class Population:
                 dead_worker.knob_config = selected_config
                 dead_worker.performance_score = 0.0
                 dead_worker.metrics = None
+                dead_worker.force_restart_next_eval = True
 
                 dead_worker.parent_id = None
                 dead_worker.generation_created = self.current_generation + 1
                 config_changed = dead_worker.knob_config != previous_config
 
                 if self.env is not None:
-                    if not self.env.recover_instance(dead_worker.worker_id):
+                    recovered = False
+                    try:
+                        recovered = self.env.recover_instance(dead_worker.worker_id)
+                    except (ConnectionError, RuntimeError, OSError) as exc:
+                        dead_logger.error(
+                            "[DEAD_CONFIG] Fallback resample recovery raised an unexpected error: %s",
+                            exc,
+                            exc_info=True,
+                        )
+
+                    if not recovered:
                         dead_logger.error(
                             "[DEAD_CONFIG] Fallback resample could not recover worker instance"
                         )
@@ -560,9 +571,20 @@ class Population:
             )
 
             dead_worker.clone_from(donor, self.current_generation)
+            dead_worker.force_restart_next_eval = True
 
             if self.env is not None:
-                if not self.env.recover_instance(dead_worker.worker_id):
+                recovered = False
+                try:
+                    recovered = self.env.recover_instance(dead_worker.worker_id)
+                except (ConnectionError, RuntimeError, OSError) as exc:
+                    dead_logger.error(
+                        "[DEAD_CONFIG] Instance recovery raised an unexpected error during immediate rescue: %s",
+                        exc,
+                        exc_info=True,
+                    )
+
+                if not recovered:
                     dead_logger.error(
                         "[DEAD_CONFIG] Instance recovery failed during immediate rescue"
                     )
@@ -724,7 +746,9 @@ class Population:
         if self._ranges_updated:
             converged = check_convergence(
                 self.workers,
-                self.config.convergence_threshold
+                self.config.convergence_threshold,
+                dead_config_threshold=self.config.dead_config_threshold,
+                min_valid_workers=2,
             )
         else:
             logger.debug(
@@ -753,6 +777,13 @@ class Population:
             self.generations_without_improvement += 1
 
         return result
+
+    @staticmethod
+    def _invoke_optional_worker_callback(callback: Any, worker_id: int) -> bool:
+        """Invoke a worker callback only when present and callable."""
+        if not callable(callback):
+            return False
+        return bool(callback(worker_id))
 
     def train_generation(
         self,
@@ -814,8 +845,36 @@ class Population:
 
             try:
                 if self.env:
+                    failed_workers = []
                     for worker in self.workers:
-                        self.env.restore_snapshot(worker.worker_id)
+                        restored = self.env.restore_snapshot(worker.worker_id)
+                        if not restored:
+                            logger.error(
+                                "Snapshot restore failed for worker %d; attempting clean-slate rebuild",
+                                worker.worker_id,
+                            )
+
+                            rebuilt = False
+                            rebuild_fn = getattr(self.env, "rebuild_worker_instance", None)
+                            rebuilt = self._invoke_optional_worker_callback(
+                                rebuild_fn,
+                                worker.worker_id,
+                            )
+                            if not callable(rebuild_fn):
+                                logger.error(
+                                    "Environment does not implement clean-slate rebuild for worker %d",
+                                    worker.worker_id,
+                                )
+
+                            if not rebuilt:
+                                failed_workers.append(worker.worker_id)
+
+                    if failed_workers:
+                        raise RuntimeError(
+                            "Snapshot restore recovery failed for workers: "
+                            f"{failed_workers}"
+                        )
+
                     logger.info("✓ Database snapshots restored successfully")
                 else:
                     logger.warning("Snapshot restoration requested but env not available")
@@ -930,9 +989,19 @@ class Population:
                 )
                 throughput = worker.metrics.throughput
 
+                latency_below_min = latency > 0 and latency < metric_config.latency_min
+                latency_above_max = latency > 0 and latency > metric_config.latency_max
+                throughput_below_min = (
+                    throughput > 0 and throughput < metric_config.throughput_min
+                )
+                throughput_above_max = (
+                    throughput > 0 and throughput > metric_config.throughput_max
+                )
                 exceeds_bounds = (
-                    (latency > 0 and latency < metric_config.latency_min)
-                    or (throughput > 0 and throughput > metric_config.throughput_max)
+                    latency_below_min
+                    or latency_above_max
+                    or throughput_below_min
+                    or throughput_above_max
                 )
                 if exceeds_bounds:
                     clamped_workers.append(worker)
@@ -1037,7 +1106,12 @@ class Population:
             'min_score': stats['min'],
             'best_worker_id': best_worker.worker_id,
             'best_config': best_worker.knob_config.copy(),  # type: ignore
-            'converged': check_convergence(self.workers, self.config.convergence_threshold),
+            'converged': check_convergence(
+                self.workers,
+                self.config.convergence_threshold,
+                dead_config_threshold=self.config.dead_config_threshold,
+                min_valid_workers=2,
+            ),
             'best_overall_score': self.best_overall_score,
             'generations_without_improvement': self.generations_without_improvement,
         }

--- a/src/tuner/core/worker.py
+++ b/src/tuner/core/worker.py
@@ -109,6 +109,11 @@ class Worker:
         Instance-specific database configuration
         Set by instance manager during initialization
         Contains host, port, dbname, user, password for worker's instance
+
+    force_restart_next_eval : bool
+        Whether evaluator should force a PostgreSQL restart on the next
+        configuration application. Used after dead-worker rescue to ensure
+        restart-required knobs are actually activated before benchmarking.
         
     Notes
     -----
@@ -138,6 +143,7 @@ class Worker:
 
     port: Optional[int] = None
     db_config: Optional[DatabaseConfig] = None
+    force_restart_next_eval: bool = False
 
     def __post_init__(self):
         """Initialize worker with random configuration if none provided."""
@@ -325,6 +331,7 @@ class Worker:
         self.performance_score = 0.0
         self.metrics = None
         self.parent_id = None
+        self.force_restart_next_eval = False
 
     def __repr__(self) -> str:
         """Human-readable representation."""
@@ -367,4 +374,5 @@ class Worker:
             'parent_id': self.parent_id,
             'generation_created': self.generation_created,
             'port': self.port,
+            'force_restart_next_eval': self.force_restart_next_eval,
         }

--- a/src/tuner/evaluator/evaluator.py
+++ b/src/tuner/evaluator/evaluator.py
@@ -99,6 +99,9 @@ class EvaluatorConfig:
     vacuum_analyze_timeout_seconds : float
         Per-worker timeout for post-workload VACUUM ANALYZE safety maintenance.
         Prevents generation stalls when maintenance blocks or runs too long.
+    worker_memory_budget_bytes : Optional[int]
+        Per-worker RAM budget used to normalize PostgreSQL RSS into
+        memory_utilization [0, 1]. If None/invalid, falls back to host RAM.
     """
     workload_type: WorkloadType
     metric_config: MetricConfig
@@ -112,6 +115,7 @@ class EvaluatorConfig:
     random_seed: Optional[int] = None
     warmup_passes: int = 0
     vacuum_analyze_timeout_seconds: float = 45.0
+    worker_memory_budget_bytes: Optional[int] = None
 
 
 class WorkloadExecutor:
@@ -846,14 +850,22 @@ class Evaluator:
                 )
 
                 # Only restart every restart_interval generations (batching strategy)
-                should_restart = generation is not None and (generation % restart_interval == 0)
+                should_interval_restart = (
+                    generation is not None and (generation % restart_interval == 0)
+                )
+                should_restart = force_restart or should_interval_restart
 
                 if should_restart:
                     if restart_manager:
-                        worker_logger.info(
-                            "Restarting (generation %d is restart interval)",
-                            generation
-                        )
+                        if force_restart and not should_interval_restart:
+                            worker_logger.info(
+                                "Restarting (forced for config consistency after recovery)"
+                            )
+                        else:
+                            worker_logger.info(
+                                "Restarting (generation %d is restart interval)",
+                                generation
+                            )
                         restart_occurred = self._perform_restart(
                             connection, restart_manager, worker_log_id, worker_id=worker_id
                         )
@@ -1295,24 +1307,47 @@ class Evaluator:
                         except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
                             continue
 
-                    # Memory percentage
+                    # Normalize worker RSS against worker RAM budget when available.
+                    # This avoids dilution from dividing by full host RAM.
                     try:
-                        system_memory = psutil.virtual_memory().total
-                        metrics['memory_utilization'] = total_memory_rss / system_memory
+                        worker_budget = self.config.worker_memory_budget_bytes
+                        denominator = (
+                            float(worker_budget)
+                            if worker_budget is not None and worker_budget > 0
+                            else float(psutil.virtual_memory().total)
+                        )
+                        if denominator <= 0.0:
+                            metrics['memory_utilization'] = 0.0
+                        else:
+                            ratio = total_memory_rss / denominator
+                            metrics['memory_utilization'] = max(0.0, min(1.0, ratio))
+
                         memory_mb = total_memory_rss / (1024 * 1024)
+                        denominator_mb = denominator / (1024 * 1024) if denominator > 0 else 0.0
                         memory_pct = metrics['memory_utilization'] * 100
+                        denominator_label = "worker-budget" if worker_budget and worker_budget > 0 else "host-total"
+
                         if worker_id is not None:
                             worker_logger = get_logger(__name__, worker_id=worker_id)
                             worker_logger.debug(
-                                "Memory: %.1fMB (%.1f%%) across %d processes",
-                                memory_mb, memory_pct, len(postgres_processes)
+                                "Memory: %.1fMB / %.1fMB (%s) => %.1f%% across %d processes",
+                                memory_mb,
+                                denominator_mb,
+                                denominator_label,
+                                memory_pct,
+                                len(postgres_processes),
                             )
                         else:
                             logger.debug(
-                                "Memory: %.1fMB (%.1f%%) across %d processes",
-                                memory_mb, memory_pct, len(postgres_processes)
+                                "Memory: %.1fMB / %.1fMB (%s) => %.1f%% across %d processes",
+                                memory_mb,
+                                denominator_mb,
+                                denominator_label,
+                                memory_pct,
+                                len(postgres_processes),
                             )
-                    except:
+                    except (OSError, ValueError, TypeError) as exc:
+                        logger.debug("Memory denominator resolution failed: %s", exc)
                         metrics['memory_utilization'] = 0.0
 
                 except Exception as e:
@@ -1524,6 +1559,8 @@ class Evaluator:
                     worker_id=worker.worker_id
                 )
 
+                force_restart = worker.force_restart_next_eval
+
                 restart_manager = None
                 if self.config.enable_restart:
                     import copy
@@ -1549,11 +1586,17 @@ class Evaluator:
                     knob_applicator=knob_applicator,
                     restart_manager=restart_manager,
                     worker_log_id=worker_log_id,
-                    force_restart=False,
+                    force_restart=force_restart,
                     generation=generation,
                     restart_interval=self.config.restart_interval,
                     worker_id=worker.worker_id
                 )
+
+                if force_restart and restart_occurred:
+                    worker.force_restart_next_eval = False
+                    worker_logger.debug(
+                        "Cleared forced-restart marker after successful restart"
+                    )
 
                 if restart_occurred:
                     self.disconnect(connection, worker_id=worker.worker_id)

--- a/src/tuner/evaluator/executor.py
+++ b/src/tuner/evaluator/executor.py
@@ -11,6 +11,8 @@ results directly comparable to published academic baselines.
 from abc import ABC, abstractmethod
 from typing import Optional
 
+from psycopg2 import sql
+
 from src.config.database import DatabaseConfig
 from src.utils.metrics import PerformanceMetrics
 
@@ -71,3 +73,39 @@ class BenchmarkExecutor(ABC):
         hand, typically runs for a fixed duration and can benefit from a
         random seed for reproducibility.
         """
+
+    def _drop_existing_public_tables(
+        self,
+        cursor,
+        logger,
+        log_prefix: str = "",
+    ) -> None:
+        """Drop all existing tables in PostgreSQL public schema.
+
+        Args:
+            cursor: Active psycopg2 cursor bound to target database.
+            logger: Logger used for debug diagnostics.
+            log_prefix: Optional benchmark-specific prefix for log messages.
+        """
+        cursor.execute("SELECT tablename FROM pg_tables WHERE schemaname = 'public'")
+        existing_tables = [str(row[0]) for row in cursor.fetchall()]
+        if not existing_tables:
+            return
+
+        if log_prefix:
+            logger.debug(
+                f"{log_prefix} Dropping existing public tables (%d)...",
+                len(existing_tables),
+            )
+        else:
+            logger.debug(
+                "Dropping existing public tables (%d)...",
+                len(existing_tables),
+            )
+
+        for table_name in sorted(existing_tables):
+            cursor.execute(
+                sql.SQL("DROP TABLE IF EXISTS {} CASCADE").format(
+                    sql.Identifier(table_name)
+                )
+            )

--- a/src/utils/rescoring.py
+++ b/src/utils/rescoring.py
@@ -1,0 +1,87 @@
+"""Shared global rescoring utilities.
+
+This module is the single source of truth for post-hoc global rescoring logic
+used across evaluation and analysis packages.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from src.utils.metrics import MetricConfig, PerformanceMetrics, create_metric_config
+
+
+def workload_for_benchmark(benchmark: str) -> str:
+    """Map benchmark names to metric workload configuration keys."""
+    if benchmark == "tpch":
+        return "olap"
+    if benchmark == "sysbench":
+        return "oltp"
+    return "mixed"
+
+
+def _count_valid_observations(
+    metrics: list[PerformanceMetrics],
+    latency_attr: str,
+) -> tuple[int, int]:
+    """Count valid latency and throughput observations for range calibration."""
+    valid_latency = sum(1 for m in metrics if getattr(m, latency_attr) > 0.0)
+    valid_throughput = sum(1 for m in metrics if m.throughput > 0.0)
+    return valid_latency, valid_throughput
+
+
+def rescore_metrics_globally(
+    metrics: list[PerformanceMetrics],
+    *,
+    benchmark: str | None = None,
+    workload: str | None = None,
+    padding_factor: float = 0.0,
+) -> tuple[MetricConfig, list[float], dict[str, Any]]:
+    """
+    Recompute scores using one globally calibrated normalization range.
+
+    Args:
+        metrics: Flat metric observations to rescore.
+        benchmark: Optional benchmark identifier (sysbench/tpch/mixed).
+        workload: Optional workload identifier (oltp/olap/mixed).
+        padding_factor: Extra range padding factor for normalization.
+
+    Returns:
+        Tuple of (calibrated_metric_config, rescored_values, metadata).
+
+    Raises:
+        ValueError: If neither workload nor benchmark is provided.
+    """
+    if workload is None:
+        if benchmark is None:
+            raise ValueError("Either 'workload' or 'benchmark' must be provided.")
+        workload = workload_for_benchmark(benchmark)
+
+    metric_config = create_metric_config(workload)
+    latency_metric_name = metric_config.latency_metric
+    latency_attr = f"latency_{latency_metric_name}"
+
+    valid_latency, valid_throughput = _count_valid_observations(metrics, latency_attr)
+    ranges_calibrated = valid_latency >= 3 and valid_throughput >= 3
+
+    if ranges_calibrated:
+        metric_config.update_ranges(metrics, padding_factor=padding_factor)
+
+    scores = [metric_config.compute_score(m) for m in metrics]
+    metadata = {
+        "mode": "global_posthoc",
+        "workload": workload,
+        "benchmark": benchmark,
+        "padding_factor": padding_factor,
+        "latency_metric": latency_metric_name,
+        "ranges_calibrated": ranges_calibrated,
+        "n_observations": len(metrics),
+        "n_valid_latency": valid_latency,
+        "n_valid_throughput": valid_throughput,
+        "latency_min": metric_config.latency_min,
+        "latency_max": metric_config.latency_max,
+        "throughput_min": metric_config.throughput_min,
+        "throughput_max": metric_config.throughput_max,
+    }
+
+    return metric_config, scores, metadata

--- a/test-docker.yml
+++ b/test-docker.yml
@@ -1,6 +1,0 @@
-services:
-  test:
-    image: docker:latest
-    command: docker info
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock

--- a/tests/unit/benchmarks/test_sysbench_executor_validation.py
+++ b/tests/unit/benchmarks/test_sysbench_executor_validation.py
@@ -1,0 +1,184 @@
+"""Unit tests for strict Sysbench schema-profile validation."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from src.benchmarks.sysbench.executor import SysbenchExecutor
+from src.config.database import DatabaseConfig
+
+
+class _FakeCursor:
+    """Cursor stub for deterministic validate() query responses."""
+
+    def __init__(self, table_names: list[str], max_id: int | None, row_count: int | None):
+        self._table_names = table_names
+        self._max_id = max_id
+        self._row_count = row_count
+        self._last_query = ""
+        self.closed = False
+
+    def execute(self, query: object) -> None:
+        self._last_query = str(query)
+
+    def fetchall(self) -> list[tuple[str]]:
+        if "information_schema.tables" not in self._last_query:
+            raise AssertionError("fetchall() called for unexpected query")
+        return [(table_name,) for table_name in self._table_names]
+
+    def fetchone(self) -> tuple[int | None]:
+        if "SELECT max(id) FROM sbtest1" in self._last_query:
+            return (self._max_id,)
+        if "SELECT count(*) FROM sbtest1" in self._last_query:
+            return (self._row_count,)
+        raise AssertionError("fetchone() called for unexpected query")
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _FakeConnection:
+    """Connection stub for deterministic validate() flow."""
+
+    def __init__(self, cursor: _FakeCursor):
+        self._cursor = cursor
+        self.closed = False
+
+    def cursor(self) -> _FakeCursor:
+        return self._cursor
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _PrepareCursorStub:
+    """Cursor stub for deterministic prepare() schema-cleanup behavior."""
+
+    def __init__(self, table_names: list[str] | None = None) -> None:
+        self._table_names = table_names or []
+        self._last_query = ""
+        self.executed: list[str] = []
+        self.closed = False
+
+    def execute(self, query: object) -> None:
+        text = str(query)
+        self._last_query = text
+        self.executed.append(text)
+
+    def fetchall(self) -> list[tuple[str]]:
+        if "pg_tables" not in self._last_query:
+            raise AssertionError("fetchall() called for unexpected query")
+        return [(table_name,) for table_name in self._table_names]
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _PrepareConnectionStub:
+    """Connection stub for deterministic prepare() flow."""
+
+    def __init__(self, cursor: _PrepareCursorStub) -> None:
+        self._cursor = cursor
+        self.autocommit = False
+        self.closed = False
+
+    def cursor(self) -> _PrepareCursorStub:
+        return self._cursor
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _make_db_config() -> DatabaseConfig:
+    return DatabaseConfig(
+        user="postgres",
+        password="postgres",
+        host="127.0.0.1",
+        port=5440,
+        dbname="test_dataset",
+    )
+
+
+def test_validate_accepts_exact_table_set_and_row_count() -> None:
+    """Validation should pass only when schema matches configured profile shape."""
+    cursor = _FakeCursor(table_names=["sbtest1", "sbtest2"], max_id=25000, row_count=10200)
+    conn = _FakeConnection(cursor)
+    executor = SysbenchExecutor(tables=2, table_size=10_000)
+
+    with (
+        patch("src.benchmarks.sysbench.executor.get_connection", return_value=conn),
+        patch("src.benchmarks.sysbench.executor.get_logger", return_value=MagicMock()),
+    ):
+        assert executor.validate(_make_db_config()) is True
+
+    assert cursor.closed is True
+    assert conn.closed is True
+
+
+def test_validate_rejects_extra_tables_from_previous_profile() -> None:
+    """Rapid profile should reject leftover standard schema (10 tables instead of 2)."""
+    table_names = [f"sbtest{i}" for i in range(1, 11)]
+    cursor = _FakeCursor(table_names=table_names, max_id=100000, row_count=100000)
+    conn = _FakeConnection(cursor)
+    executor = SysbenchExecutor(tables=2, table_size=10_000)
+
+    with (
+        patch("src.benchmarks.sysbench.executor.get_connection", return_value=conn),
+        patch("src.benchmarks.sysbench.executor.get_logger", return_value=MagicMock()),
+    ):
+        assert executor.validate(_make_db_config()) is False
+
+
+def test_validate_rejects_row_cardinality_mismatch() -> None:
+    """Validation should fail when row cardinality does not match table_size contract."""
+    cursor = _FakeCursor(table_names=["sbtest1", "sbtest2"], max_id=250000, row_count=100000)
+    conn = _FakeConnection(cursor)
+    executor = SysbenchExecutor(tables=2, table_size=10_000)
+
+    with (
+        patch("src.benchmarks.sysbench.executor.get_connection", return_value=conn),
+        patch("src.benchmarks.sysbench.executor.get_logger", return_value=MagicMock()),
+    ):
+        assert executor.validate(_make_db_config()) is False
+
+
+def test_prepare_drops_tpch_leftovers_before_sysbench_prepare() -> None:
+    """TPC-H tables should be removed before sysbench prepare to avoid contamination."""
+    executor = SysbenchExecutor(tables=2, table_size=10_000)
+    logger = MagicMock()
+
+    cleanup_cursor = _PrepareCursorStub(table_names=["lineitem", "orders", "_tpch_metadata"])
+    cleanup_conn = _PrepareConnectionStub(cleanup_cursor)
+    vacuum_cursor = _PrepareCursorStub()
+    vacuum_conn = _PrepareConnectionStub(vacuum_cursor)
+
+    with (
+        patch(
+            "src.benchmarks.sysbench.executor.get_connection",
+            side_effect=[cleanup_conn, vacuum_conn],
+        ),
+        patch("src.benchmarks.sysbench.executor.get_logger", return_value=logger),
+        patch("src.benchmarks.sysbench.executor.subprocess.run") as run_mock,
+    ):
+        executor.prepare(_make_db_config())
+
+    assert "SELECT tablename FROM pg_tables" in cleanup_cursor.executed[0]
+    drop_statements = cleanup_cursor.executed[1:]
+    assert len(drop_statements) == 3
+    assert any("lineitem" in statement for statement in drop_statements)
+    assert any("orders" in statement for statement in drop_statements)
+    assert any("_tpch_metadata" in statement for statement in drop_statements)
+
+    assert run_mock.call_count == 2
+    cleanup_call = run_mock.call_args_list[0]
+    prepare_call = run_mock.call_args_list[1]
+    assert cleanup_call.args[0][-1] == "cleanup"
+    assert prepare_call.args[0][-1] == "prepare"
+
+    assert "VACUUM ANALYZE sbtest1" in vacuum_cursor.executed
+    assert "VACUUM ANALYZE sbtest2" in vacuum_cursor.executed
+
+    assert cleanup_cursor.closed is True
+    assert cleanup_conn.closed is True
+    assert vacuum_cursor.closed is True
+    assert vacuum_conn.closed is True

--- a/tests/unit/benchmarks/test_tpch_executor_schema_cleanup.py
+++ b/tests/unit/benchmarks/test_tpch_executor_schema_cleanup.py
@@ -1,0 +1,54 @@
+"""Unit tests for TPC-H schema cleanup safeguards."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from src.benchmarks.tpch.executor import TPCHExecutor
+
+
+class _CursorStub:
+    """Cursor stub for validating DROP behavior in schema cleanup."""
+
+    def __init__(self, table_names: list[str]) -> None:
+        self._table_names = table_names
+        self.executed: list[tuple[object, tuple[object, ...]]] = []
+
+    def execute(self, query: object, *params: object) -> None:
+        self.executed.append((query, params))
+
+    def fetchall(self) -> list[tuple[str]]:
+        return [(table_name,) for table_name in self._table_names]
+
+
+def test_drop_existing_public_tables_removes_foreign_workload_tables() -> None:
+    """TPC-H cleanup should remove leftover Sysbench/public tables before load."""
+    executor = TPCHExecutor(scale_factor=0.1)
+    logger = MagicMock()
+    cursor = _CursorStub(["sbtest1", "lineitem", "_tpch_metadata"])
+
+    executor._drop_existing_public_tables(cursor, logger)
+
+    assert len(cursor.executed) == 4
+    assert "SELECT tablename FROM pg_tables" in str(cursor.executed[0][0])
+
+    drop_statements = [str(query) for query, _ in cursor.executed[1:]]
+    assert any("sbtest1" in statement for statement in drop_statements)
+    assert any("lineitem" in statement for statement in drop_statements)
+    assert any("_tpch_metadata" in statement for statement in drop_statements)
+    logger.debug.assert_called_once_with(
+        "[TPC-H] Dropping existing public tables (%d)...",
+        3,
+    )
+
+
+def test_drop_existing_public_tables_noop_when_schema_is_empty() -> None:
+    """Cleanup should be a no-op when public schema has no tables."""
+    executor = TPCHExecutor(scale_factor=0.1)
+    logger = MagicMock()
+    cursor = _CursorStub([])
+
+    executor._drop_existing_public_tables(cursor, logger)
+
+    assert len(cursor.executed) == 1
+    logger.debug.assert_not_called()

--- a/tests/unit/core/test_dead_rescue_convergence_and_restart.py
+++ b/tests/unit/core/test_dead_rescue_convergence_and_restart.py
@@ -1,0 +1,291 @@
+"""Regression tests for dead-worker rescue convergence and restart guards."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.config.database import DatabaseConfig
+from src.tuner.core.population import Population, PopulationConfig
+from src.tuner.core.worker import Worker
+from src.tuner.evaluator.evaluator import Evaluator, EvaluatorConfig
+from src.tuner.evaluator.executor import BenchmarkExecutor
+from src.utils.applicator import ApplicationResult
+from src.utils.metrics import MetricConfig, PerformanceMetrics, WorkloadType
+
+
+class _ClosedConnection:
+    """Connection stub that appears closed to skip stats sampling."""
+
+    closed = True
+
+    def close(self) -> None:
+        return
+
+
+class _HealthyBenchmarkExecutor(BenchmarkExecutor):
+    """Benchmark executor stub that always returns valid metrics."""
+
+    def prepare(self, db_config: DatabaseConfig) -> None:
+        return
+
+    def validate(self, db_config: DatabaseConfig) -> bool:
+        return True
+
+    def execute(
+        self,
+        db_config: DatabaseConfig,
+        worker_id: int | None = None,
+        **kwargs,
+    ) -> PerformanceMetrics:
+        return PerformanceMetrics(
+            latency_p95=10.0,
+            throughput=1000.0,
+            total_queries=100,
+            total_time=1.0,
+        )
+
+
+def _make_evaluator(executor: BenchmarkExecutor) -> Evaluator:
+    db_config = DatabaseConfig(
+        user="postgres",
+        password="postgres",
+        host="127.0.0.1",
+        port=5440,
+        dbname="test_dataset",
+    )
+    config = EvaluatorConfig(
+        workload_type=WorkloadType.OLTP,
+        metric_config=MetricConfig.for_oltp(),
+        db_config=db_config,
+    )
+    return Evaluator(config=config, workload_executor=executor)
+
+
+def _make_worker() -> Worker:
+    worker = Worker(worker_id=0, knob_space=MagicMock(), knob_config={"shared_buffers": "256MB"})
+    worker.db_config = DatabaseConfig(
+        user="postgres",
+        password="postgres",
+        host="127.0.0.1",
+        port=5440,
+        dbname="test_dataset",
+    )
+    worker.port = 5440
+    return worker
+
+
+def test_record_generation_not_converged_after_all_dead_resample() -> None:
+    """All-dead rescue/resample generations should never be marked as converged."""
+    knob_space = MagicMock()
+    knob_space.sample_diverse_configs.return_value = [
+        {"shared_buffers": "64MB"},
+        {"shared_buffers": "96MB"},
+        {"shared_buffers": "128MB"},
+        {"shared_buffers": "160MB"},
+        {"shared_buffers": "192MB"},
+    ]
+    knob_space.sample_random_config.return_value = {"shared_buffers": "224MB"}
+    knob_space.perturb_config.return_value = {"shared_buffers": "256MB"}
+
+    population = Population(
+        knob_space=knob_space,
+        config=PopulationConfig(population_size=3, dead_config_threshold=1.0),
+    )
+
+    population.workers = [
+        Worker(worker_id=idx, knob_space=MagicMock(), knob_config={"shared_buffers": "32MB"})
+        for idx in range(3)
+    ]
+
+    for worker in population.workers:
+        worker.metrics = PerformanceMetrics(failure_type="crash_dead")
+        worker.performance_score = -1.0
+
+    population.env = MagicMock()
+    population.env.recover_instance.return_value = True
+
+    rescued = population.rescue_dead_workers(lambda _w: (PerformanceMetrics(), 0.0))
+
+    assert rescued == 3
+    assert all(worker.force_restart_next_eval for worker in population.workers)
+    assert all(worker.metrics is None for worker in population.workers)
+
+    setattr(population, "_ranges_updated", True)
+    result = population.record_generation()
+
+    assert result.converged is False
+    assert population.should_stop() is False
+
+
+def test_apply_configuration_force_restart_overrides_interval_deferral() -> None:
+    """Forced restart must execute even when restart interval would defer it."""
+    evaluator = _make_evaluator(_HealthyBenchmarkExecutor())
+    connection = MagicMock()
+    knob_applicator = MagicMock()
+    knob_applicator.apply.return_value = ApplicationResult(
+        success=True,
+        applied_count=1,
+        restart_required={"shared_buffers"},
+    )
+    restart_manager = MagicMock()
+
+    with patch.object(evaluator, "_perform_restart", return_value=True) as restart_mock:
+        restart_occurred = evaluator.apply_configuration(
+            connection=connection,
+            knob_config={"shared_buffers": "256MB"},
+            knob_applicator=knob_applicator,
+            restart_manager=restart_manager,
+            worker_log_id="Worker-0",
+            force_restart=True,
+            generation=3,
+            restart_interval=10,
+            worker_id=0,
+        )
+
+    assert restart_occurred is True
+    restart_mock.assert_called_once()
+
+
+def test_evaluate_worker_consumes_force_restart_marker() -> None:
+    """Evaluator should forward and clear force-restart marker after successful restart."""
+    evaluator = _make_evaluator(_HealthyBenchmarkExecutor())
+    worker = _make_worker()
+    worker.force_restart_next_eval = True
+
+    with (
+        patch.object(evaluator, "connect", return_value=_ClosedConnection()),
+        patch.object(evaluator, "apply_configuration", return_value=True) as apply_mock,
+        patch.object(
+            evaluator,
+            "collect_system_metrics",
+            return_value={"cache_hit_ratio": 0.0, "memory_utilization": 0.0},
+        ),
+        patch.object(evaluator, "_vacuum_after_dml", return_value=None),
+    ):
+        _metrics, _score, restart_occurred = evaluator.evaluate_worker(
+            worker,
+            apply_config=True,
+            generation=4,
+        )
+
+    assert restart_occurred is True
+    assert apply_mock.call_args.kwargs["force_restart"] is True
+    assert worker.force_restart_next_eval is False
+
+
+def test_train_generation_rebuilds_worker_when_snapshot_restore_fails() -> None:
+    """Generation should attempt clean-slate rebuild when snapshot restore fails."""
+    knob_space = MagicMock()
+    population = Population(
+        knob_space=knob_space,
+        config=PopulationConfig(population_size=2),
+    )
+    population.workers = [
+        Worker(worker_id=0, knob_space=MagicMock()),
+        Worker(worker_id=1, knob_space=MagicMock()),
+    ]
+    population.enable_snapshots = True
+    population.restore_interval = 5
+    population.current_generation = 5
+    population.env = MagicMock()
+    population.env.restore_snapshot.side_effect = [True, False]
+    population.env.rebuild_worker_instance.return_value = True
+    population.evaluate_generation = MagicMock()
+    population.rescue_dead_workers = MagicMock(return_value=0)
+    population.update_metric_ranges_if_needed = MagicMock()
+    population._check_and_handle_saturation = MagicMock()
+    population.exploit_and_explore = MagicMock(return_value=0)
+    population.record_generation = MagicMock(
+        return_value=MagicMock(
+            generation=5,
+            best_score=0.0,
+            mean_score=0.0,
+            std_score=0.0,
+            converged=False,
+            num_exploited=0,
+        )
+    )
+
+    population.train_generation(
+        lambda _w: (PerformanceMetrics(), 0.0),
+        parallel=False,
+    )
+
+    population.env.rebuild_worker_instance.assert_called_once_with(1)
+    population.evaluate_generation.assert_called_once()
+
+
+def test_train_generation_raises_when_snapshot_restore_and_rebuild_fail() -> None:
+    """Generation should abort only if both restore and rebuild fail for a worker."""
+    knob_space = MagicMock()
+    population = Population(
+        knob_space=knob_space,
+        config=PopulationConfig(population_size=2),
+    )
+    population.workers = [
+        Worker(worker_id=0, knob_space=MagicMock()),
+        Worker(worker_id=1, knob_space=MagicMock()),
+    ]
+    population.enable_snapshots = True
+    population.restore_interval = 5
+    population.current_generation = 5
+    population.env = MagicMock()
+    population.env.restore_snapshot.side_effect = [True, False]
+    population.env.rebuild_worker_instance.return_value = False
+    population.evaluate_generation = MagicMock()
+
+    with pytest.raises(RuntimeError, match="Snapshot restore recovery failed"):
+        population.train_generation(
+            lambda _w: (PerformanceMetrics(), 0.0),
+            parallel=False,
+        )
+
+    population.evaluate_generation.assert_not_called()
+
+
+def test_saturation_detection_expands_ranges_for_high_latency_low_throughput() -> None:
+    """Out-of-bounds in the opposite direction should also trigger expansion."""
+    knob_space = MagicMock()
+    population = Population(
+        knob_space=knob_space,
+        config=PopulationConfig(population_size=2, dead_config_threshold=6.0),
+    )
+
+    metric_config = MetricConfig.for_oltp()
+    metric_config.latency_min = 80.0
+    metric_config.latency_max = 160.0
+    metric_config.throughput_min = 100.0
+    metric_config.throughput_max = 200.0
+
+    population.evaluator = MagicMock()
+    population.evaluator.config.metric_config = metric_config
+    setattr(population, "_ranges_updated", True)
+    population.current_generation = 5
+
+    workers = []
+    worker_points = [(240.0, 70.0, 0.12), (230.0, 75.0, 0.13)]
+    for worker_id, (latency, throughput, memory) in enumerate(worker_points):
+        worker = Worker(worker_id=worker_id, knob_space=MagicMock(), knob_config={})
+        worker.metrics = PerformanceMetrics(
+            latency_p95=latency,
+            throughput=throughput,
+            memory_utilization=memory,
+            error_rate=0.0,
+        )
+        worker.performance_score = 9.0 + worker_id
+        workers.append(worker)
+
+    population.workers = workers
+    population.best_overall_metrics = workers[0].metrics
+    population.best_overall_score = workers[0].performance_score
+
+    old_latency_max = metric_config.latency_max
+    old_throughput_min = metric_config.throughput_min
+
+    saturation_check = getattr(population, "_check_and_handle_saturation")
+    saturation_check(lambda _w: (PerformanceMetrics(), 0.0))
+
+    assert metric_config.latency_max > old_latency_max
+    assert metric_config.throughput_min < old_throughput_min

--- a/tests/unit/core/test_evaluator_fault_injection.py
+++ b/tests/unit/core/test_evaluator_fault_injection.py
@@ -1,0 +1,124 @@
+"""Fault-injection tests for evaluator benchmark failure and readiness repair paths."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.config.database import DatabaseConfig
+from src.tuner.core.worker import Worker
+from src.tuner.evaluator.evaluator import Evaluator, EvaluatorConfig
+from src.tuner.evaluator.executor import BenchmarkExecutor
+from src.utils.metrics import MetricConfig, PerformanceMetrics, WorkloadType
+
+
+class _ClosedConnection:
+    """Connection stub that appears closed to skip stats sampling."""
+
+    closed = True
+
+    def close(self) -> None:
+        return
+
+
+class _FailingBenchmarkExecutor(BenchmarkExecutor):
+    """Benchmark executor that fails during execution."""
+
+    def prepare(self, db_config: DatabaseConfig) -> None:
+        return
+
+    def validate(self, db_config: DatabaseConfig) -> bool:
+        return True
+
+    def execute(
+        self,
+        db_config: DatabaseConfig,
+        worker_id: int | None = None,
+        **kwargs,
+    ) -> PerformanceMetrics:
+        raise RuntimeError("injected benchmark failure")
+
+
+class _InvalidBenchmarkExecutor(BenchmarkExecutor):
+    """Benchmark executor that remains invalid even after prepare()."""
+
+    def __init__(self) -> None:
+        self.prepare_called = False
+
+    def prepare(self, db_config: DatabaseConfig) -> None:
+        self.prepare_called = True
+
+    def validate(self, db_config: DatabaseConfig) -> bool:
+        return False
+
+    def execute(
+        self,
+        db_config: DatabaseConfig,
+        worker_id: int | None = None,
+        **kwargs,
+    ) -> PerformanceMetrics:
+        return PerformanceMetrics()
+
+
+def _make_evaluator(executor: BenchmarkExecutor) -> Evaluator:
+    db_config = DatabaseConfig(
+        user="postgres",
+        password="postgres",
+        host="127.0.0.1",
+        port=5440,
+        dbname="test_dataset",
+    )
+    config = EvaluatorConfig(
+        workload_type=WorkloadType.OLTP,
+        metric_config=MetricConfig.for_oltp(),
+        db_config=db_config,
+    )
+    return Evaluator(config=config, workload_executor=executor)
+
+
+def _make_worker() -> Worker:
+    worker = Worker(worker_id=0, knob_space=MagicMock(), knob_config={})
+    worker.db_config = DatabaseConfig(
+        user="postgres",
+        password="postgres",
+        host="127.0.0.1",
+        port=5440,
+        dbname="test_dataset",
+    )
+    worker.port = 5440
+    return worker
+
+
+def test_evaluate_worker_raises_on_benchmark_execution_failure() -> None:
+    """Injected benchmark execution failures should propagate as RuntimeError."""
+    evaluator = _make_evaluator(_FailingBenchmarkExecutor())
+    worker = _make_worker()
+
+    with (
+        patch.object(evaluator, "connect", return_value=_ClosedConnection()),
+        patch.object(evaluator, "collect_system_metrics", return_value={}),
+        patch.object(evaluator, "_vacuum_after_dml", return_value=None),
+    ):
+        with pytest.raises(RuntimeError, match="Workload execution failed"):
+            evaluator.evaluate_worker(worker, apply_config=False, generation=3)
+
+
+def test_ensure_benchmark_ready_raises_if_schema_still_invalid() -> None:
+    """Benchmark readiness repair should fail fast when validate() never passes."""
+    executor = _InvalidBenchmarkExecutor()
+    evaluator = _make_evaluator(executor)
+
+    with pytest.raises(RuntimeError, match="Benchmark validation still failing"):
+        evaluator._ensure_benchmark_ready(
+            db_config=DatabaseConfig(
+                user="postgres",
+                password="postgres",
+                host="127.0.0.1",
+                port=5440,
+                dbname="test_dataset",
+            ),
+            worker_logger=MagicMock(),
+        )
+
+    assert executor.prepare_called is True

--- a/tests/unit/core/test_evaluator_memory_normalization.py
+++ b/tests/unit/core/test_evaluator_memory_normalization.py
@@ -1,0 +1,107 @@
+"""Tests for worker-scoped memory normalization in evaluator system metrics."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.config.database import DatabaseConfig
+from src.tuner.evaluator.evaluator import Evaluator, EvaluatorConfig
+from src.utils.metrics import MetricConfig, WorkloadType
+
+
+class _StubCursor:
+    """Cursor stub returning a fixed cache-hit ratio."""
+
+    def __init__(self, cache_hit_ratio: float) -> None:
+        self._cache_hit_ratio = cache_hit_ratio
+
+    def execute(self, _query: str) -> None:
+        return None
+
+    def fetchone(self) -> tuple[float]:
+        return (self._cache_hit_ratio,)
+
+    def close(self) -> None:
+        return None
+
+
+class _StubConnection:
+    """Connection stub used by collect_system_metrics."""
+
+    closed = False
+
+    def __init__(self, cache_hit_ratio: float = 0.0) -> None:
+        self._cache_hit_ratio = cache_hit_ratio
+
+    def cursor(self) -> _StubCursor:
+        return _StubCursor(cache_hit_ratio=self._cache_hit_ratio)
+
+
+class _StubProcess:
+    """psutil.Process stand-in exposing only memory_info()."""
+
+    def __init__(self, rss_bytes: int) -> None:
+        self._rss_bytes = rss_bytes
+
+    def memory_info(self) -> SimpleNamespace:
+        return SimpleNamespace(rss=self._rss_bytes)
+
+
+def _make_evaluator(worker_memory_budget_bytes: int | None) -> Evaluator:
+    db_config = DatabaseConfig(
+        user="postgres",
+        password="postgres",
+        host="127.0.0.1",
+        port=5440,
+        dbname="test_dataset",
+    )
+    config = EvaluatorConfig(
+        workload_type=WorkloadType.OLTP,
+        metric_config=MetricConfig.for_oltp(),
+        db_config=db_config,
+        worker_memory_budget_bytes=worker_memory_budget_bytes,
+    )
+    return Evaluator(config=config, workload_executor=MagicMock())
+
+
+def test_collect_system_metrics_uses_worker_memory_budget_denominator() -> None:
+    """When configured, evaluator should normalize memory by worker RAM budget."""
+    evaluator = _make_evaluator(worker_memory_budget_bytes=4 * 1024)
+    connection = _StubConnection(cache_hit_ratio=0.87)
+
+    postgres_processes = [_StubProcess(1024), _StubProcess(1024)]
+    with (
+        patch.object(evaluator, "_get_postmaster_pid", return_value=999),
+        patch.object(evaluator, "_get_all_postgres_processes", return_value=postgres_processes),
+        patch(
+            "src.tuner.evaluator.evaluator.psutil.virtual_memory",
+            return_value=SimpleNamespace(total=8 * 1024),
+        ),
+    ):
+        metrics = evaluator.collect_system_metrics(connection, port=5440, worker_id=0)
+
+    assert metrics["memory_utilization"] == pytest.approx(0.5)
+    assert metrics["cache_hit_ratio"] == pytest.approx(0.87)
+
+
+def test_collect_system_metrics_falls_back_to_host_denominator_without_budget() -> None:
+    """Without worker budget, evaluator should preserve host-total fallback behavior."""
+    evaluator = _make_evaluator(worker_memory_budget_bytes=None)
+    connection = _StubConnection(cache_hit_ratio=0.92)
+
+    postgres_processes = [_StubProcess(1024), _StubProcess(1024)]
+    with (
+        patch.object(evaluator, "_get_postmaster_pid", return_value=999),
+        patch.object(evaluator, "_get_all_postgres_processes", return_value=postgres_processes),
+        patch(
+            "src.tuner.evaluator.evaluator.psutil.virtual_memory",
+            return_value=SimpleNamespace(total=8 * 1024),
+        ),
+    ):
+        metrics = evaluator.collect_system_metrics(connection, port=5440, worker_id=0)
+
+    assert metrics["memory_utilization"] == pytest.approx(0.25)
+    assert metrics["cache_hit_ratio"] == pytest.approx(0.92)

--- a/tests/unit/evaluation/conftest.py
+++ b/tests/unit/evaluation/conftest.py
@@ -1,0 +1,149 @@
+"""
+Shared fixtures for evaluate_tuning unit tests.
+
+Uses in-memory fakes so no Docker, PostgreSQL, or filesystem
+access is needed during unit testing.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.utils.metrics import PerformanceMetrics
+from src.evaluation.types import (
+    RunResult,
+    WorkerResources,
+)
+
+
+# ---------------------------------------------------------------------------
+# Sample tuning session JSON (matches real file structure)
+# ---------------------------------------------------------------------------
+
+SAMPLE_SESSION: dict = {
+    "tuning_session": {
+        "timestamp": "20260326_2115",
+        "benchmark_name": "tpch",
+        "workload_type": "OLAP",
+        "tier": "extensive",
+        "generations": 20,
+        "population_size": 8,
+    },
+    "best_configuration": {
+        "score": 72.3,
+        "knobs": {
+            "shared_buffers": "400MB",
+            "work_mem": "32MB",
+            "effective_cache_size": "1GB",
+            "checkpoint_completion_target": "0.9",
+            "wal_buffers": "16MB",
+        },
+        "metrics": {
+            "throughput": 45.2,
+            "latency_p95": 210.0,
+        },
+    },
+    "worker_resources": {
+        "ram_bytes": 1_641_393_356,
+        "cpu_cores": 1,
+        "disk_type": "SSD",
+    },
+    "warm_start": None,
+    "convergence": {"converged": False, "plateau_generations": 3},
+    "system_info": {
+        "cpu_model": "Intel(R) Core(TM) i5-6300U CPU @ 2.40GHz",
+        "cpu_cores": {"physical": 2, "logical": 4},
+        "ram": {"total_bytes": 8_206_966_784, "total_gb": 7.64},
+        "disk_type": "SSD",
+        "pg_version": "PostgreSQL 18.3",
+        "os": {
+            "system": "Linux",
+            "release": "6.18.18-1-lts",
+            "version": "#1 SMP PREEMPT_DYNAMIC",
+            "machine": "x86_64",
+        },
+    },
+}
+
+
+@pytest.fixture()
+def sample_session_file(tmp_path: Path) -> Path:
+    """Write a valid PBT results JSON to a temp directory and return the path."""
+    session_path = tmp_path / "pbt_results_20260326_2115.json"
+    session_path.write_text(json.dumps(SAMPLE_SESSION), encoding="utf-8")
+    return session_path
+
+
+@pytest.fixture()
+def sample_worker_resources() -> WorkerResources:
+    """Return the WorkerResources matching the sample session."""
+    return WorkerResources(
+        ram_bytes=1_641_393_356,
+        cpu_cores=1,
+        disk_type="SSD",
+    )
+
+
+@pytest.fixture()
+def make_run_result():
+    """
+    Factory fixture: create a RunResult with deterministic values.
+
+    Usage::
+        default_run = make_run_result("default", 1, score=42.0, tps=800.0)
+    """
+    def _factory(
+        config_type: str,
+        run_number: int,
+        score: float = 50.0,
+        tps: float = 1000.0,
+        p95_ms: float = 200.0,
+        memory_utilization: float = 0.5,
+    ) -> RunResult:
+        order_in_pair = 1 if config_type == "default" else 2
+        return RunResult(
+            config_type=config_type,
+            run_number=run_number,
+            pair_seed=50_000 + run_number - 1,
+            order_in_pair=order_in_pair,
+            metrics=PerformanceMetrics(
+                latency_p50=p95_ms * 0.6,
+                latency_p95=p95_ms,
+                latency_p99=p95_ms * 1.3,
+                throughput=tps,
+                error_rate=0.0,
+                memory_utilization=memory_utilization,
+                total_queries=int(tps * 60),
+                total_time=60.0,
+            ),
+            score=score,
+            duration_seconds=90.0,
+        )
+    return _factory
+
+
+@pytest.fixture()
+def default_runs(make_run_result) -> list[RunResult]:
+    """Five default-config runs with realistic variance."""
+    scores = [41.2, 42.5, 40.8, 43.1, 41.9]
+    tps_vals = [750.0, 780.0, 745.0, 800.0, 760.0]
+    p95_vals = [220.0, 210.0, 225.0, 205.0, 215.0]
+    return [
+        make_run_result("default", i + 1, score=s, tps=t, p95_ms=p)
+        for i, (s, t, p) in enumerate(zip(scores, tps_vals, p95_vals, strict=True))
+    ]
+
+
+@pytest.fixture()
+def tuned_runs(make_run_result) -> list[RunResult]:
+    """Five tuned-config runs showing clear improvement."""
+    scores = [68.4, 70.1, 67.9, 71.2, 69.5]
+    tps_vals = [1250.0, 1310.0, 1240.0, 1350.0, 1290.0]
+    p95_vals = [140.0, 135.0, 145.0, 130.0, 138.0]
+    return [
+        make_run_result("tuned", i + 1, score=s, tps=t, p95_ms=p)
+        for i, (s, t, p) in enumerate(zip(scores, tps_vals, p95_vals, strict=True))
+    ]

--- a/tests/unit/evaluation/test_evaluate_tuning.py
+++ b/tests/unit/evaluation/test_evaluate_tuning.py
@@ -1,0 +1,990 @@
+"""
+Unit tests for the evaluate_tuning module.
+
+Coverage:
+    - loader.py:     load_tuning_session() — happy path + error cases
+    - statistics.py: compute_comparison_statistics() — correctness of
+                     Wilcoxon, bootstrap CI, Holm correction, Cohen's d
+    - types.py:      Dataclass field validation
+    - runner.py:     _metrics_to_score(), _extract_pg_major(),
+                     _serialise_result() — isolated from I/O
+    - __main__.py:   CLI argument parsing and validation
+
+No Docker, PostgreSQL, or filesystem I/O beyond tmp_path fixtures.
+"""
+
+from __future__ import annotations
+
+import json
+import copy
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.evaluation.exceptions import (
+    DockerEnvironmentError,
+    EvaluationError,
+    TuningSessionLoadError,
+)
+from src.evaluation.loader import (
+    load_tuning_session,
+)
+from src.evaluation.runner import (
+    ComparisonRunner,
+    _extract_pg_major,
+    _metrics_to_score,
+)
+from src.evaluation.statistics import (
+    _bootstrap_ci_median,
+    _paired_cohens_d,
+    _stat_summary,
+    _wilcoxon_p,
+    compute_comparison_statistics,
+)
+from src.evaluation.types import (
+    ComparisonConfig,
+    ComparisonResult,
+    ComparisonStatistics,
+    PerformanceMetrics,
+    RunResult,
+    TuningSessionData,
+    WorkerResources,
+)
+from src.utils.rescoring import rescore_metrics_globally
+
+
+# ===========================================================================
+# loader.py tests
+# ===========================================================================
+
+class TestLoadTuningSession:
+    """Tests for load_tuning_session()."""
+
+    def test_happy_path(self, sample_session_file: Path) -> None:
+        """Valid session file loads without error."""
+        data = load_tuning_session(sample_session_file)
+
+        assert data.benchmark == "tpch"
+        assert data.workload_type == "olap"
+        assert data.best_score == pytest.approx(72.3)
+        assert "shared_buffers" in data.best_knobs
+        assert data.worker_resources.cpu_cores == 1
+        assert data.worker_resources.ram_bytes == 1_641_393_356
+        assert data.worker_resources.disk_type == "SSD"
+
+    def test_missing_file_raises(self, tmp_path: Path) -> None:
+        """Non-existent file raises TuningSessionLoadError."""
+        with pytest.raises(TuningSessionLoadError, match="not found"):
+            load_tuning_session(tmp_path / "nonexistent.json")
+
+    def test_invalid_json_raises(self, tmp_path: Path) -> None:
+        """Malformed JSON raises TuningSessionLoadError."""
+        bad = tmp_path / "bad.json"
+        bad.write_text("{not valid json", encoding="utf-8")
+        with pytest.raises(TuningSessionLoadError, match="Failed to parse"):
+            load_tuning_session(bad)
+
+    def test_missing_best_configuration_raises(self, tmp_path: Path) -> None:
+        """Missing best_configuration key raises TuningSessionLoadError."""
+        data = {
+            "tuning_session": {"benchmark": "tpch"},
+            "worker_resources": {"ram_bytes": 1000, "cpu_cores": 1, "disk_type": "SSD"},
+            # best_configuration intentionally omitted
+        }
+        p = tmp_path / "missing_best.json"
+        p.write_text(json.dumps(data), encoding="utf-8")
+        with pytest.raises(TuningSessionLoadError, match="best_configuration"):
+            load_tuning_session(p)
+
+    def test_missing_worker_resources_raises(self, tmp_path: Path) -> None:
+        """Missing worker_resources key raises TuningSessionLoadError."""
+        data = {
+            "tuning_session": {"benchmark": "tpch"},
+            "best_configuration": {
+                "knobs": {"shared_buffers": "128MB"},
+                "score": 50.0,
+            },
+            # worker_resources intentionally omitted
+        }
+        p = tmp_path / "missing_wr.json"
+        p.write_text(json.dumps(data), encoding="utf-8")
+        with pytest.raises(TuningSessionLoadError, match="worker_resources"):
+            load_tuning_session(p)
+
+    def test_negative_cpu_cores_raises(self, tmp_path: Path, sample_session_file: Path) -> None:
+        """Negative cpu_cores raises TuningSessionLoadError."""
+        with open(sample_session_file, encoding="utf-8") as f:
+            data = json.load(f)
+        data["worker_resources"]["cpu_cores"] = -1
+        p = tmp_path / "bad_cpu.json"
+        p.write_text(json.dumps(data), encoding="utf-8")
+        with pytest.raises(TuningSessionLoadError, match="cpu_cores"):
+            load_tuning_session(p)
+
+    def test_empty_knobs_raises(self, tmp_path: Path, sample_session_file: Path) -> None:
+        """Empty knobs dict raises TuningSessionLoadError."""
+        with open(sample_session_file, encoding="utf-8") as f:
+            data = json.load(f)
+        data["best_configuration"]["knobs"] = {}
+        p = tmp_path / "empty_knobs.json"
+        p.write_text(json.dumps(data), encoding="utf-8")
+        with pytest.raises(TuningSessionLoadError, match="non-empty"):
+            load_tuning_session(p)
+
+    @pytest.mark.parametrize("path_segment,expected", [
+        ("olap/pbt_runs", "tpch"),
+        ("oltp/pbt_runs", "sysbench"),
+        ("tpch/results", "tpch"),
+    ])
+    def test_benchmark_inferred_from_path(
+        self,
+        tmp_path: Path,
+        sample_session_file: Path,
+        path_segment: str,
+        expected: str,
+    ) -> None:
+        """Benchmark type inferred from file path when not in metadata."""
+        with open(sample_session_file, encoding="utf-8") as f:
+            data = json.load(f)
+        # Remove benchmark key from tuning_session
+        data["tuning_session"].pop("benchmark_name", None)
+        if "workload_type" in data["tuning_session"]:
+            del data["tuning_session"]["workload_type"]
+        # Place file under a path that contains the segment
+        nested = tmp_path / path_segment
+        nested.mkdir(parents=True, exist_ok=True)
+        p = nested / "pbt_results_test.json"
+        p.write_text(json.dumps(data), encoding="utf-8")
+
+        result = load_tuning_session(p)
+        assert result.benchmark == expected
+
+    def test_runtime_metadata_is_normalized_for_evaluation(
+        self,
+        tmp_path: Path,
+        sample_session_file: Path,
+    ) -> None:
+        """Legacy timing keys should be normalized into canonical evaluation keys."""
+        with open(sample_session_file, encoding="utf-8") as f:
+            data = json.load(f)
+
+        data["tuning_session"]["evaluation_duration"] = 45
+        data["tuning_session"]["warmup_duration"] = 12
+        data["tuning_session"]["warmup_passes"] = 2
+        p = tmp_path / "normalized.json"
+        p.write_text(json.dumps(data), encoding="utf-8")
+
+        result = load_tuning_session(p)
+        assert result.tuning_config["sysbench_duration_seconds"] == 45
+        assert result.tuning_config["sysbench_warmup_seconds"] == 12
+        assert result.tuning_config["tpch_warmup_passes"] == 2
+
+
+# ===========================================================================
+# statistics.py tests
+# ===========================================================================
+
+class TestStatisticalPrimitives:
+    """Tests for individual statistical functions."""
+
+    def test_stat_summary_basic(self) -> None:
+        """_stat_summary computes correct mean, std, median, IQR."""
+        values = [1.0, 2.0, 3.0, 4.0, 5.0]
+        s = _stat_summary(values)
+        assert s.mean == pytest.approx(3.0)
+        assert s.median == pytest.approx(3.0)
+        assert s.iqr_lower == pytest.approx(2.0)
+        assert s.iqr_upper == pytest.approx(4.0)
+        assert s.values == values
+
+    def test_stat_summary_single_value(self) -> None:
+        """Single-element list produces std=0 without errors."""
+        s = _stat_summary([42.0])
+        assert s.mean == pytest.approx(42.0)
+        assert s.std == pytest.approx(0.0)
+
+    def test_wilcoxon_all_same_direction(self) -> None:
+        """All differences in same direction → significant at α=0.05."""
+        import numpy as np
+        # All 5 differences positive → minimum p-value for N=5 Wilcoxon
+        diffs = np.array([5.0, 3.0, 7.0, 4.0, 6.0])
+        p = _wilcoxon_p(diffs)
+        assert p < 0.1   # Should be clearly significant for N=5
+
+    def test_wilcoxon_all_zero(self) -> None:
+        """All-zero differences → p=1.0 (no effect)."""
+        import numpy as np
+        diffs = np.zeros(5)
+        p = _wilcoxon_p(diffs)
+        assert p == pytest.approx(1.0)
+
+    def test_wilcoxon_mixed_directions(self) -> None:
+        """Mixed direction differences → high p-value (not significant)."""
+        import numpy as np
+        diffs = np.array([5.0, -5.0, 3.0, -3.0, 1.0])
+        p = _wilcoxon_p(diffs)
+        assert p > 0.2  # Not significant
+
+    def test_bootstrap_ci_contains_median(self) -> None:
+        """Bootstrap 95% CI should contain the true sample median."""
+        import numpy as np
+        rng = np.random.default_rng(0)
+        diffs = rng.normal(10.0, 1.0, size=5)
+        lo, hi = _bootstrap_ci_median(diffs, n_bootstrap=1000)
+        assert lo < np.median(diffs) < hi
+
+    def test_bootstrap_ci_width_reasonable(self) -> None:
+        """CI should be non-zero width for non-constant differences."""
+        import numpy as np
+        diffs = np.array([8.0, 10.0, 9.0, 11.0, 7.0])
+        lo, hi = _bootstrap_ci_median(diffs, n_bootstrap=1000)
+        assert hi > lo
+
+    def test_cohens_d_large_effect(self) -> None:
+        """Large consistent improvement → |d| > 0.8."""
+        import numpy as np
+        # All differences large and consistent
+        diffs = np.array([20.0, 22.0, 19.0, 21.0, 23.0])
+        d = _paired_cohens_d(diffs)
+        assert abs(d) > 0.8
+
+    def test_cohens_d_zero_effect(self) -> None:
+        """All-zero differences → d=0.0."""
+        import numpy as np
+        diffs = np.zeros(5)
+        d = _paired_cohens_d(diffs)
+        assert d == pytest.approx(0.0)
+
+
+class TestComputeComparisonStatistics:
+    """Integration tests for compute_comparison_statistics()."""
+
+    def test_clear_improvement_detected(
+        self,
+        default_runs: list[RunResult],
+        tuned_runs: list[RunResult],
+    ) -> None:
+        """Clear improvement in all metrics → positive overall improvement."""
+        stats = compute_comparison_statistics(default_runs, tuned_runs, benchmark="sysbench")
+        assert stats.overall_improvement_pct > 0.0
+
+    def test_primary_alpha_correct(
+        self,
+        default_runs: list[RunResult],
+        tuned_runs: list[RunResult],
+    ) -> None:
+        """Primary endpoint is tested at alpha=0.05 without family correction."""
+        stats = compute_comparison_statistics(default_runs, tuned_runs, benchmark="sysbench")
+        assert stats.alpha == pytest.approx(0.05)
+
+    def test_returns_primary_plus_three_secondary_metrics(
+        self,
+        default_runs: list[RunResult],
+        tuned_runs: list[RunResult],
+    ) -> None:
+        """Statistics include score + benchmark latency + throughput + memory."""
+        stats = compute_comparison_statistics(default_runs, tuned_runs, benchmark="sysbench")
+        metric_names = {mc.metric_name for mc in stats.metrics}
+        assert metric_names == {"score", "latency_p95", "throughput", "memory_utilization"}
+
+    def test_latency_higher_is_better_flag(
+        self,
+        default_runs: list[RunResult],
+        tuned_runs: list[RunResult],
+    ) -> None:
+        """latency_p95 should have higher_is_better=False."""
+        stats = compute_comparison_statistics(default_runs, tuned_runs, benchmark="sysbench")
+        latency_mc = next(m for m in stats.metrics if m.metric_name == "latency_p95")
+        assert latency_mc.higher_is_better is False
+
+    def test_memory_utilization_treated_as_lower_is_better(self, make_run_result) -> None:
+        """Memory utilization should be penalized when tuned uses more memory."""
+        default_runs = [
+            make_run_result(
+                "default",
+                i,
+                score=50.0,
+                memory_utilization=0.10,
+            )
+            for i in range(1, 6)
+        ]
+        tuned_runs = [
+            make_run_result(
+                "tuned",
+                i,
+                score=50.0,
+                memory_utilization=0.20,
+            )
+            for i in range(1, 6)
+        ]
+
+        stats = compute_comparison_statistics(default_runs, tuned_runs, benchmark="sysbench")
+        memory_mc = next(m for m in stats.metrics if m.metric_name == "memory_utilization")
+
+        assert memory_mc.higher_is_better is False
+        assert memory_mc.improvement_pct < 0.0
+
+    def test_tpch_uses_latency_p99_endpoint(
+        self,
+        default_runs: list[RunResult],
+        tuned_runs: list[RunResult],
+    ) -> None:
+        """TPC-H statistical endpoint uses latency_p99 instead of p95."""
+        stats = compute_comparison_statistics(default_runs, tuned_runs, benchmark="tpch")
+        metric_names = {mc.metric_name for mc in stats.metrics}
+        assert "latency_p99" in metric_names
+        assert "latency_p95" not in metric_names
+
+    def test_ci_is_ordered(
+        self,
+        default_runs: list[RunResult],
+        tuned_runs: list[RunResult],
+    ) -> None:
+        """Bootstrap CI lower bound < upper bound for all metrics."""
+        stats = compute_comparison_statistics(default_runs, tuned_runs, benchmark="sysbench")
+        for mc in stats.metrics:
+            lo, hi = mc.improvement_ci
+            assert lo <= hi, f"CI inverted for {mc.metric_name}: [{lo}, {hi}]"
+
+    def test_empty_runs_raises(self) -> None:
+        """Empty run list raises ValueError."""
+        with pytest.raises(ValueError, match="non-empty"):
+            compute_comparison_statistics([], [], benchmark="sysbench")
+
+    def test_mismatched_lengths_raise(
+        self,
+        default_runs: list[RunResult],
+        tuned_runs: list[RunResult],
+        make_run_result,
+    ) -> None:
+        """Mismatched lengths should fail to protect pair integrity."""
+        extra = default_runs + [make_run_result("default", 6)]
+        with pytest.raises(ValueError, match="equal length"):
+            compute_comparison_statistics(extra, tuned_runs, benchmark="sysbench")
+
+    def test_no_improvement_not_significant(self, make_run_result) -> None:
+        """When both configs produce identical scores → not significant."""
+        same_default = [make_run_result("default", i, score=50.0) for i in range(1, 6)]
+        same_tuned = [make_run_result("tuned", i, score=50.0) for i in range(1, 6)]
+        stats = compute_comparison_statistics(same_default, same_tuned, benchmark="sysbench")
+        score_mc = next(m for m in stats.metrics if m.metric_name == "score")
+        assert not score_mc.significant
+
+    def test_mismatched_pair_keys_raise(
+        self,
+        default_runs: list[RunResult],
+        tuned_runs: list[RunResult],
+    ) -> None:
+        """Pair IDs and seeds must align exactly before paired statistics."""
+        tuned_runs[0].pair_seed = 9999
+
+        with pytest.raises(ValueError, match="not aligned"):
+            compute_comparison_statistics(default_runs, tuned_runs, benchmark="sysbench")
+
+    def test_statistics_metadata_includes_power_warning_for_n5(
+        self,
+        default_runs: list[RunResult],
+        tuned_runs: list[RunResult],
+    ) -> None:
+        stats = compute_comparison_statistics(default_runs, tuned_runs, benchmark="sysbench")
+
+        assert stats.n_pairs == 5
+        assert stats.correction_method == "holm_secondary"
+        assert stats.secondary_correction_method == "holm"
+        assert stats.primary_endpoint == "score"
+        assert set(stats.secondary_endpoints) == {
+            "latency_p95",
+            "throughput",
+            "memory_utilization",
+        }
+        assert stats.power_warning is not None
+        assert "0.0625" in stats.power_warning
+
+
+# ===========================================================================
+# runner.py helper tests
+# ===========================================================================
+
+class TestRunnerHelpers:
+    """Tests for standalone helper functions in runner.py."""
+
+    @pytest.mark.parametrize("pg_str,expected", [
+        ("PostgreSQL 16.2", "16"),
+        ("PostgreSQL 18.3", "18"),
+        ("PostgreSQL 14.0 (Ubuntu)", "14"),
+        ("unknown", "16"),
+        ("", "16"),
+    ])
+    def test_extract_pg_major(self, pg_str: str, expected: str) -> None:
+        assert _extract_pg_major(pg_str) == expected
+
+    def test_metrics_to_score_sysbench_high_tps(self) -> None:
+        """High TPS, low latency → score approaches 100."""
+        snap = PerformanceMetrics(
+            latency_p50=50.0, latency_p95=80.0, latency_p99=100.0,
+            throughput=2000.0, error_rate=0.0, memory_utilization=0.4,
+            total_queries=120_000, total_time=60.0,
+        )
+        score = _metrics_to_score(snap, "sysbench")
+        assert 0.0 < score <= 100.0
+        assert score > 50.0  # High TPS should give a good score
+
+    def test_metrics_to_score_sysbench_zero_tps(self) -> None:
+        """Zero TPS → score = 0."""
+        snap = PerformanceMetrics(
+            latency_p50=0.0, latency_p95=0.0, latency_p99=0.0,
+            throughput=0.0, error_rate=1.0, memory_utilization=0.0,
+            total_queries=0, total_time=60.0,
+        )
+        score = _metrics_to_score(snap, "sysbench")
+        assert score == pytest.approx(0.0)
+
+    def test_metrics_to_score_tpch(self) -> None:
+        """TPC-H score capped at 100, non-negative."""
+        snap = PerformanceMetrics(
+            latency_p50=5000.0, latency_p95=8000.0, latency_p99=10000.0,
+            throughput=0.5, error_rate=0.0, memory_utilization=0.8,
+            total_queries=22, total_time=3600.0,
+        )
+        score = _metrics_to_score(snap, "tpch")
+        assert 0.0 <= score <= 100.0
+
+
+class TestRescoring:
+    """Tests for deterministic post-hoc global rescoring."""
+
+    def test_rescoring_uses_workload_latency_endpoint(
+        self,
+        default_runs: list[RunResult],
+        tuned_runs: list[RunResult],
+    ) -> None:
+        all_runs = sorted(
+            [*default_runs, *tuned_runs],
+            key=lambda r: (r.run_number, r.order_in_pair, r.config_type),
+        )
+        _, scores, metadata = rescore_metrics_globally(
+            [r.metrics for r in all_runs],
+            benchmark="tpch",
+        )
+        for run, score in zip(all_runs, scores, strict=True):
+            run.score = score
+
+        assert metadata["mode"] == "global_posthoc"
+        assert metadata["latency_metric"] == "p99"
+        assert metadata["benchmark"] == "tpch"
+        assert metadata["n_observations"] == 10
+
+    def test_rescoring_is_deterministic_for_same_inputs(
+        self,
+        default_runs: list[RunResult],
+        tuned_runs: list[RunResult],
+    ) -> None:
+        default_runs_a = copy.deepcopy(default_runs)
+        tuned_runs_a = copy.deepcopy(tuned_runs)
+        default_runs_b = copy.deepcopy(default_runs)
+        tuned_runs_b = copy.deepcopy(tuned_runs)
+
+        all_runs_a = sorted(
+            [*default_runs_a, *tuned_runs_a],
+            key=lambda r: (r.run_number, r.order_in_pair, r.config_type),
+        )
+        all_runs_b = sorted(
+            [*default_runs_b, *tuned_runs_b],
+            key=lambda r: (r.run_number, r.order_in_pair, r.config_type),
+        )
+
+        _, scores_a, _ = rescore_metrics_globally(
+            [r.metrics for r in all_runs_a],
+            benchmark="sysbench",
+        )
+        _, scores_b, _ = rescore_metrics_globally(
+            [r.metrics for r in all_runs_b],
+            benchmark="sysbench",
+        )
+        for run, score in zip(all_runs_a, scores_a, strict=True):
+            run.score = score
+        for run, score in zip(all_runs_b, scores_b, strict=True):
+            run.score = score
+
+        scores_a = [r.score for r in [*default_runs_a, *tuned_runs_a]]
+        scores_b = [r.score for r in [*default_runs_b, *tuned_runs_b]]
+        assert scores_a == pytest.approx(scores_b)
+
+
+class TestBenchmarkParameterResolution:
+    """Tests for CLI > session > default benchmark parameter precedence."""
+
+    def _make_session(self, tuning_config: dict[str, object]) -> TuningSessionData:
+        return TuningSessionData(
+            best_knobs={},
+            best_score=10.0,
+            worker_resources=WorkerResources(ram_bytes=1_000_000_000, cpu_cores=1, disk_type="SSD"),
+            system_info={},
+            tuning_config=tuning_config,
+            benchmark="sysbench",
+            workload_type="oltp",
+            session_id="s1",
+        )
+
+    def test_session_values_used_when_cli_omits(
+        self,
+    ) -> None:
+        config = ComparisonConfig(
+            tuning_session_path=Path("results/oltp/pbt_runs/core/tuning_sessions/session.json"),
+            benchmark="sysbench",
+        )
+        runner = ComparisonRunner(config)
+        session = self._make_session(
+            {
+                "sysbench_duration_seconds": 75,
+                "sysbench_warmup_seconds": 9,
+                "sysbench_tables": 22,
+                "sysbench_table_size": 123456,
+                "tpch_warmup_passes": 2,
+                "scale_factor": 3.0,
+            }
+        )
+
+        resolved = runner._resolve_effective_benchmark_params(session, benchmark="sysbench")
+
+        assert resolved["sysbench_duration"] == 75
+        assert resolved["sysbench_warmup_seconds"] == 9
+        assert resolved["sysbench_tables"] == 22
+        assert resolved["sysbench_table_size"] == 123456
+        assert resolved["tpch_warmup_passes"] == 2
+        assert resolved["scale_factor"] == pytest.approx(3.0)
+
+    def test_cli_values_override_session(
+        self,
+    ) -> None:
+        config = ComparisonConfig(
+            tuning_session_path=Path("results/oltp/pbt_runs/core/tuning_sessions/session.json"),
+            benchmark="sysbench",
+            sysbench_duration=99,
+            sysbench_warmup_seconds=14,
+            sysbench_tables=11,
+            sysbench_table_size=222222,
+            tpch_warmup_passes=4,
+            scale_factor=7.0,
+        )
+        runner = ComparisonRunner(config)
+        session = self._make_session(
+            {
+                "sysbench_duration_seconds": 10,
+                "sysbench_warmup_seconds": 3,
+                "sysbench_tables": 2,
+                "sysbench_table_size": 1000,
+                "tpch_warmup_passes": 1,
+                "scale_factor": 1.0,
+            }
+        )
+
+        resolved = runner._resolve_effective_benchmark_params(session, benchmark="sysbench")
+
+        assert resolved["sysbench_duration"] == 99
+        assert resolved["sysbench_warmup_seconds"] == 14
+        assert resolved["sysbench_tables"] == 11
+        assert resolved["sysbench_table_size"] == 222222
+        assert resolved["tpch_warmup_passes"] == 4
+        assert resolved["scale_factor"] == pytest.approx(7.0)
+
+
+class TestDockerPrerequisites:
+    """Tests for Docker preflight checks in ComparisonRunner."""
+
+    @staticmethod
+    def _fake_docker_module() -> tuple[SimpleNamespace, SimpleNamespace]:
+        image_not_found = type("ImageNotFound", (Exception,), {})
+        api_error = type("APIError", (Exception,), {})
+        docker_exception = type("DockerException", (Exception,), {})
+        errors = SimpleNamespace(
+            ImageNotFound=image_not_found,
+            APIError=api_error,
+            DockerException=docker_exception,
+        )
+        client = MagicMock()
+        client.ping.return_value = None
+        module = SimpleNamespace(from_env=MagicMock(return_value=client), errors=errors)
+        return module, client
+
+    def test_preflight_noop_when_docker_disabled(self, sample_session_file: Path) -> None:
+        config = ComparisonConfig(
+            tuning_session_path=sample_session_file,
+            benchmark="sysbench",
+            use_docker=False,
+        )
+        runner = ComparisonRunner(config)
+
+        runner._validate_docker_prerequisites()
+
+    def test_preflight_raises_with_build_hint_when_image_missing(
+        self,
+        sample_session_file: Path,
+    ) -> None:
+        config = ComparisonConfig(
+            tuning_session_path=sample_session_file,
+            benchmark="sysbench",
+            use_docker=True,
+            docker_image="pbt-eval",
+        )
+        runner = ComparisonRunner(config)
+
+        fake_docker, fake_client = self._fake_docker_module()
+        fake_client.images.get.side_effect = fake_docker.errors.ImageNotFound()
+        fake_client.images.pull.side_effect = fake_docker.errors.ImageNotFound()
+
+        with patch.dict(sys.modules, {"docker": fake_docker}):
+            with pytest.raises(DockerEnvironmentError, match="docker build -f docker/eval\\.Dockerfile"):
+                runner._validate_docker_prerequisites()
+
+        fake_client.close.assert_called_once()
+
+    def test_preflight_accepts_image_after_successful_pull(
+        self,
+        sample_session_file: Path,
+    ) -> None:
+        config = ComparisonConfig(
+            tuning_session_path=sample_session_file,
+            benchmark="sysbench",
+            use_docker=True,
+            docker_image="example/eval:latest",
+        )
+        runner = ComparisonRunner(config)
+
+        fake_docker, fake_client = self._fake_docker_module()
+        fake_client.images.get.side_effect = fake_docker.errors.ImageNotFound()
+        fake_client.images.pull.return_value = object()
+
+        with patch.dict(sys.modules, {"docker": fake_docker}):
+            runner._validate_docker_prerequisites()
+
+        fake_client.images.pull.assert_called_once_with("example/eval:latest")
+        fake_client.close.assert_called_once()
+
+
+class TestOutputPathResolution:
+    """Tests for ComparisonRunner output directory contract."""
+
+    @staticmethod
+    def _build_result(
+        config: ComparisonConfig,
+        workload_type: str,
+        tuning_config: dict[str, object] | None = None,
+    ) -> ComparisonResult:
+        session = TuningSessionData(
+            best_knobs={},
+            best_score=0.0,
+            worker_resources=WorkerResources(
+                ram_bytes=1_000_000_000,
+                cpu_cores=1,
+                disk_type="SSD",
+            ),
+            system_info={},
+            tuning_config=tuning_config or {},
+            benchmark="sysbench",
+            workload_type=workload_type,
+            session_id="20260411_120000",
+        )
+        stats = ComparisonStatistics(
+            metrics=[],
+            significant_metrics=[],
+            overall_improvement_pct=0.0,
+            overall_improvement_ci=(0.0, 0.0),
+        )
+        return ComparisonResult(
+            default_runs=[],
+            tuned_runs=[],
+            tuned_knobs={},
+            statistics=stats,
+            config=config,
+            session_data=session,
+            timestamp="20260411_120000",
+        )
+
+    def test_default_output_dir_uses_workload_type(self) -> None:
+        config = ComparisonConfig(
+            tuning_session_path=Path("results/olap/pbt_runs/extensive/tuning_sessions/session.json"),
+            benchmark="sysbench",
+            output_dir=None,
+        )
+        runner = ComparisonRunner(config)
+        result = self._build_result(config, workload_type="olap")
+
+        assert runner._resolve_output_dir(result) == (
+            Path("results") / "olap" / "comparisons" / "extensive"
+        )
+
+    def test_metadata_tier_preferred_over_path_tier(self) -> None:
+        config = ComparisonConfig(
+            tuning_session_path=Path("results/olap/pbt_runs/extensive/tuning_sessions/session.json"),
+            benchmark="sysbench",
+            output_dir=None,
+        )
+        runner = ComparisonRunner(config)
+        result = self._build_result(
+            config,
+            workload_type="olap",
+            tuning_config={"knob_tier": "core"},
+        )
+
+        assert runner._resolve_output_dir(result) == (
+            Path("results") / "olap" / "comparisons" / "core"
+        )
+
+    def test_metadata_tier_field_supported(self) -> None:
+        config = ComparisonConfig(
+            tuning_session_path=Path("results/olap/pbt_runs/extensive/tuning_sessions/session.json"),
+            benchmark="sysbench",
+            output_dir=None,
+        )
+        runner = ComparisonRunner(config)
+        result = self._build_result(
+            config,
+            workload_type="olap",
+            tuning_config={"tier": "minimal"},
+        )
+
+        assert runner._resolve_output_dir(result) == (
+            Path("results") / "olap" / "comparisons" / "minimal"
+        )
+
+    def test_unknown_workload_falls_back_to_mixed(self) -> None:
+        config = ComparisonConfig(
+            tuning_session_path=Path("results/unknown/session.json"),
+            benchmark="sysbench",
+            output_dir=None,
+        )
+        runner = ComparisonRunner(config)
+        result = self._build_result(config, workload_type="custom")
+
+        assert runner._resolve_output_dir(result) == (
+            Path("results") / "mixed" / "comparisons" / "unknown"
+        )
+
+    def test_custom_output_dir_is_used_as_is(self, tmp_path: Path) -> None:
+        custom_output = tmp_path / "custom-comparisons"
+        config = ComparisonConfig(
+            tuning_session_path=Path("results/oltp/session.json"),
+            benchmark="sysbench",
+            output_dir=custom_output,
+        )
+        runner = ComparisonRunner(config)
+        result = self._build_result(config, workload_type="oltp")
+
+        assert runner._resolve_output_dir(result) == custom_output
+
+    def test_log_output_path_uses_logs_subdir(self) -> None:
+        config = ComparisonConfig(
+            tuning_session_path=Path("results/oltp/session.json"),
+            benchmark="sysbench",
+            output_dir=Path("results/oltp/comparisons/core"),
+        )
+        runner = ComparisonRunner(config)
+
+        log_path = runner._resolve_log_output_path(config.output_dir, "20260412_090000")
+
+        assert log_path == (
+            Path("results/oltp/comparisons/core") / "logs" / "evaluation_20260412_090000.html"
+        )
+
+
+class TestTunedKnobResolution:
+    """Tests for converting serialized tuned knob fractions to absolute values."""
+
+    def test_hardware_relative_knobs_are_resolved_from_fractions(self) -> None:
+        config = ComparisonConfig(
+            tuning_session_path=Path("results/oltp/pbt_runs/core/tuning_sessions/session.json"),
+            benchmark="sysbench",
+        )
+        runner = ComparisonRunner(config)
+
+        session = TuningSessionData(
+            best_knobs={
+                "shared_buffers": 0.25,
+                "max_worker_processes": 0.75,
+                "random_page_cost": 1.2,
+            },
+            best_score=50.0,
+            worker_resources=WorkerResources(
+                ram_bytes=2_147_483_648,
+                cpu_cores=8,
+                disk_type="SSD",
+            ),
+            system_info={},
+            tuning_config={"tier": "core"},
+            benchmark="sysbench",
+            workload_type="oltp",
+            session_id="20260412_090000",
+        )
+
+        resolved = runner._resolve_tuned_knobs(session)
+
+        assert isinstance(resolved["shared_buffers"], int)
+        assert resolved["shared_buffers"] >= 16
+        assert isinstance(resolved["max_worker_processes"], int)
+        assert resolved["max_worker_processes"] >= 1
+        assert resolved["random_page_cost"] == pytest.approx(1.2)
+
+
+# ===========================================================================
+# CLI (__main__.py) tests
+# ===========================================================================
+
+class TestCLI:
+    """Tests for the CLI argument parser (main() with mocked runner)."""
+
+    def test_missing_session_exits_nonzero(self) -> None:
+        """Calling without --session should exit with error via SystemExit."""
+        from src.evaluation.__main__ import main
+        with pytest.raises(SystemExit) as exc_info:
+            main(["--repetitions", "5"])   # Missing --session
+        assert exc_info.value.code != 0
+
+    def test_repetitions_less_than_2_exits_nonzero(self, tmp_path: Path) -> None:
+        """--repetitions 1 should fail validation."""
+        fake = tmp_path / "s.json"
+        fake.write_text("{}", encoding="utf-8")
+        from src.evaluation.__main__ import main
+        # argparse.error() calls sys.exit(2) which pytest catches as SystemExit
+        with pytest.raises(SystemExit) as exc_info:
+            main(["--session", str(fake), "--repetitions", "1"])
+        assert exc_info.value.code != 0
+
+    def test_successful_run_returns_zero(
+        self,
+        sample_session_file: Path,
+    ) -> None:
+        """With a mocked ComparisonRunner, CLI should return 0."""
+        mock_result = MagicMock()
+        with patch(
+            "src.evaluation.__main__.ComparisonRunner"
+        ) as MockRunner:
+            MockRunner.return_value.run.return_value = mock_result
+            from src.evaluation.__main__ import main
+            rc = main([
+                "--session", str(sample_session_file),
+                "--repetitions", "5",
+                "--no-docker",
+            ])
+        assert rc == 0
+
+    def test_evaluation_error_returns_one(
+        self,
+        sample_session_file: Path,
+    ) -> None:
+        """EvaluationError from runner → exit code 1."""
+        with patch(
+            "src.evaluation.__main__.ComparisonRunner"
+        ) as MockRunner:
+            MockRunner.return_value.run.side_effect = EvaluationError("fail")
+            from src.evaluation.__main__ import main
+            rc = main([
+                "--session", str(sample_session_file),
+                "--no-docker",
+            ])
+        assert rc == 1
+
+    def test_no_docker_flag_sets_use_docker_false(
+        self,
+        sample_session_file: Path,
+    ) -> None:
+        """--no-docker flag sets use_docker=False in ComparisonConfig."""
+        captured_config = {}
+        with patch(
+            "src.evaluation.__main__.ComparisonRunner"
+        ) as MockRunner:
+            def capture(config):
+                captured_config["use_docker"] = config.use_docker
+                m = MagicMock()
+                m.run.return_value = MagicMock()
+                return m
+            MockRunner.side_effect = capture
+            from src.evaluation.__main__ import main
+            main(["--session", str(sample_session_file), "--no-docker"])
+
+        assert captured_config.get("use_docker") is False
+
+    def test_legacy_warmup_flag_rejected(self, sample_session_file: Path) -> None:
+        """Generic --warmup flag is removed; benchmark-specific flags must be used."""
+        from src.evaluation.__main__ import main
+
+        with pytest.raises(SystemExit) as exc_info:
+            main([
+                "--session", str(sample_session_file),
+                "--warmup", "30",
+            ])
+        assert exc_info.value.code != 0
+
+    def test_seed_and_sysbench_flags_propagate_to_config(
+        self,
+        sample_session_file: Path,
+    ) -> None:
+        """CLI benchmark-specific flags should map to ComparisonConfig fields."""
+        captured_config: dict[str, object] = {}
+
+        with patch("src.evaluation.__main__.ComparisonRunner") as MockRunner:
+            def capture(config):
+                captured_config["pair_seed"] = config.pair_seed
+                captured_config["sysbench_duration"] = config.sysbench_duration
+                captured_config["sysbench_warmup_seconds"] = config.sysbench_warmup_seconds
+                captured_config["sysbench_tables"] = config.sysbench_tables
+                captured_config["sysbench_table_size"] = config.sysbench_table_size
+                m = MagicMock()
+                m.run.return_value = MagicMock()
+                return m
+
+            MockRunner.side_effect = capture
+            from src.evaluation.__main__ import main
+
+            main([
+                "--session", str(sample_session_file),
+                "--seed", "777",
+                "--sysbench-duration", "75",
+                "--sysbench-warmup-seconds", "12",
+                "--sysbench-tables", "16",
+                "--sysbench-table-size", "200000",
+            ])
+
+        assert captured_config["pair_seed"] == 777
+        assert captured_config["sysbench_duration"] == 75
+        assert captured_config["sysbench_warmup_seconds"] == 12
+        assert captured_config["sysbench_tables"] == 16
+        assert captured_config["sysbench_table_size"] == 200000
+
+    def test_cli_defaults_are_owned_by_python_entrypoint(
+        self,
+        sample_session_file: Path,
+    ) -> None:
+        """Default values should come from python CLI contract, not wrapper logic."""
+        captured_config: dict[str, object] = {}
+
+        with patch("src.evaluation.__main__.ComparisonRunner") as MockRunner:
+            def capture(config):
+                captured_config["repetitions"] = config.repetitions
+                captured_config["benchmark"] = config.benchmark
+                captured_config["use_docker"] = config.use_docker
+                captured_config["output_dir"] = config.output_dir
+                captured_config["sysbench_duration"] = config.sysbench_duration
+                captured_config["sysbench_warmup_seconds"] = config.sysbench_warmup_seconds
+                captured_config["tpch_warmup_passes"] = config.tpch_warmup_passes
+                captured_config["pair_seed"] = config.pair_seed
+                m = MagicMock()
+                m.run.return_value = MagicMock()
+                return m
+
+            MockRunner.side_effect = capture
+            from src.evaluation.__main__ import main
+
+            main(["--session", str(sample_session_file)])
+
+        assert captured_config["repetitions"] == 5
+        assert captured_config["benchmark"] is None
+        assert captured_config["use_docker"] is True
+        assert captured_config["output_dir"] is None
+        assert captured_config["sysbench_duration"] is None
+        assert captured_config["sysbench_warmup_seconds"] is None
+        assert captured_config["tpch_warmup_passes"] is None
+        assert captured_config["pair_seed"] == 50_000

--- a/tests/unit/evaluation/test_public_api_exports.py
+++ b/tests/unit/evaluation/test_public_api_exports.py
@@ -1,0 +1,25 @@
+"""Public API export contract tests for src.evaluation."""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+def test_all_declared_exports_are_resolvable() -> None:
+    """Every symbol listed in __all__ should be importable from src.evaluation."""
+    module = importlib.import_module("src.evaluation")
+
+    for export_name in module.__all__:
+        assert hasattr(module, export_name), f"Missing export: {export_name}"
+
+
+def test_performance_snapshot_is_intentionally_not_exported() -> None:
+    """PerformanceSnapshot should remain absent from the public API contract."""
+    module = importlib.import_module("src.evaluation")
+
+    assert "PerformanceSnapshot" not in module.__all__
+
+    with pytest.raises(ImportError):
+        exec("from src.evaluation import PerformanceSnapshot")


### PR DESCRIPTION
## Summary

This PR introduces a full default-vs-tuned evaluation workflow and hardens several tuning/runtime paths that affected reproducibility and stability.

## Why

- We need a repeatable, publication-ready comparison flow between default PostgreSQL and tuned configurations.
- We also need safer runtime behavior when workers fail, recover, or drift outside scoring bounds.

## What Changed

- Added a new evaluation package for loading tuning sessions, running paired comparisons, computing statistics, and exposing a CLI entrypoint.
- Added reproducible evaluation infrastructure:
- Docker evaluation assets for isolated runs.
- A lightweight repro launcher script.
- A reproducibility runbook with canonical commands and triage guidance.
- Extracted global rescoring logic into a shared utility and updated analysis loading to use it.
- Applied core/evaluator/benchmark fixes for:
- dead-worker rescue and restart consistency
- convergence checks with valid-worker filtering
- bidirectional bound exceedance handling for range expansion
- benchmark schema cleanup/validation safeguards
- worker-scoped memory normalization behavior
- Updated ignore behavior to keep papers and OLTP comparison artifacts untracked.

## Validation

- pytest tests/unit/evaluation -q  
  Result: 64 passed
- pytest test_sysbench_executor_validation.py test_tpch_executor_schema_cleanup.py test_dead_rescue_convergence_and_restart.py test_evaluator_fault_injection.py test_evaluator_memory_normalization.py -q  
  Result: 16 passed