### PR TITLE
feat(env): harden environment lifecycle and integrate runtime-aware tuner startup

### DIFF
--- a/src/tuner/main.py
+++ b/src/tuner/main.py
@@ -39,6 +39,7 @@ import sys
 import math
 import time
 import logging
+import re
 from pathlib import Path
 from typing import Optional, Dict, Any, Tuple, List
 from datetime import datetime
@@ -46,6 +47,7 @@ import numpy as np
 import psycopg2
 
 from src.config.database import get_db_config
+from src.database.connection import get_connection
 
 from src.tuner.config import (
     get_knob_space,
@@ -181,6 +183,7 @@ class PBTTuner:
 
         self.cleanup_instances = kwargs.get('cleanup_instances', False)
         self.no_docker = kwargs.get('no_docker', False)
+        self.docker_image = kwargs.get('docker_image', None)
 
         self.warm_start_path = kwargs.get('warm_start_path', None)
         self.warm_start_provenance = {"enabled": False}
@@ -192,8 +195,8 @@ class PBTTuner:
         self.knob_space = get_knob_space(knob_tier)
 
         self.logger.debug("  Detecting hardware resources...")
-        worker_resources = detect_worker_resources(self.pbt_config.num_parallel_workers)
-        self.knob_space.resolve_hardware_ranges(worker_resources)
+        self.worker_resources = detect_worker_resources(self.pbt_config.num_parallel_workers)
+        self.knob_space.resolve_hardware_ranges(self.worker_resources)
 
         self.logger.debug("✓ Loaded %d knobs\n", len(self.knob_space))
 
@@ -212,6 +215,7 @@ class PBTTuner:
             restart_interval=10,
             random_seed=random_seed,
             warmup_passes=self.pbt_config.warmup_passes,
+            worker_memory_budget_bytes=self.worker_resources.ram_bytes,
             restart_config=RestartConfig(
                 method='pg_ctl' if self.no_docker else 'docker'
             )
@@ -263,6 +267,8 @@ class PBTTuner:
             workload_executor = self._create_workload_executor(workload_type, workload_file)
             self.snapshot_identifier = f"{self.benchmark_name}_sf{self.pbt_config.scale_factor}"
 
+        self.snapshot_identifier = self._normalize_snapshot_identifier(self.snapshot_identifier)
+
         self.output_dir = (
             Path(kwargs.get('output_dir', "results"))
             / self.workload_type.value
@@ -292,9 +298,6 @@ class PBTTuner:
 
 
         self.system_info = get_system_info()
-        self.worker_resources = detect_worker_resources(
-            max_parallel_workers=self.pbt_config.num_parallel_workers
-        )
 
         no_docker = kwargs.get('no_docker', False)
         self.env = EnvironmentFactory.create(
@@ -304,7 +307,9 @@ class PBTTuner:
             base_port=5440,
             db_config=self.db_config,
             worker_resources=self.worker_resources,
-            run_id="tuner_run"
+            run_id=self.snapshot_identifier,
+            image_name=self.docker_image,
+            force_recreate_baseline=self.force_recreate_baseline,
         )
         self.start_time: Optional[float] = None
         self.generation_history = []
@@ -330,6 +335,73 @@ class PBTTuner:
         """Dynamically fetch the all-time mathematically rescored best score from Population"""
         _, score = self.population.get_best_configuration()
         return score
+
+    def _normalize_snapshot_identifier(self, snapshot_identifier: str) -> str:
+        """Normalize snapshot identifiers for filesystem and Docker compatibility."""
+        normalized = re.sub(r"[^a-z0-9_.-]+", "-", snapshot_identifier.lower()).strip("-")
+        return normalized or "default"
+
+    def _get_runtime_supported_knobs(self, worker_id: int = 0) -> Tuple[set[str], str]:
+        """Get runtime pg_settings knob names and server version from a worker instance."""
+        db_config = self.env.get_db_config(worker_id)
+
+        conn = None
+        cursor = None
+        try:
+            conn = get_connection(config=db_config, connect_timeout=5)
+            cursor = conn.cursor()
+            cursor.execute("SELECT current_setting('server_version')")
+            version_row = cursor.fetchone()
+            server_version = str(version_row[0]) if version_row else "unknown"
+
+            cursor.execute("SELECT name FROM pg_settings")
+            supported_knobs = {str(row[0]) for row in cursor.fetchall()}
+            return supported_knobs, server_version
+        except (psycopg2.Error, RuntimeError, OSError, ValueError) as exc:
+            self.logger.warning(
+                "Failed to inspect runtime pg_settings for knob compatibility: %s",
+                exc,
+            )
+            return set(self.knob_space.knobs.keys()), "unknown"
+        finally:
+            if cursor is not None:
+                cursor.close()
+            if conn is not None:
+                conn.close()
+
+    def _prune_unsupported_runtime_knobs(self) -> None:
+        """Prune knobs unavailable on runtime PostgreSQL to avoid apply/verify failures."""
+        supported_knobs, server_version = self._get_runtime_supported_knobs(worker_id=0)
+        configured_knobs = set(self.knob_space.knobs.keys())
+        unsupported_knobs = sorted(configured_knobs - supported_knobs)
+
+        if not unsupported_knobs:
+            self.logger.info(
+                "✓ Runtime knob compatibility check passed against PostgreSQL %s (%d knobs)",
+                server_version,
+                len(configured_knobs),
+            )
+            return
+
+        for knob_name in unsupported_knobs:
+            self.knob_space.knobs.pop(knob_name, None)
+
+        preview = unsupported_knobs[:20]
+        suffix = " ..." if len(unsupported_knobs) > len(preview) else ""
+        self.logger.warning(
+            "Pruned %d unsupported knobs for PostgreSQL %s: %s%s",
+            len(unsupported_knobs),
+            server_version,
+            ", ".join(preview),
+            suffix,
+        )
+
+        if len(self.knob_space) == 0:
+            raise RuntimeError(
+                "No runtime-compatible knobs remain after pg_settings compatibility pruning."
+            )
+
+        self.logger.info("✓ Continuing with %d runtime-compatible knobs", len(self.knob_space))
 
     def _create_workload_executor(
         self,
@@ -426,7 +498,21 @@ class PBTTuner:
             return metrics, score
 
         except (ConnectionError, psycopg2.Error) as e:
-            recovered = self.env.recover_instance(worker.worker_id)
+            recovered = False
+            if self.env is None:
+                worker_logger.error(
+                    "[DEAD_CONFIG] No environment available for immediate recovery"
+                )
+            else:
+                try:
+                    recovered = self.env.recover_instance(worker.worker_id)
+                except (ConnectionError, RuntimeError, OSError) as recovery_error:
+                    worker_logger.error(
+                        "[DEAD_CONFIG] Immediate recovery raised an unexpected error: %s",
+                        recovery_error,
+                        exc_info=True,
+                    )
+
             if recovered:
                 worker_logger.info(
                     "[DEAD_CONFIG] Immediate instance recovery succeeded after connection failure"
@@ -604,94 +690,102 @@ class PBTTuner:
         self.logger.info("Output Dir:      %s", self.output_dir)
         self.start_time = time.time()
 
-        log_section_header(self.logger, "Setting Up PostgreSQL Instances")
-        self.logger.info(
-            "Creating %d PostgreSQL instances for parallel execution...",
-            self.pbt_config.population_size
-        )
-
         try:
-            instances = self.env.setup_instances(
-                num_workers=self.pbt_config.population_size,
-                force_recreate=self.force_recreate_instances
+            log_section_header(self.logger, "Setting Up PostgreSQL Instances")
+            self.logger.info(
+                "Creating %d PostgreSQL instances for parallel execution...",
+                self.pbt_config.population_size
             )
-            self.logger.info("✓ Created %d instances", len(instances))
 
-            verification = self.env.verify_instances()
-            failed = [wid for wid, status in verification.items() if not status]
-            if failed:
-                self.logger.error("❌ Failed to verify instances: %s", failed)
-                raise RuntimeError(f"Instance verification failed for workers: {failed}")
+            try:
+                instances = self.env.setup_instances(
+                    num_workers=self.pbt_config.population_size,
+                    force_recreate=self.force_recreate_instances
+                )
+                self.logger.info("✓ Created %d instances", len(instances))
 
-            self.logger.info("✓ All instances verified and accessible\n")
-        except Exception as e:
-            self.logger.error("❌ Failed to setup instances: %s", e)
-            raise
+                verification = self.env.verify_instances()
+                failed = [wid for wid, status in verification.items() if not status]
+                if failed:
+                    self.logger.error("❌ Failed to verify instances: %s", failed)
+                    raise RuntimeError(f"Instance verification failed for workers: {failed}")
 
-        self.logger.info("Initializing population...")
-        if self.warm_start_path:
-            self.logger.debug("Warm-starting from %s", self.warm_start_path)
-            warm_configs = self._build_warm_start_configs(
-                warm_start_path=Path(self.warm_start_path),
-                population_size=self.pbt_config.population_size,
-                seed=42,
+                self.logger.info("✓ All instances verified and accessible\n")
+                self._prune_unsupported_runtime_knobs()
+            except Exception as e:
+                self.logger.error("❌ Failed to setup instances: %s", e)
+                raise
+
+            self.logger.info("Initializing population...")
+            if self.warm_start_path:
+                self.logger.debug("Warm-starting from %s", self.warm_start_path)
+                warm_configs = self._build_warm_start_configs(
+                    warm_start_path=Path(self.warm_start_path),
+                    population_size=self.pbt_config.population_size,
+                    seed=42,
+                )
+                self.population.initialize(
+                    initial_configs=warm_configs,
+                    random_seed=self.random_seed
+                )
+            else:
+                self.population.initialize(random_seed=self.random_seed)
+
+            self.logger.debug("Assigning instance configurations to workers...")
+            self.population.setup_worker_instances(
+                instances=instances,
+                dbname=self.db_config.dbname,
+                user=self.db_config.user,
+                password=self.db_config.password
             )
-            self.population.initialize(
-                initial_configs=warm_configs,
-                random_seed=self.random_seed
+            self.population.env = self.env
+            self.logger.info(
+                "✓ Initialized %d workers with dedicated instances\n",
+                len(self.population.workers)
             )
-        else:
-            self.population.initialize(random_seed=self.random_seed)
 
-        self.logger.debug("Assigning instance configurations to workers...")
-        self.population.setup_worker_instances(
-            instances=instances,
-            dbname=self.db_config.dbname,
-            user=self.db_config.user,
-            password=self.db_config.password
-        )
-        self.population.env = self.env
-        self.logger.info(
-            "✓ Initialized %d workers with dedicated instances\n",
-            len(self.population.workers)
-        )
-
-        # Register snapshot manager with population
-        if self.pbt_config.enable_snapshots:
-            self.population.setup_snapshots(
-                env=self.env,
-                pbt_config=self.pbt_config,
-            )
-            self.logger.info("✓ Snapshot restoration configured\n")
+            # Register snapshot manager with population
+            if self.pbt_config.enable_snapshots:
+                self.population.setup_snapshots(
+                    env=self.env,
+                    pbt_config=self.pbt_config,
+                )
+                self.logger.info("✓ Snapshot restoration configured\n")
 
 
-        try:
-            for generation in range(self.pbt_config.num_generations):
-                self.run_generation(generation)
+            try:
+                for generation in range(self.pbt_config.num_generations):
+                    self.run_generation(generation)
 
-                if self.population.should_stop():
-                    reason = self._get_stop_reason()
-                    self.logger.info("⚠ Early stopping triggered: %s", reason)
-                    break
+                    if self.population.should_stop():
+                        reason = self._get_stop_reason()
+                        self.logger.info("⚠ Early stopping triggered: %s", reason)
+                        break
 
-                if (generation + 1) % 5 == 0:
-                    self.save_intermediate_results(generation)
+                    if (generation + 1) % 5 == 0:
+                        self.save_intermediate_results(generation)
 
-        except KeyboardInterrupt:
-            self.logger.info("⚠ Interrupted by user. Saving results...")
+            except KeyboardInterrupt:
+                self.logger.info("⚠ Interrupted by user. Saving results...")
 
-        except (RuntimeError, ValueError) as e:
-            self.logger.error("\n❌ Error during training: %s", e)
-            self.logger.debug("Exception details:", exc_info=True)
+            except (RuntimeError, ValueError) as e:
+                self.logger.error("\n❌ Error during training: %s", e)
+                self.logger.debug("Exception details:", exc_info=True)
 
         finally:
             self.logger.info("Stopping PostgreSQL instances...")
-            self.env.stop_all()
+            try:
+                self.env.stop_all()
+            except (RuntimeError, ValueError, ConnectionError, OSError) as e:
+                self.logger.warning("⚠ Failed to stop PostgreSQL instances cleanly: %s", e)
 
             if self.cleanup_instances:
                 self.logger.info("Cleaning up environment...")
-                self.env.cleanup(remove_data=True)
-                self.logger.info("✓ Instance data removed")
+                try:
+                    self.env.cleanup(remove_data=True)
+                    self.logger.info("✓ Instance data removed")
+                except (RuntimeError, ValueError, ConnectionError, OSError) as e:
+                    self.logger.warning("⚠ Failed to clean up instance data: %s", e)
 
         total_time = time.time() - self.start_time
         results = self.save_final_results(total_time)
@@ -748,9 +842,12 @@ class PBTTuner:
                 'num_knobs': len(self.knob_space),
                 'workload_type': self.workload_type.value,
                 'benchmark_name': self.benchmark_name,
-                'scale_factor': self.pbt_config.scale_factor,
+                'tpch_scale_factor': self.pbt_config.scale_factor,
+                'tpch_warmup_passes': self.pbt_config.warmup_passes,
                 'sysbench_tables': self.pbt_config.sysbench_tables,
                 'sysbench_table_size': self.pbt_config.sysbench_table_size,
+                'sysbench_duration_seconds': self.pbt_config.evaluation_duration,
+                'sysbench_warmup_seconds': self.pbt_config.warmup_duration,
                 'population_size': self.pbt_config.population_size,
                 'total_generations': self.population.current_generation,
                 'total_time_seconds': total_time,
@@ -828,9 +925,40 @@ class PBTTuner:
         population_size: int,
         seed: int,
     ) -> List[Dict[str, Any]]:
-        """Build initial configs from a previous best_config.json."""
-        with open(Path(self.warm_start_path), 'r', encoding='utf-8') as f:  # type: ignore
-            best_config_frac = json.load(f)
+        """Build initial configs from a previous warm-start artifact.
+
+        Accepts either:
+        - ``best_config_*.json`` (flat mapping: knob -> fraction)
+        - ``pbt_results_*.json`` (nested at ``best_configuration.knobs``)
+        """
+        with open(warm_start_path, 'r', encoding='utf-8') as f:
+            warm_start_data = json.load(f)
+
+        if not isinstance(warm_start_data, dict):
+            raise ValueError(
+                "Warm-start file must be a JSON object containing knob fractions"
+            )
+
+        best_config_frac: Dict[str, Any]
+        if "best_configuration" in warm_start_data:
+            best_configuration = warm_start_data.get("best_configuration")
+            if not isinstance(best_configuration, dict):
+                raise ValueError(
+                    "Warm-start tuning session file has invalid best_configuration block"
+                )
+
+            knobs = best_configuration.get("knobs")
+            if not isinstance(knobs, dict):
+                raise ValueError(
+                    "Warm-start tuning session file is missing best_configuration.knobs"
+                )
+
+            self.logger.debug(
+                "Warm-start source detected as tuning session output; using best_configuration.knobs"
+            )
+            best_config_frac = knobs
+        else:
+            best_config_frac = warm_start_data
 
         for knob_name, knob_val in best_config_frac.items():
             if knob_name in self.knob_space.knobs:
@@ -1075,6 +1203,16 @@ on your hardware, configuration, and workload/benchmark.
     )
 
     instance_group.add_argument(
+        '--docker-image',
+        type=str,
+        default=None,
+        help=(
+            'Docker image override for PostgreSQL workers '
+            '(e.g., postgres:18). If omitted, auto-resolved from host version.'
+        )
+    )
+
+    instance_group.add_argument(
         '--force-recreate-instances',
         action='store_true',
         help='Force recreation of PostgreSQL instances (default: reuse existing)'
@@ -1124,6 +1262,12 @@ on your hardware, configuration, and workload/benchmark.
         )
     )
 
+    output_group.add_argument(
+        '--no-color',
+        action='store_true',
+        help='Disable ANSI colors in terminal logger output'
+    )
+
     return parser.parse_args()
 
 
@@ -1145,7 +1289,6 @@ def main():
 
     setup_logging(
         verbosity=args.verbose,
-        enable_colors=True,
         show_module=True,
         output_file=output_file
     )
@@ -1228,7 +1371,8 @@ def main():
             output_dir=args.output_dir,
             logger=logger,
             timestamp=timestamp,
-            no_docker=args.no_docker
+            no_docker=args.no_docker,
+            docker_image=args.docker_image,
         )
 
         tuner.run()

--- a/src/utils/environments/bare_metal.py
+++ b/src/utils/environments/bare_metal.py
@@ -16,10 +16,12 @@ import shutil
 from pathlib import Path
 from typing import List, Dict, Any
 import psycopg2
+import psutil
 
 from src.utils.environments.base import DatabaseEnvironment, InstanceConfig
 from src.tuner.evaluator.executor import BenchmarkExecutor
 from src.config.database import DatabaseConfig
+from src.database.connection import get_connection
 from src.utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -40,11 +42,30 @@ class BareMetalEnvironment(DatabaseEnvironment):
         schema_provider: BenchmarkExecutor,
         base_port: int = 5440,
         base_dir: Path = Path("./pg_instances"),
+        ram_bytes: int = 0,
+        force_recreate_baseline: bool = False,
     ):
-        super().__init__(run_id, db_config, schema_provider)
+        logger.info(
+            "Initializing BareMetalEnvironment with base_port=%d, base_dir=%s...",
+            base_port,
+            base_dir
+        )
+        super().__init__(
+            run_id,
+            db_config,
+            schema_provider,
+            force_recreate_baseline=force_recreate_baseline,
+        )
         self.base_port = base_port
         self.base_dir = base_dir
+        self.ram_bytes = ram_bytes
         self.instances: Dict[int, InstanceConfig] = {}
+
+        logger.debug(
+            "➤ Initialized BareMetalEnvironment with base_port=%d, base_dir=%s",
+            self.base_port,
+            self.base_dir
+        )
 
     def setup_instances(
             self,
@@ -60,6 +81,9 @@ class BareMetalEnvironment(DatabaseEnvironment):
             num_workers,
             force_recreate
         )
+
+        if self.force_recreate_baseline:
+            self._remove_baseline_snapshot()
 
         for worker_id in range(num_workers):
             port = self.base_port + worker_id
@@ -115,7 +139,7 @@ class BareMetalEnvironment(DatabaseEnvironment):
                 
                 # Overwrite postgresql.conf to ensure the correct port is bound natively
                 conf_path = data_dir / "postgresql.conf"
-                with open(conf_path, "a") as f:
+                with open(conf_path, "a", encoding="utf-8") as f:
                     f.write(f"\nport = {port}\n")
                     f.write("unix_socket_directories = '/tmp'\n")
                     f.write("listen_addresses = '*'\n")
@@ -128,7 +152,7 @@ class BareMetalEnvironment(DatabaseEnvironment):
                 running=False
             )
             self.instances[worker_id] = instance
-            
+
             self.start_instance(worker_id)
             self._wait_for_ready(worker_id)
 
@@ -137,9 +161,18 @@ class BareMetalEnvironment(DatabaseEnvironment):
                 logger.info("  Initializing schema for worker %d...", worker_id)
                 self.initialize_schema(worker_id)
                 if worker_id == 0:
-                    logger.debug("  Caching worker 0 baseline snapshot for fast-path initialization...")
-                    self.create_snapshot(worker_id=0)
-            
+                    baseline_snapshot = self._resolve_snapshot_path()
+                    if baseline_snapshot.exists():
+                        logger.debug(
+                            "  Baseline snapshot already exists at %s; skipping recreation",
+                            baseline_snapshot,
+                        )
+                    else:
+                        logger.debug(
+                            "  Caching worker 0 baseline snapshot for fast-path initialization..."
+                        )
+                        self.create_snapshot(worker_id=0)
+
         return list(self.instances.values())
 
     def start_instance(self, worker_id: int) -> bool:
@@ -228,13 +261,30 @@ class BareMetalEnvironment(DatabaseEnvironment):
             self.start_instance(worker_id)
             self._wait_for_ready(worker_id)
 
+    def _resolve_snapshot_path(self, snapshot_id: str = "") -> Path:
+        """Resolve a snapshot identifier to an absolute snapshot directory path."""
+        if snapshot_id:
+            return Path(snapshot_id)
+        return self.base_dir / "pg_snapshots" / self.run_id
+
+    def _remove_baseline_snapshot(self) -> None:
+        """Remove the baseline snapshot directory if it exists."""
+        baseline_snapshot = self._resolve_snapshot_path()
+        if baseline_snapshot.exists():
+            logger.info(
+                "Removing baseline snapshot at %s (force_recreate_baseline=True)",
+                baseline_snapshot,
+            )
+            shutil.rmtree(baseline_snapshot, ignore_errors=True)
+
     def create_snapshot(self, worker_id: int = 0) -> str:
         """Create a baseline snapshot from the specified worker instance using Rsync."""
-        baseline_path = self.base_dir / "pbt-snapshot-baseline"
+        baseline_path = self._resolve_snapshot_path()
 
         self.stop_instance(worker_id)
 
         # Rsync the data
+        baseline_path.parent.mkdir(parents=True, exist_ok=True)
         shutil.rmtree(baseline_path, ignore_errors=True)
         subprocess.run([
             "rsync", "-a", "--delete",
@@ -249,22 +299,19 @@ class BareMetalEnvironment(DatabaseEnvironment):
 
     def restore_snapshot(self, worker_id: int, snapshot_id: str = "") -> bool:
         """Restore a targeted worker's data directory/volume from the baseline snapshot."""
-        if not snapshot_id:
-            snapshot_id = str(self.base_dir / "pbt-snapshot-baseline")
-
-        snapshot_path = Path(snapshot_id)
+        snapshot_path = self._resolve_snapshot_path(snapshot_id)
         if not snapshot_path.exists():
-            logger.debug("  No snapshot found at %s, skipping restore", snapshot_id)
+            logger.debug("  No snapshot found at %s, skipping restore", snapshot_path)
             return False
 
         data_dir = self.instances[worker_id].data_dir
         self.stop_instance(worker_id, mode='immediate')
-        
+
         try:
             subprocess.run([
                 "rsync", "-a", "--delete",
                 "--exclude", "postgresql.conf",
-                snapshot_id + "/",
+                str(snapshot_path) + "/",
                 str(data_dir) + "/"
             ], check=True)
         except subprocess.CalledProcessError as e:
@@ -291,6 +338,47 @@ class BareMetalEnvironment(DatabaseEnvironment):
             user=self.base_config.user,
             password=self.base_config.password
         )
+
+    def collect_memory_utilization(self, worker_id: int) -> float:
+        """Collect PostgreSQL RSS utilization ratio against worker memory budget."""
+        db_config = self.get_db_config(worker_id)
+
+        try:
+            conn = get_connection(db_config, connect_timeout=5)
+            try:
+                cur = conn.cursor()
+                cur.execute("SELECT pg_backend_pid()")
+                row = cur.fetchone()
+                if row is None or row[0] is None:
+                    return 0.0
+                backend_pid = int(row[0])
+                cur.close()
+            finally:
+                conn.close()
+        except psycopg2.Error as exc:
+            logger.debug("Memory collection connect/query failed for worker %d: %s", worker_id, exc)
+            return 0.0
+
+        try:
+            backend_process = psutil.Process(backend_pid)
+            postmaster_process = backend_process.parent()
+            if postmaster_process is None:
+                return 0.0
+
+            total_rss = float(postmaster_process.memory_info().rss)
+            for proc in postmaster_process.children(recursive=True):
+                try:
+                    total_rss += float(proc.memory_info().rss)
+                except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
+                    continue
+
+            denominator = float(self.ram_bytes) if self.ram_bytes > 0 else float(psutil.virtual_memory().total)
+            if denominator <= 0.0:
+                return 0.0
+            return max(0.0, min(1.0, total_rss / denominator))
+        except (psutil.NoSuchProcess, psutil.AccessDenied, ValueError) as exc:
+            logger.debug("Memory RSS aggregation failed for worker %d: %s", worker_id, exc)
+            return 0.0
 
     def _wait_for_ready(self, worker_id: int, timeout=30) -> None:
         """Wait until PostgreSQL is accepting connections.

--- a/src/utils/environments/base.py
+++ b/src/utils/environments/base.py
@@ -11,6 +11,7 @@ from abc import ABC, abstractmethod
 from typing import Any, Dict, List
 from pathlib import Path
 from dataclasses import dataclass
+import time
 
 import psycopg2
 from psycopg2 import sql
@@ -44,7 +45,8 @@ class DatabaseEnvironment(ABC):
     def __init__(
         self, run_id: str,
         db_config: DatabaseConfig,
-        schema_provider: BenchmarkExecutor
+        schema_provider: BenchmarkExecutor,
+        force_recreate_baseline: bool = False,
     ):
         """
         Initialize the environment manager.
@@ -57,10 +59,13 @@ class DatabaseEnvironment(ABC):
             Base configuration describing the database to manage.
         schema_provider : BenchmarkExecutor
             Provider to handle database schema initialization (e.g. SysbenchExecutor).
+        force_recreate_baseline : bool
+            If True, removes and recreates the baseline snapshot before setup.
         """
         self.run_id = run_id
         self.base_config = db_config
         self.schema_provider = schema_provider
+        self.force_recreate_baseline = force_recreate_baseline
 
     def initialize_schema(self, worker_id: int) -> None:
         """
@@ -75,6 +80,7 @@ class DatabaseEnvironment(ABC):
         """
         config = self.get_db_config(worker_id)
         self._ensure_database_exists(config)
+        self._reset_persisted_configuration(worker_id, config)
 
         LOGGER.debug("    Validating schema for worker %d...", worker_id)
         if self.schema_provider.validate(config):
@@ -94,6 +100,7 @@ class DatabaseEnvironment(ABC):
         )
         if self.restore_snapshot(worker_id):
             if self.schema_provider.validate(config):
+                self._reset_persisted_configuration(worker_id, config)
                 LOGGER.debug(
                     "%s    ➤ Schema restored from snapshot for worker %d%s",
                     ColorCode.OKGREEN,
@@ -150,6 +157,68 @@ class DatabaseEnvironment(ABC):
         except psycopg2.Error as e:
             LOGGER.error("Failed to ensure database '%s' exists: %s", config.dbname, e)
 
+    def _wait_until_connectable(self, config: DatabaseConfig, timeout_seconds: int = 30) -> bool:
+        """Wait for PostgreSQL to accept connections after restart operations."""
+        deadline = time.time() + timeout_seconds
+        while time.time() < deadline:
+            try:
+                conn = get_connection(config=config, connect_timeout=2)
+                conn.close()
+                return True
+            except (RuntimeError, psycopg2.Error):
+                time.sleep(0.5)
+        return False
+
+    def _reset_persisted_configuration(self, worker_id: int, config: DatabaseConfig) -> None:
+        """Clear persisted ALTER SYSTEM settings and restart if pending_restart remains."""
+        conn = None
+        cursor = None
+        pending_restart_count = 0
+        try:
+            conn = get_connection(config=config, connect_timeout=5)
+            conn.autocommit = True
+            cursor = conn.cursor()
+            cursor.execute("ALTER SYSTEM RESET ALL")
+            cursor.execute("SELECT pg_reload_conf()")
+            cursor.execute("SELECT count(*) FROM pg_settings WHERE pending_restart")
+            row = cursor.fetchone()
+            pending_restart_count = int(row[0]) if row and row[0] is not None else 0
+        except (RuntimeError, psycopg2.Error, ValueError) as exc:
+            LOGGER.warning(
+                "Failed to reset persisted configuration for worker %d: %s",
+                worker_id,
+                exc,
+            )
+            return
+        finally:
+            if cursor is not None:
+                cursor.close()
+            if conn is not None:
+                conn.close()
+
+        if pending_restart_count <= 0:
+            return
+
+        if not self.stop_instance(worker_id):
+            LOGGER.warning(
+                "Failed to stop worker %d during persisted configuration reset",
+                worker_id,
+            )
+            return
+
+        if not self.start_instance(worker_id):
+            LOGGER.warning(
+                "Failed to restart worker %d during persisted configuration reset",
+                worker_id,
+            )
+            return
+
+        if not self._wait_until_connectable(config):
+            LOGGER.warning(
+                "Worker %d did not become connectable after persisted configuration reset",
+                worker_id,
+            )
+
     @abstractmethod
     def setup_instances(
         self,
@@ -198,3 +267,7 @@ class DatabaseEnvironment(ABC):
     @abstractmethod
     def get_db_config(self, worker_id: int) -> DatabaseConfig:
         """Get the runtime connection configuration for a defined worker."""
+
+    @abstractmethod
+    def collect_memory_utilization(self, worker_id: int) -> float:
+        """Collect per-worker PostgreSQL memory utilization as a [0, 1] ratio."""

--- a/src/utils/environments/docker.py
+++ b/src/utils/environments/docker.py
@@ -14,11 +14,16 @@ Responsibilities:
 """
 
 import time
+import hashlib
+import json
+import re
+from datetime import datetime, timezone
 from contextlib import contextmanager
 from typing import Optional, List, Dict, Any
 from pathlib import Path
 
 import psycopg2
+import requests
 
 from src.utils.environments.base import DatabaseEnvironment, InstanceConfig
 from src.utils.applicator import KnobApplicator, ApplicatorConfig
@@ -53,12 +58,18 @@ class DockerEnvironment(DatabaseEnvironment):
         schema_provider: BenchmarkExecutor,
         cpu_cores: float = 0.0,
         ram_bytes: int = 0,
-        image_name: str = "postgres:17",
+        image_name: str = "postgres:18",
         base_port: int = 5440,
         base_dir: Path = Path("./pg_instances"),
         container_prefix: str = "pbt-worker",
+        force_recreate_baseline: bool = False,
     ):
-        super().__init__(run_id, db_config, schema_provider)
+        super().__init__(
+            run_id,
+            db_config,
+            schema_provider,
+            force_recreate_baseline=force_recreate_baseline,
+        )
         self.cpu_cores = cpu_cores
         self.ram_bytes = ram_bytes
         self.image_name = image_name
@@ -69,19 +80,259 @@ class DockerEnvironment(DatabaseEnvironment):
         self.client = docker.from_env(timeout=30)
         self.instances: Dict[int, InstanceConfig] = {}
         self._snapshot_timeout = self._derive_snapshot_timeout()
+        self._ready_timeout = 60
+        self._restore_ready_timeout = self._derive_restore_ready_timeout()
+        self._restore_api_timeout = self._derive_restore_api_timeout()
 
         # Ensure network exists
         self.network_name = "pbt-network"
         try:
             self.client.networks.get(self.network_name)
         except docker.errors.NotFound:
-            LOGGER.info("Creating Docker network '%s'", self.network_name)
+            LOGGER.info("Creating Docker network '%s'...", self.network_name)
             self.client.networks.create(self.network_name, driver="bridge")
             LOGGER.debug("➤ Network '%s' created successfully", self.network_name)
 
     def _container_name(self, worker_id: int) -> str:
         """Build the Docker container name for a worker."""
         return f"{self.container_prefix}-{worker_id}"
+
+    def _pgdata_volume_name(self, worker_id: int) -> str:
+        """Build a deterministic Docker volume name for a worker's PGDATA."""
+        return f"{self._container_name(worker_id)}-pgdata"
+
+    def _worker_port(self, worker_id: int) -> int:
+        """Resolve a worker's host port."""
+        return self.base_port + worker_id
+
+    def _container_runtime_kwargs(
+        self,
+        worker_id: int,
+        volumes: Optional[Dict[str, Dict[str, str]]] = None,
+    ) -> Dict[str, Any]:
+        """Build runtime kwargs shared across worker container launches."""
+        kwargs: Dict[str, Any] = {
+            "environment": {
+                'POSTGRES_USER': self.base_config.user,
+                'POSTGRES_PASSWORD': self.base_config.password,
+                'POSTGRES_DB': self.base_config.dbname,
+                'PGDATA': '/pgdata/data',
+            },
+            "ports": {'5432/tcp': self._worker_port(worker_id)},
+            "mem_limit": self.ram_bytes if self.ram_bytes > 0 else None,
+            "nano_cpus": int(self.cpu_cores * 1e9) if self.cpu_cores > 0 else None,
+            "network": self.network_name,
+            "detach": True,
+        }
+
+        if volumes is not None:
+            kwargs["volumes"] = volumes
+
+        return kwargs
+
+    def _remove_worker_container(self, worker_id: int, purpose: str) -> bool:
+        """Remove an existing worker container if present."""
+        container_name = self._container_name(worker_id)
+        try:
+            old_container = self.client.containers.get(container_name)
+            old_container.remove(force=True)
+        except docker.errors.NotFound:
+            return True
+        except docker.errors.DockerException as exc:
+            LOGGER.error(
+                "Failed removing worker container '%s' during %s: %s",
+                container_name,
+                purpose,
+                exc,
+            )
+            return False
+        return True
+
+    def _recreate_worker_pgdata_volume(self, worker_id: int) -> Optional[str]:
+        """Replace worker-specific PGDATA volume with a fresh volume."""
+        volume_name = self._pgdata_volume_name(worker_id)
+        try:
+            try:
+                existing_volume = self.client.volumes.get(volume_name)
+                existing_volume.remove(force=True)
+            except docker.errors.NotFound:
+                pass
+
+            self.client.volumes.create(name=volume_name)
+            return volume_name
+        except docker.errors.DockerException as exc:
+            LOGGER.error(
+                "Failed preparing fresh PGDATA volume '%s' for worker %d: %s",
+                volume_name,
+                worker_id,
+                exc,
+            )
+            return None
+
+    def _ensure_container_running_after_timeout(
+        self,
+        worker_id: int,
+        action_label: str,
+    ) -> bool:
+        """Recover from Docker client timeout by checking container state."""
+        container_name = self._container_name(worker_id)
+        try:
+            container = self.client.containers.get(container_name)
+            container.reload()
+            if container.status != 'running':
+                container.start()
+            return True
+        except docker.errors.DockerException as state_exc:
+            LOGGER.error(
+                "Container '%s' unavailable after %s timeout: %s",
+                container_name,
+                action_label,
+                state_exc,
+            )
+            return False
+
+    def _launch_worker_container(
+        self,
+        image_name: str,
+        worker_id: int,
+        action_label: str,
+        volumes: Optional[Dict[str, Dict[str, str]]] = None,
+        timeout: Optional[int] = None,
+    ) -> tuple[bool, Optional[Exception]]:
+        """Launch a worker container with shared timeout + recovery handling."""
+        container_name = self._container_name(worker_id)
+        kwargs = self._container_runtime_kwargs(worker_id=worker_id, volumes=volumes)
+
+        try:
+            with self._with_timeout(timeout):
+                self.client.containers.run(
+                    image_name,
+                    name=container_name,
+                    **kwargs,
+                )
+            return True, None
+        except requests.exceptions.ReadTimeout as exc:
+            LOGGER.warning(
+                "Docker timed out %s '%s'; checking container state: %s",
+                action_label,
+                container_name,
+                exc,
+            )
+            recovered = self._ensure_container_running_after_timeout(
+                worker_id=worker_id,
+                action_label=action_label,
+            )
+            return recovered, (None if recovered else exc)
+        except docker.errors.DockerException as exc:
+            LOGGER.error(
+                "Failed %s '%s' for worker %d: %s",
+                action_label,
+                container_name,
+                worker_id,
+                exc,
+            )
+            return False, exc
+
+    def _seed_pgdata_volume_from_snapshot(
+        self,
+        worker_id: int,
+        snapshot_id: str,
+    ) -> Optional[str]:
+        """Create a fresh PGDATA volume and seed it from a snapshot image.
+
+        Restored workers should run on a Docker volume-backed PGDATA directory
+        instead of the snapshot image writable layer. This avoids overlayfs write
+        amplification and keeps runtime I/O paths consistent across restarts.
+        """
+        volume_name = self._recreate_worker_pgdata_volume(worker_id)
+        if not volume_name:
+            return None
+
+        try:
+            with self._with_timeout(self._restore_api_timeout):
+                self.client.containers.run(
+                    snapshot_id,
+                    entrypoint=["bash", "-lc"],
+                    command="set -euo pipefail; cp -a /pgdata/data/. /pgseed/",
+                    volumes={volume_name: {"bind": "/pgseed", "mode": "rw"}},
+                    remove=True,
+                    detach=False,
+                )
+
+            return volume_name
+        except docker.errors.DockerException as exc:
+            LOGGER.error(
+                "Failed to seed PGDATA volume '%s' from snapshot '%s': %s",
+                volume_name,
+                snapshot_id,
+                exc,
+            )
+            return None
+
+    def rebuild_worker_instance(self, worker_id: int) -> bool:
+        """Recreate one worker from scratch after snapshot restore failure.
+
+        This path mirrors startup-style clean initialization: remove worker
+        container + PGDATA volume, launch from base PostgreSQL image, then
+        prepare schema for the configured benchmark profile.
+        """
+        container_name = self._container_name(worker_id)
+        port = self._worker_port(worker_id)
+
+        LOGGER.error(
+            "Snapshot restore failed for worker %d; rebuilding clean slate instance",
+            worker_id,
+        )
+
+        if not self._remove_worker_container(worker_id=worker_id, purpose="rebuild"):
+            return False
+
+        volume_name = self._recreate_worker_pgdata_volume(worker_id)
+        if not volume_name:
+            return False
+
+        volumes = {volume_name: {'bind': '/pgdata/data', 'mode': 'rw'}}
+        launched, _ = self._launch_worker_container(
+            image_name=self.image_name,
+            worker_id=worker_id,
+            action_label="creating clean-slate worker",
+            volumes=volumes,
+            timeout=self._restore_api_timeout,
+        )
+        if not launched:
+            return False
+
+        try:
+            self._wait_for_ready(
+                container_name,
+                port,
+                timeout=self._restore_ready_timeout,
+                context="clean-rebuild",
+            )
+
+            config = self.get_db_config(worker_id)
+            self._ensure_database_exists(config)
+            self.schema_provider.prepare(config)
+
+            if not self.schema_provider.validate(config):
+                LOGGER.error(
+                    "Schema validation failed after clean-slate rebuild for worker %d",
+                    worker_id,
+                )
+                return False
+
+            if worker_id in self.instances:
+                self.instances[worker_id].running = True
+
+            LOGGER.info("Clean-slate rebuild completed for worker %d", worker_id)
+            return True
+        except (RuntimeError, psycopg2.Error, OSError, ValueError, docker.errors.DockerException) as exc:
+            LOGGER.error(
+                "Clean-slate rebuild failed for worker %d: %s",
+                worker_id,
+                exc,
+            )
+            return False
 
     def setup_instances(
             self,
@@ -100,28 +351,51 @@ class DockerEnvironment(DatabaseEnvironment):
             ColorCode.RESET
         )
 
+        if self.force_recreate_baseline:
+            self._remove_baseline_snapshot()
+
+        baseline_snapshot_available = bool(
+            self.schema_provider and self.snapshot_exists(worker_id=0)
+        )
+
         for worker_id in range(num_workers):
-            port = self.base_port + worker_id
+            port = self._worker_port(worker_id)
             container_name = self._container_name(worker_id)
             LOGGER.info("  Setting up container '%s' on port %d:", container_name, port)
 
-            if force_recreate:
-                try:
-                    LOGGER.debug("    Removing existing container '%s'...", container_name)
-                    c = self.client.containers.get(container_name)
-                    c.remove(force=True)
+            recreate_worker0_for_baseline = (
+                worker_id == 0
+                and self.schema_provider is not None
+                and not force_recreate
+                and not baseline_snapshot_available
+            )
 
-                    LOGGER.debug(
-                        "%s    ➤ Container '%s' removed successfully%s",
-                        ColorCode.OKGREEN,
-                        container_name,
-                        ColorCode.RESET
+            if force_recreate:
+                LOGGER.debug("    Removing existing container '%s'...", container_name)
+                if not self._remove_worker_container(
+                    worker_id=worker_id,
+                    purpose="forced recreate",
+                ):
+                    raise RuntimeError(
+                        f"Failed to remove container '{container_name}' during forced recreate"
                     )
-                except docker.errors.NotFound:
-                    pass
+
+                LOGGER.debug(
+                    "%s    ➤ Container '%s' removed successfully%s",
+                    ColorCode.OKGREEN,
+                    container_name,
+                    ColorCode.RESET
+                )
 
             try:  # Exists already
                 container = self.client.containers.get(container_name)
+                if recreate_worker0_for_baseline:
+                    LOGGER.debug(
+                        "    Recreating existing worker-0 container because baseline snapshot is missing"
+                    )
+                    container.remove(force=True)
+                    raise docker.errors.NotFound("recreate worker-0 for baseline")
+
                 if container.status != 'running':
                     LOGGER.debug("    Starting stopped container '%s'...", container_name)
                     container.start()
@@ -134,32 +408,18 @@ class DockerEnvironment(DatabaseEnvironment):
                     ColorCode.RESET
                 )
             except docker.errors.NotFound:  # Create it
-                volumes: Dict[str, Dict[str, str]] = {}
-                environment = {
-                    'POSTGRES_USER': self.base_config.user,
-                    'POSTGRES_PASSWORD': self.base_config.password,
-                    'POSTGRES_DB': self.base_config.dbname,
-                    'PGDATA': '/pgdata/data',
-                }
-                ports = {'5432/tcp': port}
-
-                nano_cpus = int(self.cpu_cores * 1e9) if self.cpu_cores > 0 else None
-
                 LOGGER.debug("    Creating container '%s'...", container_name)
-                try:
-                    self.client.containers.run(
-                        self.image_name,
-                        name=container_name,
-                        environment=environment,
-                        ports=ports,
-                        volumes=volumes,
-                        mem_limit=self.ram_bytes if self.ram_bytes > 0 else None,
-                        nano_cpus=nano_cpus,
-                        network=self.network_name,
-                        detach=True
-                    )
-                except docker.errors.APIError as e:
-                    raise RuntimeError(f"Failed to create container '{container_name}'") from e
+                launched, launch_error = self._launch_worker_container(
+                    image_name=self.image_name,
+                    worker_id=worker_id,
+                    action_label="creating worker container",
+                    volumes={},
+                    timeout=self._ready_timeout,
+                )
+                if not launched:
+                    raise RuntimeError(
+                        f"Failed to create container '{container_name}'"
+                    ) from launch_error
 
                 running = True
                 LOGGER.debug(
@@ -169,13 +429,13 @@ class DockerEnvironment(DatabaseEnvironment):
                     ColorCode.RESET
                 )
 
-            self._wait_for_ready(container_name, port)
             self.instances[worker_id] = InstanceConfig(
                 worker_id=worker_id,
                 port=port,
                 data_dir=self.base_dir / f"worker_{worker_id}",
                 running=running
             )
+            self._wait_for_ready(container_name, port)
 
             # Auto-initialize schema natively and leverage snapshots to accelerate parallel workers
             if self.schema_provider:
@@ -183,13 +443,15 @@ class DockerEnvironment(DatabaseEnvironment):
                 self.initialize_schema(worker_id)
 
                 if worker_id == 0:
-                    if self.snapshot_exists(worker_id=0):
+                    baseline_snapshot_available = self.snapshot_exists(worker_id=0)
+                    if baseline_snapshot_available:
                         LOGGER.debug("    Baseline snapshot already exists; skipping snapshot creation")
                     else:
                         LOGGER.debug(
                             "    Caching worker 0 baseline snapshot for fast-path initialization...",
                         )
                         self.create_snapshot(worker_id=0)
+                        baseline_snapshot_available = True
 
             LOGGER.debug(
                 "%s  ➤ Container '%s' set up successfully.%s",
@@ -214,9 +476,25 @@ class DockerEnvironment(DatabaseEnvironment):
         try:
             container = self.client.containers.get(container_name)
             container.start()
-            self.instances[worker_id].running = True
+            if worker_id in self.instances:
+                self.instances[worker_id].running = True
             return True
-        except docker.errors.APIError:
+        except docker.errors.DockerException as exc:
+            LOGGER.warning(
+                "Failed to start container '%s' for worker %d: %s",
+                container_name,
+                worker_id,
+                exc,
+            )
+            return False
+        except (requests.exceptions.RequestException, TimeoutError, OSError) as exc:
+            LOGGER.warning(
+                "Unexpected error while starting container '%s' for worker %d: %s",
+                container_name,
+                worker_id,
+                exc,
+                exc_info=True,
+            )
             return False
 
     def stop_instance(self, worker_id: int, mode: str = 'fast') -> bool:
@@ -225,20 +503,81 @@ class DockerEnvironment(DatabaseEnvironment):
         try:
             container = self.client.containers.get(container_name)
             container.stop(timeout=5)
-            self.instances[worker_id].running = False
+            if worker_id in self.instances:
+                self.instances[worker_id].running = False
             return True
-        except docker.errors.APIError:
+        except docker.errors.DockerException as exc:
+            LOGGER.warning(
+                "Failed to stop container '%s' for worker %d: %s",
+                container_name,
+                worker_id,
+                exc,
+            )
+            return False
+        except (requests.exceptions.RequestException, TimeoutError, OSError) as exc:
+            LOGGER.warning(
+                "Unexpected error while stopping container '%s' for worker %d: %s",
+                container_name,
+                worker_id,
+                exc,
+                exc_info=True,
+            )
             return False
 
     def stop_all(self, mode: str = 'fast') -> bool:
-        """Stop all known worker containers."""
-        for worker_id in self.instances:
+        """Stop all running containers associated with this environment."""
+        for worker_id in list(self.instances):
             self.stop_instance(worker_id, mode)
+
+        managed_name_pattern = re.compile(
+            rf"^{re.escape(self.container_prefix)}-\d+$"
+        )
+        try:
+            for container in self.client.containers.list(all=False):
+                container_name = getattr(container, "name", "")
+                if not managed_name_pattern.match(container_name):
+                    continue
+                try:
+                    container.stop(timeout=5)
+                except (
+                    docker.errors.DockerException,
+                    requests.exceptions.RequestException,
+                    TimeoutError,
+                    OSError,
+                ) as exc:
+                    LOGGER.debug(
+                        "Failed to stop container '%s' during stop_all: %s",
+                        container_name,
+                        exc,
+                    )
+        except (
+            docker.errors.DockerException,
+            requests.exceptions.RequestException,
+            TimeoutError,
+            OSError,
+        ) as exc:
+            LOGGER.debug("Unable to list running Docker containers during stop_all: %s", exc)
+
         return True
 
     def recover_instance(self, worker_id: int) -> bool:
         """Restart a failed container."""
-        return self.start_instance(worker_id)
+        try:
+            return self.start_instance(worker_id)
+        except (
+            docker.errors.DockerException,
+            requests.exceptions.RequestException,
+            TimeoutError,
+            OSError,
+            RuntimeError,
+        ) as exc:
+            LOGGER.warning(
+                "Unexpected error while recovering worker %d: %s",
+                worker_id,
+                exc,
+                exc_info=True,
+            )
+            return False
 
     def verify_instances(self) -> dict[int, bool]:
         """Check status of containers."""
@@ -249,19 +588,43 @@ class DockerEnvironment(DatabaseEnvironment):
                 container = self.client.containers.get(container_name)
                 res[worker_id] = container.status == 'running'
                 instance_config.running = res[worker_id]
-            except docker.errors.NotFound:
+            except (
+                docker.errors.DockerException,
+                requests.exceptions.RequestException,
+                TimeoutError,
+                OSError,
+            ) as exc:
                 res[worker_id] = False
+                instance_config.running = False
+                LOGGER.debug(
+                    "Unable to verify container '%s' for worker %d: %s",
+                    container_name,
+                    worker_id,
+                    exc,
+                )
         return res
 
     def cleanup(self, remove_data: bool = False) -> None:
         """Remove containers."""
-        for worker_id in self.instances:
+        for worker_id in list(self.instances):
             container_name = self._container_name(worker_id)
             try:
                 container = self.client.containers.get(container_name)
                 container.remove(force=True)
             except docker.errors.NotFound:
-                pass
+                continue
+            except (
+                docker.errors.DockerException,
+                requests.exceptions.RequestException,
+                TimeoutError,
+                OSError,
+            ) as exc:
+                LOGGER.debug(
+                    "Unable to remove container '%s' for worker %d during cleanup: %s",
+                    container_name,
+                    worker_id,
+                    exc,
+                )
         self.instances.clear()
 
     def apply_knobs(self, worker_id: int, knobs: Dict[str, Any]) -> None:
@@ -319,35 +682,215 @@ class DockerEnvironment(DatabaseEnvironment):
             return None
         return 120
 
+    def _derive_restore_ready_timeout(self) -> int:
+        """Derive startup timeout after snapshot restore.
+
+        Restoring from an image snapshot can trigger WAL replay/recovery,
+        especially for larger OLAP datasets. Keep normal startup strict,
+        but allow longer readiness for restore paths.
+        """
+        from src.benchmarks.tpch.executor import TPCHExecutor
+        if isinstance(self.schema_provider, TPCHExecutor):
+            return 240
+        return 90
+
+    def _derive_restore_api_timeout(self) -> Optional[int]:
+        """Derive Docker API timeout used by snapshot restore operations.
+
+        Snapshot restore can involve slow container creation on busy daemons.
+        Keep a longer timeout for Sysbench and disable timeout for TPC-H,
+        where larger images/volumes can exceed fixed API time budgets.
+        """
+        from src.benchmarks.tpch.executor import TPCHExecutor
+        if isinstance(self.schema_provider, TPCHExecutor):
+            return None
+        return 180
+
+    def _checkpoint_instance(self, worker_id: int) -> None:
+        """Issue a CHECKPOINT before snapshot creation to reduce recovery time on restore."""
+        db_config = self.get_db_config(worker_id)
+        conn = None
+        cursor = None
+        try:
+            conn = get_connection(config=db_config, connect_timeout=5)
+            cursor = conn.cursor()
+            cursor.execute("CHECKPOINT")
+            conn.commit()
+        except (psycopg2.Error, RuntimeError, OSError, ValueError) as exc:
+            LOGGER.warning(
+                "Failed to issue CHECKPOINT before snapshot for worker %d: %s",
+                worker_id,
+                exc,
+            )
+        finally:
+            if cursor is not None:
+                cursor.close()
+            if conn is not None:
+                conn.close()
+
+    def _snapshot_profile_context(self) -> Dict[str, Any]:
+        """Build a stable benchmark-profile payload used for snapshot identity."""
+        provider = self.schema_provider
+        provider_name = f"{provider.__class__.__module__}.{provider.__class__.__name__}"
+
+        context: Dict[str, Any] = {
+            "provider": provider_name,
+        }
+        for attribute in ("tables", "table_size", "num_tables", "scale_factor", "script"):
+            if not hasattr(provider, attribute):
+                continue
+            value = getattr(provider, attribute)
+            if isinstance(value, (str, int, float, bool)) or value is None:
+                context[attribute] = value
+
+        return context
+
+    def _snapshot_profile_signature(self) -> str:
+        """Compute a compact signature for the current benchmark schema profile."""
+        profile_payload = json.dumps(
+            self._snapshot_profile_context(),
+            sort_keys=True,
+            separators=(",", ":"),
+            default=str,
+        )
+        return hashlib.sha1(profile_payload.encode("utf-8")).hexdigest()[:12]
+
+    def _default_snapshot_id(self) -> str:
+        """Build a Docker-safe snapshot repository name for this run + profile."""
+        run_slug = re.sub(r"[^a-z0-9_.-]+", "-", self.run_id.lower()).strip("-")
+        if not run_slug:
+            run_slug = "default"
+        return f"pbt-snapshot-{run_slug}-{self._snapshot_profile_signature()}"
+
+    def _snapshot_manifest_path(self) -> Path:
+        """Path to snapshot metadata persisted in the project tree."""
+        return self.base_dir / "pg_snapshots" / f"{self._default_snapshot_id()}.json"
+
+    def _write_snapshot_manifest(self, snapshot_id: str, image_id: str) -> None:
+        """Persist snapshot metadata for traceability within the project workspace."""
+        manifest_path = self._snapshot_manifest_path()
+        manifest_path.parent.mkdir(parents=True, exist_ok=True)
+
+        payload = {
+            "snapshot_id": snapshot_id,
+            "image_id": image_id,
+            "run_id": self.run_id,
+            "base_image": self.image_name,
+            "profile_signature": self._snapshot_profile_signature(),
+            "profile_context": self._snapshot_profile_context(),
+            "created_at_utc": datetime.now(tz=timezone.utc).isoformat(),
+        }
+        manifest_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+    def _read_snapshot_manifest(self) -> Optional[Dict[str, Any]]:
+        """Load snapshot metadata manifest, returning None when missing or invalid."""
+        manifest_path = self._snapshot_manifest_path()
+        if not manifest_path.exists():
+            return None
+
+        try:
+            return json.loads(manifest_path.read_text(encoding="utf-8"))
+        except (OSError, TypeError, ValueError) as exc:
+            LOGGER.debug("Snapshot manifest '%s' is unreadable: %s", manifest_path, exc)
+            return None
+
+    def _remove_snapshot_manifest(self) -> None:
+        """Remove local snapshot metadata manifest if present."""
+        manifest_path = self._snapshot_manifest_path()
+        if manifest_path.exists():
+            manifest_path.unlink()
+
+    def _remove_baseline_snapshot(self) -> None:
+        """Remove existing baseline snapshot image and metadata."""
+        snapshot_id = self._default_snapshot_id()
+        try:
+            snapshot_image = self.client.images.get(snapshot_id)
+            LOGGER.info(
+                "Removing baseline Docker snapshot '%s' (force_recreate_baseline=True)",
+                snapshot_id,
+            )
+            self.client.images.remove(snapshot_image.id, force=True)
+        except docker.errors.ImageNotFound:
+            pass
+        except docker.errors.APIError as exc:
+            LOGGER.warning("Failed removing snapshot image '%s': %s", snapshot_id, exc)
+
+        self._remove_snapshot_manifest()
+
     def create_snapshot(self, worker_id: int = 0) -> str:
         """Create a baseline snapshot from the specified worker instance using Docker Commit."""
         container_name = self._container_name(worker_id)
-        snapshot_id = f"pbt-snapshot-{self.run_id}"
+        snapshot_id = self._default_snapshot_id()
+        port = self.base_port + worker_id
         try:
             container = self.client.containers.get(container_name)
+            self._checkpoint_instance(worker_id)
+
+            # Commit an exited container so the snapshot restores from a clean shutdown state
+            # and avoids unnecessary crash-recovery startup penalties.
+            container.reload()
+            if container.status == "running":
+                container.stop(timeout=45)
+
+            container = self.client.containers.get(container_name)
             with self._with_timeout(self._snapshot_timeout):
-                container.commit(repository=snapshot_id)
+                snapshot_image = container.commit(repository=snapshot_id, pause=False)
+
+            container.start()
+            self._wait_for_ready(
+                container_name,
+                port,
+                timeout=self._ready_timeout,
+                context="snapshot-post-start",
+            )
+
+            image_id = getattr(snapshot_image, "id", "")
+            self._write_snapshot_manifest(snapshot_id=snapshot_id, image_id=image_id)
             return snapshot_id
-        except docker.errors.APIError as e:
+        except (docker.errors.DockerException, RuntimeError) as e:
             LOGGER.error("Failed to create snapshot from %s: %s", container_name, e)
             return ""
 
     def snapshot_exists(self, worker_id: int = 0) -> bool:
         """Check whether the baseline snapshot image already exists."""
         del worker_id  # Snapshot identity is run-scoped, not worker-scoped.
-        snapshot_id = f"pbt-snapshot-{self.run_id}"
+        snapshot_id = self._default_snapshot_id()
         try:
             self.client.images.get(snapshot_id)
-            return True
         except docker.errors.ImageNotFound:
             return False
         except docker.errors.APIError:
             return False
 
+        manifest = self._read_snapshot_manifest()
+        if manifest is None:
+            LOGGER.debug(
+                "Snapshot image '%s' exists but manifest is missing/invalid; treating as stale",
+                snapshot_id,
+            )
+            return False
+
+        expected_signature = self._snapshot_profile_signature()
+        manifest_snapshot_id = str(manifest.get("snapshot_id", ""))
+        manifest_signature = str(manifest.get("profile_signature", ""))
+
+        if manifest_snapshot_id != snapshot_id or manifest_signature != expected_signature:
+            LOGGER.debug(
+                "Snapshot '%s' manifest mismatch (manifest_snapshot_id=%s, "
+                "manifest_signature=%s, expected_signature=%s); treating as stale",
+                snapshot_id,
+                manifest_snapshot_id,
+                manifest_signature,
+                expected_signature,
+            )
+            return False
+
+        return True
+
     def restore_snapshot(self, worker_id: int, snapshot_id: str = "") -> bool:
         """Restore a targeted worker's data directory/volume from the baseline snapshot."""
         if not snapshot_id:
-            snapshot_id = f"pbt-snapshot-{self.run_id}"
+            snapshot_id = self._default_snapshot_id()
 
         try:
             self.client.images.get(snapshot_id)
@@ -356,40 +899,41 @@ class DockerEnvironment(DatabaseEnvironment):
             return False
 
         container_name = self._container_name(worker_id)
-        port = self.base_port + worker_id
+        port = self._worker_port(worker_id)
 
         # Stop and remove current container
-        try:
-            old_c = self.client.containers.get(container_name)
-            old_c.remove(force=True)
-        except docker.errors.NotFound:
-            pass
+        if not self._remove_worker_container(worker_id=worker_id, purpose="snapshot restore"):
+            return False
 
-        environment = {
-            'POSTGRES_USER': self.base_config.user,
-            'POSTGRES_PASSWORD': self.base_config.password,
-            'POSTGRES_DB': self.base_config.dbname,
-            'PGDATA': '/pgdata/data',
-        }
-        ports = {'5432/tcp': port}
-        nano_cpus = int(self.cpu_cores * 1e9) if self.cpu_cores > 0 else None
+        volume_name = self._seed_pgdata_volume_from_snapshot(
+            worker_id=worker_id,
+            snapshot_id=snapshot_id,
+        )
+        if not volume_name:
+            return False
+
+        volumes = {volume_name: {'bind': '/pgdata/data', 'mode': 'rw'}}
+        launched, _ = self._launch_worker_container(
+            image_name=snapshot_id,
+            worker_id=worker_id,
+            action_label="creating snapshot-restored worker",
+            volumes=volumes,
+            timeout=self._restore_api_timeout,
+        )
+        if not launched:
+            return False
 
         try:
-            self.client.containers.run(
-                snapshot_id,
-                name=container_name,
-                environment=environment,
-                ports=ports,
-                mem_limit=self.ram_bytes if self.ram_bytes > 0 else None,
-                nano_cpus=nano_cpus,
-                network=self.network_name,
-                detach=True
+            self._wait_for_ready(
+                container_name,
+                port,
+                timeout=self._restore_ready_timeout,
+                context="snapshot-restore",
             )
-            self._wait_for_ready(container_name, port)
             if worker_id in self.instances:
                 self.instances[worker_id].running = True
             return True
-        except Exception as e:
+        except (docker.errors.DockerException, RuntimeError) as e:
             LOGGER.error("Failed to restore snapshot to %s: %s", container_name, e)
             return False
 
@@ -404,7 +948,34 @@ class DockerEnvironment(DatabaseEnvironment):
             password=self.base_config.password
         )
 
-    def _wait_for_ready(self, container_name: str, port: int, timeout=60) -> None:
+    def collect_memory_utilization(self, worker_id: int) -> float:
+        """Collect container memory utilization ratio using cgroup usage/limit."""
+        container_name = self._container_name(worker_id)
+        try:
+            container = self.client.containers.get(container_name)
+            stats = container.stats(stream=False)
+        except (docker.errors.NotFound, docker.errors.APIError) as exc:
+            LOGGER.debug("Unable to collect Docker memory stats for %s: %s", container_name, exc)
+            return 0.0
+
+        try:
+            memory_stats = stats.get("memory_stats", {})
+            usage = float(memory_stats.get("usage", 0.0))
+            limit = float(memory_stats.get("limit", 0.0))
+            if limit <= 0.0:
+                return 0.0
+            return max(0.0, min(1.0, usage / limit))
+        except (TypeError, ValueError) as exc:
+            LOGGER.debug("Invalid Docker memory stats payload for %s: %s", container_name, exc)
+            return 0.0
+
+    def _wait_for_ready(
+        self,
+        container_name: str,
+        port: int,
+        timeout: int = 60,
+        context: str = "startup",
+    ) -> None:
         """Wait until PostgreSQL is accepting connections."""
         active_config = DatabaseConfig(
             host="127.0.0.1",
@@ -434,6 +1005,17 @@ class DockerEnvironment(DatabaseEnvironment):
             except psycopg2.OperationalError:
                 time.sleep(1)
 
+        log_excerpt = ""
+        try:
+            container = self.client.containers.get(container_name)
+            raw_logs = container.logs(tail=80)
+            decoded_logs = raw_logs.decode("utf-8", errors="replace")
+            if decoded_logs.strip():
+                log_excerpt = "\nRecent container logs:\n" + decoded_logs
+        except docker.errors.DockerException:
+            pass
+
         raise RuntimeError(
-            f"Database in container {container_name} failed to become ready within {timeout}s."
+            f"Database in container {container_name} failed to become ready "
+            f"within {timeout}s during {context}.{log_excerpt}"
         )

--- a/src/utils/environments/factory.py
+++ b/src/utils/environments/factory.py
@@ -8,6 +8,8 @@ to BareMetalEnvironment if Docker is unavailable or explicitly disabled
 via the `--no-docker` flag.
 """
 
+import os
+import re
 from typing import Optional, Any
 from pathlib import Path
 
@@ -19,12 +21,50 @@ from src.utils.environments.docker import DockerEnvironment
 from src.utils.environments.bare_metal import BareMetalEnvironment
 from src.tuner.evaluator.executor import BenchmarkExecutor
 from src.config.database import DatabaseConfig
+from src.utils.hardware_info import detect_pg_version
 
 logger = get_logger(__name__)
 
 
 class EnvironmentFactory:
     """Factory for creating execution environments."""
+
+    @staticmethod
+    def _extract_pg_major(version_output: str) -> Optional[str]:
+        """Extract major PostgreSQL version from version command output."""
+        match = re.search(r"(\d+)(?:\.\d+)?", version_output)
+        if not match:
+            return None
+        return match.group(1)
+
+    @staticmethod
+    def _resolve_docker_image(image_name: Optional[str]) -> str:
+        """Resolve Docker image in priority order: CLI arg, env var, host version, fallback."""
+        if image_name:
+            return image_name
+
+        env_image = os.getenv("PBT_POSTGRES_IMAGE")
+        if env_image:
+            return env_image
+
+        detected_version = detect_pg_version()
+        major = EnvironmentFactory._extract_pg_major(detected_version)
+        if major:
+            resolved = f"postgres:{major}"
+            logger.info(
+                "Resolved Docker PostgreSQL image '%s' from host version '%s'",
+                resolved,
+                detected_version,
+            )
+            return resolved
+
+        fallback = "postgres:18"
+        logger.warning(
+            "Could not detect host PostgreSQL version (detected='%s'); using fallback image '%s'",
+            detected_version,
+            fallback,
+        )
+        return fallback
 
     @staticmethod
     def create(
@@ -36,6 +76,8 @@ class EnvironmentFactory:
         worker_resources: Optional[Any] = None,
         run_id: str = "tuner-run",
         container_prefix: str = "pbt-worker",
+        image_name: Optional[str] = None,
+        force_recreate_baseline: bool = False,
     ) -> DatabaseEnvironment:
         """Create the appropriate environment backend."""
         cpu_cores = worker_resources.cpu_cores if worker_resources else 0.0
@@ -46,17 +88,26 @@ class EnvironmentFactory:
             try:
                 # Test connectivity
                 docker.from_env().ping()
+                resolved_image_name = EnvironmentFactory._resolve_docker_image(image_name)
                 return DockerEnvironment(
                     run_id=run_id,
                     db_config=db_config,
                     schema_provider=schema_provider,
                     cpu_cores=cpu_cores,
                     ram_bytes=ram_bytes,
+                    image_name=resolved_image_name,
                     base_port=base_port,
                     base_dir=base_dir,
                     container_prefix=container_prefix,
+                    force_recreate_baseline=force_recreate_baseline,
                 )
-            except (ImportError, Exception) as e:
+            except (
+                ImportError,
+                docker.errors.DockerException,
+                OSError,
+                RuntimeError,
+                ValueError,
+            ) as e:
                 logger.warning(get_isolation_warning_banner())
                 logger.warning("Docker unavailable (%s), falling back to Bare Metal", e)
 
@@ -70,4 +121,6 @@ class EnvironmentFactory:
             schema_provider=schema_provider,
             base_port=base_port,
             base_dir=base_dir,
+            ram_bytes=ram_bytes,
+            force_recreate_baseline=force_recreate_baseline,
         )

--- a/tests/unit/core/test_tuner_cli.py
+++ b/tests/unit/core/test_tuner_cli.py
@@ -1,0 +1,25 @@
+"""Tests for tuner CLI argument parsing."""
+
+from __future__ import annotations
+
+import sys
+
+from src.tuner.main import parse_args
+
+
+def test_parse_args_no_color_defaults_to_false(monkeypatch) -> None:
+    """CLI should keep colors enabled unless --no-color is provided."""
+    monkeypatch.setattr(sys, "argv", ["tuner"])
+
+    args = parse_args()
+
+    assert args.no_color is False
+
+
+def test_parse_args_no_color_enables_plain_output(monkeypatch) -> None:
+    """CLI should disable colors when --no-color is provided."""
+    monkeypatch.setattr(sys, "argv", ["tuner", "--no-color"])
+
+    args = parse_args()
+
+    assert args.no_color is True

--- a/tests/unit/core/test_tuner_shutdown.py
+++ b/tests/unit/core/test_tuner_shutdown.py
@@ -1,0 +1,138 @@
+"""Tests for PBTTuner shutdown behavior across normal and forced exits."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.config.database import DatabaseConfig
+from src.tuner.main import PBTTuner
+
+
+def _make_tuner(env: MagicMock, cleanup_instances: bool = False) -> PBTTuner:
+    """Create a PBTTuner object with minimal state needed for run() tests."""
+    tuner = PBTTuner.__new__(PBTTuner)
+
+    tuner.logger = MagicMock()
+    tuner.system_info = {}
+    tuner.knob_tier = "minimal"
+    tuner.knob_space = {}
+    tuner.workload_type = SimpleNamespace(value="oltp")
+    tuner.output_dir = Path("results")
+
+    tuner.pbt_config = SimpleNamespace(
+        population_size=1,
+        num_generations=0,
+        enable_snapshots=False,
+    )
+    tuner.force_recreate_instances = False
+    tuner.cleanup_instances = cleanup_instances
+    tuner.warm_start_path = None
+    tuner.random_seed = 42
+
+    tuner.db_config = DatabaseConfig(
+        user="postgres",
+        password="postgres",
+        host="127.0.0.1",
+        port=5432,
+        dbname="test_dataset",
+    )
+
+    tuner.env = env
+    tuner.population = SimpleNamespace(
+        initialize=MagicMock(),
+        setup_worker_instances=MagicMock(),
+        workers=[],
+        env=None,
+        setup_snapshots=MagicMock(),
+        should_stop=MagicMock(return_value=False),
+        current_generation=0,
+        history=[],
+        generations_without_improvement=0,
+        best_overall_metrics=None,
+    )
+
+    tuner._prune_unsupported_runtime_knobs = MagicMock()
+    tuner.run_generation = MagicMock()
+    tuner.save_intermediate_results = MagicMock()
+    tuner._get_stop_reason = MagicMock(return_value="test-stop")
+
+    tuner.save_final_results = MagicMock(return_value={"status": "ok"})
+    tuner.print_final_summary = MagicMock()
+
+    tuner.generation_history = []
+    tuner.timestamp = "20260417_0000"
+    tuner.warm_start_provenance = {"enabled": False}
+    tuner.benchmark_name = "sysbench"
+
+    return tuner
+
+
+def test_run_stops_instances_on_normal_exit() -> None:
+    """run() should stop instances after normal completion."""
+    env = MagicMock()
+    env.setup_instances.return_value = []
+    env.verify_instances.return_value = {}
+
+    tuner = _make_tuner(env)
+
+    result = tuner.run()
+
+    assert result == {"status": "ok"}
+    env.stop_all.assert_called_once()
+    env.cleanup.assert_not_called()
+
+
+def test_run_stops_instances_when_setup_fails() -> None:
+    """run() should still stop instances when setup raises runtime errors."""
+    env = MagicMock()
+    env.setup_instances.side_effect = RuntimeError("setup failed")
+
+    tuner = _make_tuner(env)
+
+    with pytest.raises(RuntimeError, match="setup failed"):
+        tuner.run()
+
+    env.stop_all.assert_called_once()
+    tuner.save_final_results.assert_not_called()
+
+
+def test_run_stops_instances_on_keyboard_interrupt_during_setup() -> None:
+    """run() should stop instances when Ctrl+C interrupts setup."""
+    env = MagicMock()
+    env.setup_instances.side_effect = KeyboardInterrupt()
+
+    tuner = _make_tuner(env)
+
+    with pytest.raises(KeyboardInterrupt):
+        tuner.run()
+
+    env.stop_all.assert_called_once()
+    tuner.save_final_results.assert_not_called()
+
+
+def test_evaluate_worker_handles_recovery_exception_after_connection_failure() -> None:
+    """Recovery failures after connection errors should not escape evaluate_worker."""
+    tuner = PBTTuner.__new__(PBTTuner)
+    tuner.current_generation = 0
+    tuner._restart_logged_this_gen = False
+    tuner.restart_count = 0
+    tuner.metric_config = SimpleNamespace(latency_metric="p95")
+    tuner.pbt_config = SimpleNamespace(dead_config_score=0.0, crash_score=0.0)
+
+    tuner.evaluator = MagicMock()
+    tuner.evaluator.evaluate_worker.side_effect = ConnectionError("postgres unreachable")
+
+    tuner.env = MagicMock()
+    tuner.env.recover_instance.side_effect = RuntimeError("docker read timeout")
+
+    worker = SimpleNamespace(worker_id=0)
+
+    metrics, score = tuner.evaluate_worker(worker)
+
+    assert score == 0.0
+    assert metrics.failure_type == "crash_dead"
+    tuner.env.recover_instance.assert_called_once_with(0)

--- a/tests/unit/core/test_warm_start.py
+++ b/tests/unit/core/test_warm_start.py
@@ -255,6 +255,79 @@ def test_warm_start_invalid_absolute_values(mock_knob_space, tmp_path):
             seed=42
         )
 
+
+def test_warm_start_accepts_tuning_session_results_json(mock_knob_space, tmp_path, caplog):
+    """Warm-start should extract fractions from pbt_results best_configuration.knobs."""
+    warm_start_path = tmp_path / "pbt_results_20260418_0257.json"
+    warm_start_data = {
+        "tuning_session": {
+            "knob_tier": "minimal",
+            "num_knobs": 3,
+        },
+        "best_configuration": {
+            "score": 98.2,
+            "knobs": {
+                "shared_buffers": 0.15,
+                "work_mem": 0.001,
+                "maintenance_work_mem": 0.01,
+            },
+            "metrics": {},
+        },
+        "generation_history": [],
+    }
+    with open(warm_start_path, 'w', encoding='utf-8') as f:
+        json.dump(warm_start_data, f)
+
+    tuner = PBTTuner(
+        knob_tier="minimal",
+        pbt_config=PBTConfig(population_size=4, num_generations=1, num_parallel_workers=4),
+        warm_start_path=str(warm_start_path),
+        skip_schema_init=True,
+    )
+    tuner.knob_space = mock_knob_space
+
+    configs = tuner._build_warm_start_configs(
+        warm_start_path=warm_start_path,
+        population_size=4,
+        seed=42,
+    )
+
+    assert len(configs) == 2
+    base = configs[0]
+    assert base["shared_buffers"] == 78643
+    assert base["work_mem"] == 4194
+    assert base["maintenance_work_mem"] == 41943
+    assert "Warm-start config missing knobs" not in caplog.text
+    assert "Warm-start config dropping extra knobs" not in caplog.text
+
+
+def test_warm_start_rejects_malformed_tuning_session_json(mock_knob_space, tmp_path):
+    """Malformed pbt_results payloads should fail fast with clear errors."""
+    warm_start_path = tmp_path / "pbt_results_invalid.json"
+    warm_start_data = {
+        "best_configuration": {
+            "score": 88.0,
+            # knobs intentionally missing
+        }
+    }
+    with open(warm_start_path, 'w', encoding='utf-8') as f:
+        json.dump(warm_start_data, f)
+
+    tuner = PBTTuner(
+        knob_tier="minimal",
+        pbt_config=PBTConfig(population_size=2, num_generations=1, num_parallel_workers=2),
+        warm_start_path=str(warm_start_path),
+        skip_schema_init=True,
+    )
+    tuner.knob_space = mock_knob_space
+
+    with pytest.raises(ValueError, match="best_configuration.knobs"):
+        tuner._build_warm_start_configs(
+            warm_start_path=warm_start_path,
+            population_size=2,
+            seed=42,
+        )
+
 def test_warm_start_graduated_perturbation():
     """Graduated perturbation scale correctly across variant span."""
     tuner = PBTTuner(

--- a/tests/unit/utils/test_bare_metal_memory_utilization.py
+++ b/tests/unit/utils/test_bare_metal_memory_utilization.py
@@ -1,0 +1,112 @@
+"""Unit tests for bare-metal worker memory utilization normalization."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.config.database import DatabaseConfig
+from src.utils.environments.bare_metal import BareMetalEnvironment
+
+
+class _StubCursor:
+    """Cursor stub returning a fixed backend PID."""
+
+    def execute(self, _query: str) -> None:
+        return None
+
+    def fetchone(self) -> tuple[int]:
+        return (12345,)
+
+    def close(self) -> None:
+        return None
+
+
+class _StubConnection:
+    """Connection stub for backend PID lookup."""
+
+    def cursor(self) -> _StubCursor:
+        return _StubCursor()
+
+    def close(self) -> None:
+        return None
+
+
+class _StubPostmasterProcess:
+    """Process stub with parent+children RSS accounting support."""
+
+    def __init__(self, rss_bytes: int, child_rss_bytes: list[int]) -> None:
+        self._rss_bytes = rss_bytes
+        self._children = [SimpleNamespace(memory_info=lambda rss=v: SimpleNamespace(rss=rss)) for v in child_rss_bytes]
+
+    def memory_info(self) -> SimpleNamespace:
+        return SimpleNamespace(rss=self._rss_bytes)
+
+    def children(self, recursive: bool = True) -> list[SimpleNamespace]:
+        _ = recursive
+        return self._children
+
+
+class _StubBackendProcess:
+    """Backend process stub exposing parent() to postmaster."""
+
+    def __init__(self, postmaster: _StubPostmasterProcess) -> None:
+        self._postmaster = postmaster
+
+    def parent(self) -> _StubPostmasterProcess:
+        return self._postmaster
+
+
+def _make_env(ram_bytes: int) -> BareMetalEnvironment:
+    return BareMetalEnvironment(
+        run_id="test-run",
+        db_config=DatabaseConfig(
+            user="postgres",
+            password="postgres",
+            host="127.0.0.1",
+            port=5440,
+            dbname="test_dataset",
+        ),
+        schema_provider=MagicMock(),
+        ram_bytes=ram_bytes,
+    )
+
+
+def test_collect_memory_utilization_uses_worker_budget_when_available() -> None:
+    """RSS should be normalized by worker RAM budget to avoid host-scale dilution."""
+    env = _make_env(ram_bytes=4 * 1024)
+    postmaster = _StubPostmasterProcess(rss_bytes=1024, child_rss_bytes=[1024])
+    backend = _StubBackendProcess(postmaster=postmaster)
+
+    with (
+        patch("src.utils.environments.bare_metal.get_connection", return_value=_StubConnection()),
+        patch("src.utils.environments.bare_metal.psutil.Process", return_value=backend),
+        patch(
+            "src.utils.environments.bare_metal.psutil.virtual_memory",
+            return_value=SimpleNamespace(total=8 * 1024),
+        ),
+    ):
+        ratio = env.collect_memory_utilization(worker_id=0)
+
+    assert ratio == pytest.approx(0.5)
+
+
+def test_collect_memory_utilization_falls_back_to_host_total_without_budget() -> None:
+    """When worker budget is unavailable, host-total fallback should still work."""
+    env = _make_env(ram_bytes=0)
+    postmaster = _StubPostmasterProcess(rss_bytes=1024, child_rss_bytes=[1024])
+    backend = _StubBackendProcess(postmaster=postmaster)
+
+    with (
+        patch("src.utils.environments.bare_metal.get_connection", return_value=_StubConnection()),
+        patch("src.utils.environments.bare_metal.psutil.Process", return_value=backend),
+        patch(
+            "src.utils.environments.bare_metal.psutil.virtual_memory",
+            return_value=SimpleNamespace(total=8 * 1024),
+        ),
+    ):
+        ratio = env.collect_memory_utilization(worker_id=0)
+
+    assert ratio == pytest.approx(0.25)

--- a/tests/unit/utils/test_docker_environment.py
+++ b/tests/unit/utils/test_docker_environment.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import docker
+import pytest
+import requests
 
 from src.config.database import DatabaseConfig
 from src.utils.environments.base import InstanceConfig
@@ -16,6 +19,14 @@ from src.utils.environments.docker import DockerEnvironment
 class _DummySchemaProvider:
     """Minimal schema provider stand-in used for context payload generation."""
 
+
+
+class _SysbenchLikeSchemaProvider:
+    """Schema provider stand-in with profile-defining Sysbench attributes."""
+
+    def __init__(self, tables: int, table_size: int) -> None:
+        self.tables = tables
+        self.table_size = table_size
 
 
 def _make_environment() -> DockerEnvironment:
@@ -32,19 +43,25 @@ def _make_environment() -> DockerEnvironment:
     env.schema_provider = _DummySchemaProvider()
     env.cpu_cores = 1.0
     env.ram_bytes = 256 * 1024 * 1024
-    env.image_name = "postgres:17"
+    env.image_name = "postgres:18"
     env.network_name = "pbt-network"
     env.base_port = 5440
     env.base_dir = Path("/tmp")
     env.container_prefix = "pbt-worker"
+    env.force_recreate_baseline = False
     env.instances = {
         0: InstanceConfig(worker_id=0, port=5440, data_dir=Path("/tmp/worker_0"), running=True)
     }
     env._snapshot_timeout = 120
+    env._ready_timeout = 60
+    env._restore_ready_timeout = 180
+    env._restore_api_timeout = 180
     env._wait_for_ready = MagicMock()
+    env._checkpoint_instance = MagicMock()
 
     env.client = MagicMock()
     env.client.api = SimpleNamespace(timeout=30)
+    env.client.volumes = MagicMock()
 
     return env
 
@@ -67,6 +84,95 @@ def test_restore_snapshot_returns_false_when_container_run_fails() -> None:
     assert env.restore_snapshot(worker_id=0, snapshot_id="pbt-snapshot-test") is False
 
 
+def test_restore_snapshot_uses_restore_specific_ready_timeout() -> None:
+    """Snapshot restore should use a longer, restore-specific readiness timeout."""
+    env = _make_environment()
+    env._restore_ready_timeout = 180
+
+    env.client.images.get.return_value = MagicMock()
+    env.client.volumes.get.side_effect = docker.errors.NotFound("not found")
+    env.client.volumes.create.return_value = MagicMock()
+    env.client.containers.get.side_effect = docker.errors.NotFound("not found")
+    env.client.containers.run.return_value = MagicMock()
+
+    assert env.restore_snapshot(worker_id=0, snapshot_id="pbt-snapshot-test") is True
+    env.client.volumes.create.assert_called_once_with(name="pbt-worker-0-pgdata")
+    seed_call = env.client.containers.run.call_args_list[0]
+    assert seed_call.kwargs["volumes"] == {
+        "pbt-worker-0-pgdata": {"bind": "/pgseed", "mode": "rw"}
+    }
+    run_call = env.client.containers.run.call_args_list[1]
+    assert run_call.kwargs["volumes"] == {
+        "pbt-worker-0-pgdata": {"bind": "/pgdata/data", "mode": "rw"}
+    }
+    env._wait_for_ready.assert_called_once_with(
+        "pbt-worker-0",
+        5440,
+        timeout=180,
+        context="snapshot-restore",
+    )
+
+
+def test_restore_snapshot_removes_container_before_volume_reseed() -> None:
+    """Restore should detach the old container before reseeding its PGDATA volume."""
+    env = _make_environment()
+    env.client.images.get.return_value = MagicMock()
+
+    old_container = MagicMock()
+    container_removed = {"value": False}
+
+    def _mark_removed(*_args, **_kwargs) -> None:
+        container_removed["value"] = True
+
+    old_container.remove.side_effect = _mark_removed
+    env.client.containers.get.return_value = old_container
+
+    def _seed_volume(*_args, **_kwargs) -> str:
+        assert container_removed["value"] is True
+        return "pbt-worker-0-pgdata"
+
+    env._seed_pgdata_volume_from_snapshot = MagicMock(side_effect=_seed_volume)
+    env.client.containers.run.return_value = MagicMock()
+
+    assert env.restore_snapshot(worker_id=0, snapshot_id="pbt-snapshot-test") is True
+    old_container.remove.assert_called_once_with(force=True)
+    env._seed_pgdata_volume_from_snapshot.assert_called_once_with(
+        worker_id=0,
+        snapshot_id="pbt-snapshot-test",
+    )
+
+
+def test_rebuild_worker_instance_recreates_clean_slate_and_prepares_schema() -> None:
+    """Clean-slate rebuild should recreate volume/container and prepare schema."""
+    env = _make_environment()
+    env.client.volumes.get.side_effect = docker.errors.NotFound("not found")
+    env.client.containers.get.side_effect = docker.errors.NotFound("not found")
+    env.client.containers.run.return_value = MagicMock()
+
+    env._ensure_database_exists = MagicMock()
+    env.schema_provider = MagicMock()
+    env.schema_provider.prepare = MagicMock()
+    env.schema_provider.validate.return_value = True
+
+    assert env.rebuild_worker_instance(worker_id=0) is True
+
+    env.client.volumes.create.assert_called_once_with(name="pbt-worker-0-pgdata")
+    env.client.containers.run.assert_called_once()
+    run_call = env.client.containers.run.call_args
+    assert run_call.args[0] == "postgres:18"
+    assert run_call.kwargs["volumes"] == {
+        "pbt-worker-0-pgdata": {"bind": "/pgdata/data", "mode": "rw"}
+    }
+    env._wait_for_ready.assert_called_once_with(
+        "pbt-worker-0",
+        5440,
+        timeout=180,
+        context="clean-rebuild",
+    )
+    env._ensure_database_exists.assert_called_once()
+    env.schema_provider.prepare.assert_called_once()
+
+
 def test_create_snapshot_returns_empty_string_on_api_error() -> None:
     """Snapshot creation should degrade gracefully on Docker API failures."""
     env = _make_environment()
@@ -83,6 +189,61 @@ def test_container_name_uses_configured_prefix() -> None:
     env.container_prefix = "eval-worker"
 
     assert env._container_name(0) == "eval-worker-0"
+
+
+def test_default_snapshot_id_is_profile_scoped() -> None:
+    """Snapshot repository names should include run and profile signatures."""
+    env = _make_environment()
+
+    snapshot_id = env._default_snapshot_id()
+    assert snapshot_id.startswith("pbt-snapshot-test-run-001-")
+    assert snapshot_id.endswith(env._snapshot_profile_signature())
+
+
+def test_default_snapshot_id_changes_when_schema_profile_changes() -> None:
+    """Different benchmark schema profiles must not share snapshot identities."""
+    standard_env = _make_environment()
+    standard_env.schema_provider = _SysbenchLikeSchemaProvider(tables=10, table_size=100000)
+
+    rapid_env = _make_environment()
+    rapid_env.schema_provider = _SysbenchLikeSchemaProvider(tables=2, table_size=10000)
+
+    assert standard_env._default_snapshot_id() != rapid_env._default_snapshot_id()
+
+
+def test_snapshot_exists_requires_matching_manifest_signature(tmp_path: Path) -> None:
+    """Existing images are treated as stale when manifest profile metadata mismatches."""
+    env = _make_environment()
+    env.base_dir = tmp_path
+    env.client.images.get.return_value = MagicMock()
+
+    snapshot_id = env._default_snapshot_id()
+    manifest_path = tmp_path / "pg_snapshots" / f"{snapshot_id}.json"
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "snapshot_id": snapshot_id,
+                "image_id": "sha256:stale",
+                "profile_signature": "deadbeefdead",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert env.snapshot_exists(worker_id=0) is False
+
+
+def test_snapshot_exists_returns_true_with_matching_manifest_signature(tmp_path: Path) -> None:
+    """Existing images are reusable only when manifest profile metadata matches."""
+    env = _make_environment()
+    env.base_dir = tmp_path
+    env.client.images.get.return_value = MagicMock()
+
+    snapshot_id = env._default_snapshot_id()
+    env._write_snapshot_manifest(snapshot_id=snapshot_id, image_id="sha256:current")
+
+    assert env.snapshot_exists(worker_id=0) is True
 
 
 def test_setup_instances_reuses_existing_snapshot_without_recommit() -> None:
@@ -104,3 +265,123 @@ def test_setup_instances_reuses_existing_snapshot_without_recommit() -> None:
     first_get_call = env.client.containers.get.call_args_list[0]
     assert first_get_call.args[0] == "eval-worker-0"
     env.create_snapshot.assert_not_called()
+
+
+def test_setup_instances_recreates_worker0_when_baseline_snapshot_missing() -> None:
+    """Worker 0 should not reuse an existing container when baseline snapshot is missing."""
+    env = _make_environment()
+
+    existing_container = MagicMock()
+    existing_container.status = "running"
+    env.client.containers.get.return_value = existing_container
+    env.client.containers.run.return_value = MagicMock()
+
+    env._wait_for_ready = MagicMock()
+    env.initialize_schema = MagicMock()
+    env.schema_provider = _DummySchemaProvider()
+    env.snapshot_exists = MagicMock(return_value=False)
+    env.create_snapshot = MagicMock()
+
+    env.setup_instances(num_workers=1, force_recreate=False)
+
+    existing_container.remove.assert_called_once_with(force=True)
+    env.client.containers.run.assert_called_once()
+    env.create_snapshot.assert_called_once_with(worker_id=0)
+
+
+def test_setup_instances_force_recreate_baseline_removes_snapshot_once() -> None:
+    """Forced baseline recreation should remove stale snapshots before worker setup."""
+    env = _make_environment()
+    env.force_recreate_baseline = True
+
+    env.client.containers.get.side_effect = docker.errors.NotFound("missing")
+    env.client.containers.run.return_value = MagicMock()
+
+    env._wait_for_ready = MagicMock()
+    env.initialize_schema = MagicMock()
+    env.schema_provider = _DummySchemaProvider()
+    env.snapshot_exists = MagicMock(return_value=True)
+    env.create_snapshot = MagicMock()
+    env._remove_baseline_snapshot = MagicMock()
+
+    env.setup_instances(num_workers=1, force_recreate=False)
+
+    env._remove_baseline_snapshot.assert_called_once()
+
+
+def test_setup_instances_tracks_worker_before_ready_wait() -> None:
+    """Workers should be tracked even when readiness waiting fails."""
+    env = _make_environment()
+
+    env.client.containers.get.side_effect = docker.errors.NotFound("missing")
+    env.client.containers.run.return_value = MagicMock()
+    env._wait_for_ready = MagicMock(side_effect=RuntimeError("readiness failed"))
+
+    with pytest.raises(RuntimeError, match="readiness failed"):
+        env.setup_instances(num_workers=1, force_recreate=False)
+
+    assert 0 in env.instances
+    assert env.instances[0].running is True
+    assert env.instances[0].port == 5440
+
+
+def test_stop_all_stops_untracked_running_prefixed_containers() -> None:
+    """stop_all should stop running prefixed containers even when not tracked."""
+    env = _make_environment()
+    env.instances = {}
+
+    managed = MagicMock()
+    managed.name = "pbt-worker-9"
+    other = MagicMock()
+    other.name = "unrelated-service"
+    env.client.containers.list.return_value = [managed, other]
+
+    assert env.stop_all() is True
+
+    managed.stop.assert_called_once_with(timeout=5)
+    other.stop.assert_not_called()
+
+
+def test_start_instance_returns_false_on_read_timeout() -> None:
+    """ReadTimeout from Docker SDK calls should not crash startup paths."""
+    env = _make_environment()
+    env.client.containers.get.side_effect = requests.exceptions.ReadTimeout("timeout")
+
+    assert env.start_instance(worker_id=0) is False
+
+
+def test_verify_instances_marks_worker_unhealthy_on_read_timeout() -> None:
+    """Verification should downgrade timed-out workers to unhealthy instead of raising."""
+    env = _make_environment()
+    env.client.containers.get.side_effect = requests.exceptions.ReadTimeout("timeout")
+
+    status = env.verify_instances()
+
+    assert status[0] is False
+    assert env.instances[0].running is False
+
+
+def test_create_snapshot_writes_metadata_manifest(tmp_path: Path) -> None:
+    """Snapshot creation should persist project-local metadata under pg_snapshots/."""
+    env = _make_environment()
+    env.base_dir = tmp_path
+
+    container = MagicMock()
+    snapshot_image = MagicMock()
+    snapshot_image.id = "sha256:test-image-id"
+    container.commit.return_value = snapshot_image
+    env.client.containers.get.return_value = container
+
+    snapshot_id = env.create_snapshot(worker_id=0)
+
+    expected_snapshot_id = env._default_snapshot_id()
+    assert snapshot_id == expected_snapshot_id
+
+    manifest_path = tmp_path / "pg_snapshots" / f"{expected_snapshot_id}.json"
+    assert manifest_path.exists()
+
+    manifest_data = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest_data["snapshot_id"] == expected_snapshot_id
+    assert manifest_data["image_id"] == "sha256:test-image-id"
+    assert manifest_data["profile_signature"] == env._snapshot_profile_signature()
+    assert "provider" in manifest_data["profile_context"]

--- a/tests/unit/utils/test_environment_base.py
+++ b/tests/unit/utils/test_environment_base.py
@@ -1,8 +1,10 @@
 """Targeted tests for base environment error handling paths."""
 
+# pylint: disable=protected-access
+
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, call, patch
 
 import psycopg2
 
@@ -46,15 +48,33 @@ class _DummyEnvironment(DatabaseEnvironment):
     def get_db_config(self, worker_id: int) -> DatabaseConfig:
         return self.base_config
 
+    def collect_memory_utilization(self, worker_id: int) -> float:
+        return 0.0
+
 
 class _SchemaProvider:
     """No-op schema provider stand-in."""
 
-    def prepare(self, db_config: DatabaseConfig) -> None:
+    def prepare(self, _db_config: DatabaseConfig) -> None:
         return None
 
-    def validate(self, db_config: DatabaseConfig) -> bool:
+    def validate(self, _db_config: DatabaseConfig) -> bool:
         return True
+
+
+def _make_env() -> _DummyEnvironment:
+    db_config = DatabaseConfig(
+        user="postgres",
+        password="postgres",
+        host="127.0.0.1",
+        port=5432,
+        dbname="test_dataset",
+    )
+    return _DummyEnvironment(
+        run_id="test-run",
+        db_config=db_config,
+        schema_provider=_SchemaProvider(),
+    )
 
 
 
@@ -85,3 +105,77 @@ def test_ensure_database_exists_handles_connection_failure_without_name_error() 
 
     logger_error.assert_called_once()
     assert "Failed to ensure database" in logger_error.call_args[0][0]
+
+
+def test_reset_persisted_configuration_restarts_when_pending_restart() -> None:
+    """RESET ALL should trigger restart when PostgreSQL reports pending_restart entries."""
+    env = _make_env()
+    db_config = env.base_config
+
+    cursor = MagicMock()
+    cursor.fetchone.return_value = (1,)
+    conn = MagicMock()
+    conn.cursor.return_value = cursor
+
+    env.stop_instance = MagicMock(return_value=True)
+    env.start_instance = MagicMock(return_value=True)
+    env._wait_until_connectable = MagicMock(return_value=True)
+
+    with patch("src.utils.environments.base.get_connection", return_value=conn):
+        env._reset_persisted_configuration(worker_id=0, config=db_config)
+
+    cursor.execute.assert_has_calls(
+        [
+            call("ALTER SYSTEM RESET ALL"),
+            call("SELECT pg_reload_conf()"),
+            call("SELECT count(*) FROM pg_settings WHERE pending_restart"),
+        ]
+    )
+    env.stop_instance.assert_called_once_with(0)
+    env.start_instance.assert_called_once_with(0)
+    env._wait_until_connectable.assert_called_once_with(db_config)
+
+
+def test_reset_persisted_configuration_skips_restart_when_no_pending_changes() -> None:
+    """RESET ALL should avoid restart when no pending_restart flags remain."""
+    env = _make_env()
+    db_config = env.base_config
+
+    cursor = MagicMock()
+    cursor.fetchone.return_value = (0,)
+    conn = MagicMock()
+    conn.cursor.return_value = cursor
+
+    env.stop_instance = MagicMock(return_value=True)
+    env.start_instance = MagicMock(return_value=True)
+    env._wait_until_connectable = MagicMock(return_value=True)
+
+    with patch("src.utils.environments.base.get_connection", return_value=conn):
+        env._reset_persisted_configuration(worker_id=0, config=db_config)
+
+    env.stop_instance.assert_not_called()
+    env.start_instance.assert_not_called()
+    env._wait_until_connectable.assert_not_called()
+
+
+def test_initialize_schema_resets_after_snapshot_restore() -> None:
+    """Schema initialization should reset persisted settings before and after snapshot restore."""
+    env = _make_env()
+    db_config = env.base_config
+
+    schema_provider = MagicMock()
+    schema_provider.validate.side_effect = [False, True]
+    schema_provider.prepare = MagicMock()
+    env.schema_provider = schema_provider
+
+    env.restore_snapshot = MagicMock(return_value=True)
+    env._ensure_database_exists = MagicMock()
+    env._reset_persisted_configuration = MagicMock()
+
+    env.initialize_schema(worker_id=0)
+
+    env._reset_persisted_configuration.assert_has_calls(
+        [call(0, db_config), call(0, db_config)]
+    )
+    assert env._reset_persisted_configuration.call_count == 2
+    schema_provider.prepare.assert_not_called()


### PR DESCRIPTION
## Summary

This PR isolates environment/runtime integration work into a dedicated branch. It improves Docker and bare-metal lifecycle reliability, then wires those capabilities into tuner startup behavior.

## Why

- Environment setup, snapshot lifecycle, and runtime compatibility checks are a distinct concern from baseline comparison functionality.
- Keeping this work isolated makes review and rollback cleaner.

## What Changed

- Environment backend hardening:
- improved snapshot/restore/rebuild behavior
- stronger worker lifecycle handling and recovery paths
- per-worker memory utilization normalization across backends
- base environment enhancements for persisted configuration reset and restart-safe initialization.
- Tuner runtime integration:
- runtime-aware startup wiring for environment behavior
- runtime knob compatibility pruning using server settings
- snapshot identifier normalization and Docker image override support
- warm-start support for tuning-session style artifacts
- CLI/shutdown/warm-start test coverage for integration behavior.

## Validation

- pytest test_environment_base.py test_docker_environment.py tests/unit/utils/test_bare_metal_memory_utilization.py -q  
  Result: 25 passed
- pytest test_warm_start.py tests/unit/core/test_tuner_cli.py tests/unit/core/test_tuner_shutdown.py -q  
  Result: 16 passed

## Scope Boundaries

- This branch intentionally contains only environment subsystem updates, tuner integration, and their related tests.  
- Evaluation package and comparison-suite changes stay on feat/baseline-comparison-suite.