### PR TITLE
feat(agents): add comprehensive project context skills and start-session workflow

### DIFF
--- a/.agents/workflows/start-session.md
+++ b/.agents/workflows/start-session.md
@@ -1,0 +1,60 @@
+---
+description: Run this workflow immediately when starting a new session to load the complete project context and relevant skills.
+---
+
+# Start Session / Load Context
+
+Welcome to the **Population-Based Training for PostgreSQL Configuration Tuning** repository!
+
+This is a complex research project with a layered architecture, a custom multi-objective scoring pipeline, multi-instance PostgreSQL management, and a rigorous post-hoc evaluation suite.
+
+To be an effective agent in this repository, you must avoid guessing how the system works and instead load the curated domain knowledge (skills). Follow this workflow to bootstrap your context.
+
+## 1. Load the Universal Architecture Map (Always Do This)
+
+Before answering questions or looking at code, you MUST understand the high-level data flow and package structure.
+
+**Action:** Read the `codebase-architecture` skill.
+- This gives you the map of all `src/` packages, file responsibilities, and how the tuning engine orchestrates runs.
+
+## 2. Load the Relevant Domain Skills (Task-Dependent)
+
+Based on the user's initial prompt, identify which subsystems you'll be touching and load the corresponding skills. You can load multiple skills if the task spans multiple areas.
+
+### The Tuning Engine
+If the task involves the PBT algorithm, exploit/explore logic, worker management, convergence, or the `src/tuner/core/` package:
+- **Action:** Read the `pbt-algorithm-patterns` skill.
+
+### Configuration & Parameter Space
+If the task involves adding new PostgreSQL knobs, parameter bounds, hardware-aware fractional representation, or code in `src/tuner/config/` and `src/knobs/`:
+- **Action:** Read the `postgresql-knob-tuning` skill.
+
+### The Scoring Pipeline (v2)
+If the task involves how performance metrics are normalized, weighted, or scored, or code in `src/utils/scoring/` and `src/utils/metrics.py`:
+- **Action:** Read the `scoring-pipeline` skill.
+
+### Execution & Instances
+If the task involves Docker vs. bare-metal instances, benchmark execution (Sysbench/TPC-H), snapshot restoration, or code in `src/utils/environments/` and `src/benchmarks/`:
+- **Action:** Read the `benchmark-orchestration` skill AND the `environment-backends` skill.
+
+### Evaluation & Statistics
+If the task involves comparing tuned configs against defaults, statistical significance, the `src/evaluation/` package, or the `python -m src.evaluation` CLI:
+- **Action:** Read the `evaluation-suite` skill AND the `statistical-analysis` skill.
+
+### Analysis & Experimentation
+If the task involves fANOVA/TreeSHAP knob importance, running multi-seed campaigns, or preparing plots:
+- **Action:** Read the `knob-importance-analysis` skill AND the `scientific-experiment-runner` skill.
+
+## 3. Verify Development Environment
+
+If you are going to write code, you need to know the CI gates and testing standards.
+- **Action:** Read the `dev-workflow` skill to learn about `make check-all`, pytest, ruff, and mypy constraints.
+
+## 4. Execute Context Bootstrap
+
+Once you've identified and read the necessary skills:
+1. Summarize back to the user your understanding of their task and which subsystems/skills are involved.
+2. Check the project git status (`git status`, `git log -n 3`) to see if there is uncommitted work in progress.
+3. State your plan for execution or ask clarifying questions based on the loaded domain knowledge.
+
+> **Note to Agent:** Do not hallucinate PostgreSQL tuning rules or standard PBT algorithms. The custom implementations, scoring formulas, and hardware representations defined in these skills are the absolute ground truth for this codebase.

--- a/.claude/skills/codebase-architecture/SKILL.md
+++ b/.claude/skills/codebase-architecture/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: codebase-architecture
+description: >
+  Complete codebase map for the PBT PostgreSQL tuning research project. Covers all source
+  packages, file inventory with responsibilities, dependency relationships, data flow through
+  the tuning pipeline, and navigation guide. Use this skill whenever you need to understand
+  where code lives, how packages relate to each other, which file to modify for a given task,
+  or when onboarding to the project. This is the first skill to consult when starting any
+  new task in this repository.
+---
+
+# Codebase Architecture
+
+## Project Identity
+
+- **Name**: Population-Based Training for PostgreSQL Configuration Tuning
+- **Language**: Python 3.11+
+- **Target DB**: PostgreSQL 14+
+- **Source**: ~21,000 lines across `src/`
+- **License**: Academic Research (Non-Commercial)
+
+## High-Level Data Flow
+
+```
+CLI args (main.py)
+    → TunerConfig
+    → KnobSpace (tiered CSV → KnobDefinitions)
+    → Population (N Workers, LHS-initialized)
+    → FOR each generation:
+        → Parallel evaluation via ThreadPoolExecutor
+            → KnobApplicator (ALTER SYSTEM + restart/reload)
+            → WorkloadEvaluator (sysbench / TPC-H / template SQL)
+            → PerformanceMetrics collected
+            → CompositeScorer (normalize → weight → gate → score)
+        → Evolution (truncation selection → exploit → explore → perturb)
+        → Convergence check
+    → Best config saved to results/
+    → Optional: Post-hoc evaluation (src/evaluation/)
+```
+
+## Package Map
+
+### `src/tuner/` — PBT Tuning Engine (entry point: `python -m src.tuner.main`)
+| File | Responsibility |
+|------|---------------|
+| `main.py` | CLI arg parsing, orchestration, session output |
+| `core/population.py` | PBT loop: init → evaluate → evolve → converge |
+| `core/worker.py` | Worker state (config, score, history, readiness) |
+| `core/evolution.py` | Truncation selection, perturbation, convergence detection |
+| `evaluator/evaluator.py` | Benchmark dispatch, metric collection, scoring integration |
+| `evaluator/workload.py` | JSON/YAML workload template execution |
+| `evaluator/restart_policy.py` | CDBTune-inspired batched restart logic |
+| `config/knob_space.py` | Search space definition, LHS sampling, perturbation |
+| `config/knob_loader.py` | Tiered knob CSV loading (minimal/core/standard/extensive) |
+| `config/tuner_config.py` | CLI-derived configuration dataclass |
+
+### `src/utils/scoring/` — Feature-Driven Scoring (v2)
+| File | Responsibility |
+|------|---------------|
+| `scorer.py` | `CompositeScorer`: G × Σ(w_i × u_i) |
+| `normalization.py` | `QuantileUtilityNormalizer`: quantile anchoring, drift, saturation |
+| `weights.py` | `FeatureDrivenWeightModel`: floor-constrained softmax |
+| `policies.py` | `ScoringPolicySpec`, `fixed_v1`, `feature_driven_v2` definitions |
+| `workload_features.py` | Feature extraction (sysbench, TPC-H, template SQL) |
+| `contracts.py` | `WorkloadFeatures`, `MetricSnapshot`, `ScoreBreakdown`, `NormalizationState` |
+| `constants.py` | Metric IDs, directionality, default policy constants |
+
+### `src/utils/` — Shared Utilities
+| File | Responsibility |
+|------|---------------|
+| `metrics.py` | `PerformanceMetrics` dataclass — canonical metric record |
+| `rescoring.py` | Post-hoc global score recalibration utilities |
+| `applicator.py` | `KnobApplicator` — applies configs via ALTER SYSTEM |
+| `hardware_info.py` | System resource detection (CPU, RAM, disk) |
+| `metric_instrumentation.py` | Extended metric collection (buffer stats, scan efficiency) |
+| `environments/base.py` | `DatabaseEnvironment` ABC |
+| `environments/bare_metal.py` | Bare-metal PostgreSQL backend |
+| `environments/docker.py` | Docker container-based backend |
+| `environments/factory.py` | Environment factory (auto-selects backend) |
+| `logger/` | Colored logging, banners, formatters, adapters (7 files) |
+
+### `src/evaluation/` — Post-Hoc Comparison Suite (entry: `python -m src.evaluation`)
+| File | Responsibility |
+|------|---------------|
+| `__main__.py` | CLI entry point |
+| `runner.py` | `ComparisonRunner` — orchestrates default-vs-tuned evaluations |
+| `statistics.py` | Wilcoxon, bootstrap CI, Holm-corrected α, Cohen's d |
+| `loader.py` | Session JSON parser with scoring metadata compatibility |
+| `types.py` | `ComparisonConfig`, `RunResult`, `ComparisonReport` |
+| `exceptions.py` | Domain-specific exception hierarchy |
+
+### `src/analysis/` — Post-Run Analysis
+| File | Responsibility |
+|------|---------------|
+| `data_loader.py` | Load/normalize PBT session results for analysis |
+| `importance.py` | fANOVA + TreeSHAP knob importance analysis |
+
+### Other Packages
+| Package | Responsibility |
+|---------|---------------|
+| `src/database/` | PostgreSQL connection management |
+| `src/knobs/` | Knob metadata retrieval from PG catalogs |
+| `src/benchmarks/` | Benchmark executor interfaces (sysbench, TPC-H) |
+| `src/scripts/` | Setup, cleanup, knob analysis utilities |
+| `src/config/` | Global database configuration |
+
+## Key Data Types
+
+| Type | Location | Purpose |
+|------|----------|---------|
+| `PerformanceMetrics` | `src/utils/metrics.py` | Raw metric record from evaluation |
+| `Worker` | `src/tuner/core/worker.py` | Config + score + history |
+| `KnobDefinition` | `src/tuner/config/knob_space.py` | Knob metadata (type, bounds, context) |
+| `TunerConfig` | `src/tuner/config/tuner_config.py` | Session configuration |
+| `ScoringPolicySpec` | `src/utils/scoring/policies.py` | Policy definition |
+| `ComparisonConfig` | `src/evaluation/types.py` | Evaluation session config |
+
+## Build & Validation
+
+```bash
+make lint           # ruff check src tests
+make typecheck      # mypy src/evaluation src/utils src/scripts
+make test           # pytest -q tests/unit
+make check-all      # lint + typecheck + test
+```
+
+## Result Directories
+
+```
+results/
+├── oltp/{sysbench_workload}/
+│   ├── pbt_runs/{tier}/tuning_sessions/
+│   ├── comparisons/{tier}/
+│   └── baselines/
+├── olap/
+│   └── (same structure for TPC-H)
+└── best_configs/
+```
+
+## Documentation Index
+
+| Document | Focus |
+|----------|-------|
+| `docs/FEATURE_DRIVEN_SCORING.md` | Scoring-v2 architecture |
+| `docs/PBT_CORE_COMPONENTS.md` | Worker, Evolution, Population |
+| `docs/PERFORMANCE_EVALUATION.md` | Evaluator, metrics, scoring |
+| `docs/BENCHMARKING.md` | Dual-evaluation strategy |
+| `docs/EVALUATION_RUNBOOK.md` | Reproducibility commands |
+| `docs/CONFIGURATION_MANAGEMENT.md` | KnobSpace, sampling, perturbation |
+| `docs/AUTOTUNING_KNOB_POLICY.md` | Comprehensive knob policy reference |

--- a/.claude/skills/dev-workflow/SKILL.md
+++ b/.claude/skills/dev-workflow/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: dev-workflow
+description: >
+  Development workflow, CI gates, testing patterns, and contribution conventions for the
+  PBT PostgreSQL tuning project. Covers make targets, pytest structure, ruff linting, mypy
+  type checking, git branching, and commit conventions. Use this skill when running tests,
+  fixing lint errors, adding new test files, setting up development environment, or
+  preparing changes for commit.
+---
+
+# Development Workflow
+
+## CI Gates (Makefile)
+
+```bash
+make lint           # ruff check src tests
+make typecheck      # mypy src/evaluation src/utils src/scripts
+make test           # pytest -q tests/unit
+make check-all      # lint + typecheck + test (run before committing)
+make lint-fix       # Auto-fix + format
+```
+
+The virtual environment is auto-detected: `.venv/bin/python` if present, else `python3`.
+
+## Ruff Configuration (pyproject.toml)
+
+- Line length: 88
+- Target: Python 3.11
+- Selected rules: E9, F63, F7, F82, F401, F841, I, UP, B
+- Legacy per-file ignores: `src/**` and `tests/**` skip I001 and UP rules
+
+## Mypy Scope
+
+Type checking covers: `src/evaluation`, `src/utils`, `src/scripts`
+- `ignore_missing_imports = true` (third-party stubs not required)
+- `follow_imports = "skip"` (only checks listed files)
+
+## Test Structure
+
+```
+tests/unit/
+├── analysis/     # data_loader, importance
+├── benchmarks/   # sysbench, tpch executor tests
+├── config/       # hardware normalization
+├── core/         # population, evaluator, CLI, warm start, saturation
+├── evaluation/   # comparative evaluation, public API
+├── knobs/        # metadata loader, policy loader
+├── scoring/      # normalizer, weight model, workload features
+├── scripts/      # cleanup instances
+└── utils/        # environments, hardware info, instrumentation
+```
+
+All tests use `pytest`. Common fixtures are in `tests/conftest.py` and
+`tests/unit/evaluation/conftest.py`.
+
+## Git Conventions
+
+- Branch naming: `{type}/{description}` (e.g., `feat/scoring-v2`, `fix/normalizer-drift`)
+- Commit format: Conventional Commits (`feat(scope): description`)
+- Use the `/commit` workflow for smart commits with pre-flight checks
+
+## Adding a New Test
+
+1. Create test file in the matching `tests/unit/{area}/` directory
+2. Name: `test_{module_name}.py`
+3. Import the module under test directly
+4. Use `pytest.fixture` for shared setup
+5. Run `make test` to verify
+
+## Dependencies
+
+- Runtime: `requirements.txt` (psycopg2, numpy, pandas, scipy, docker, fanova, shap)
+- Dev: `requirements-dev.txt` (pytest, ruff, mypy)
+- Install: `pip install -r requirements.txt -r requirements-dev.txt`

--- a/.claude/skills/environment-backends/SKILL.md
+++ b/.claude/skills/environment-backends/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: environment-backends
+description: >
+  DatabaseEnvironment abstraction layer for PostgreSQL instance lifecycle management.
+  Covers Docker and bare-metal backends, environment factory, instance creation/teardown,
+  configuration application, health checks, and resource isolation. Use this skill when
+  working on Docker containers, bare-metal PostgreSQL instances, environment selection,
+  instance management, port allocation, or any code in src/utils/environments/.
+---
+
+# Environment Backends
+
+The `DatabaseEnvironment` abstraction decouples tuning/evaluation logic from
+the physical PostgreSQL instance management.
+
+## Architecture
+
+```
+EnvironmentFactory.create(backend, worker_id, ...)
+    ├── "docker"     → DockerEnvironment
+    └── "bare_metal" → BareMetalEnvironment
+
+Both implement DatabaseEnvironment ABC:
+    .setup()          → Create/start instance
+    .apply_config()   → Write knobs + restart/reload
+    .health_check()   → Verify connectivity
+    .teardown()       → Stop + cleanup
+    .get_connection() → psycopg2 connection
+```
+
+## DockerEnvironment
+
+- Fresh containers from `docker/eval.Dockerfile`
+- Port: `base_port + worker_id` (default base: 5440)
+- cgroup CPU/memory limits, tmpfs for WAL
+- Use case: Evaluation pipeline (publication-quality isolation)
+
+## BareMetalEnvironment
+
+- Local `pg_ctl` / `initdb` management
+- Data dirs: `{pg_data_base}/worker_{worker_id}/`
+- Auto-detects `pg_ctl`/`initdb` via PATH
+- Reuses existing data dirs if initialized
+- Use case: PBT tuning loop (lower overhead)
+
+## Config Application Flow
+
+1. Separate knobs by context (postmaster vs sighup)
+2. Write ALL knobs to postgresql.conf
+3. postmaster changed → `pg_ctl restart`; sighup only → `pg_ctl reload`
+4. Verify via `SELECT current_setting(knob_name)`
+
+## Code Locations
+
+| Component | File |
+|-----------|------|
+| ABC | `src/utils/environments/base.py` |
+| Docker | `src/utils/environments/docker.py` |
+| Bare-metal | `src/utils/environments/bare_metal.py` |
+| Factory | `src/utils/environments/factory.py` |
+| Applicator | `src/utils/applicator.py` |
+
+## Key Constraints
+
+- One instance per worker — never share
+- Ports 5440-5460 must be free
+- Docker fallback: auto bare-metal if Docker unavailable
+- Always `teardown()` in `finally` — orphaned instances leak ports and disk

--- a/.claude/skills/evaluation-suite/SKILL.md
+++ b/.claude/skills/evaluation-suite/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: evaluation-suite
+description: >
+  Post-hoc comparative evaluation pipeline that compares PBT-tuned PostgreSQL configurations
+  against defaults using Docker-isolated benchmarks and rigorous statistical analysis
+  (Wilcoxon signed-rank, bootstrap CI, Holm correction, Cohen's d). Use this skill when
+  working on the evaluation module, comparison reports, statistical testing, session loading,
+  Docker evaluation containers, evaluation CLI, or any code in src/evaluation/. Also use
+  when running `python -m src.evaluation`, interpreting comparison results, or debugging
+  evaluation failures.
+---
+
+# Post-Hoc Evaluation Suite
+
+The evaluation module (`src/evaluation/`) is **independent of the PBT tuning loop**.
+It takes a completed tuning session JSON and runs a controlled A/B comparison:
+PBT-tuned config vs. default PostgreSQL config.
+
+## Evaluation Architecture
+
+```
+python -m src.evaluation --session <path> [--repetitions N] [--no-docker]
+    │
+    ├── SessionLoader.load()           → ComparisonConfig
+    │   ├── Parse best_config from session JSON
+    │   ├── Extract scoring metadata (policy, version)
+    │   └── Detect benchmark type (sysbench/tpch)
+    │
+    ├── ComparisonRunner.run()
+    │   ├── For each config (default, tuned) × N repetitions:
+    │   │   ├── Create fresh Docker container (or bare-metal instance)
+    │   │   ├── Apply configuration
+    │   │   ├── Run benchmark (same as tuning)
+    │   │   └── Collect PerformanceMetrics
+    │   └── Return paired RunResult lists
+    │
+    └── StatisticalAnalyzer.analyze()
+        ├── Wilcoxon signed-rank test (primary)
+        ├── Bootstrap confidence intervals (BCa, 10000 resamples)
+        ├── Holm-Bonferroni correction for secondary endpoints
+        ├── Cohen's d effect size
+        └── Generate ComparisonReport JSON
+```
+
+## Isolation Strategy
+
+| Mode | Mechanism | Isolation Level |
+|------|-----------|-----------------|
+| Docker (default) | Fresh container per run, cgroup limits, tmpfs | **Full** (publication-quality) |
+| Bare-metal (`--no-docker`) | Shared host, `pg_ctl` restart between runs | **Reduced** (development only) |
+
+Docker containers use `docker/eval.Dockerfile` with pre-installed sysbench + TPC-H dbgen.
+
+## Statistical Framework
+
+### Primary Endpoint
+- **Test**: Wilcoxon signed-rank (non-parametric, paired)
+- **Metric**: Composite score (same scoring policy as tuning session)
+- **α**: 0.05 (two-sided)
+
+### Secondary Endpoints (Holm-corrected)
+- Latency P95, Throughput, Error Rate
+- Each gets Wilcoxon test with Holm-Bonferroni α correction
+
+### Effect Size
+- **Cohen's d**: standardized mean difference
+- **Bootstrap CI**: BCa method, 10,000 resamples, 95% confidence
+
+### Minimum Repetitions
+- 5 reps (default) — minimum for Wilcoxon test validity
+- 10+ reps recommended for tighter CIs
+
+## Session Loading & Compatibility
+
+The loader handles legacy sessions without scoring-v2 metadata by applying
+compatibility defaults:
+```
+scoring_policy = "fixed_v1"
+scoring_policy_version = "1.0"
+metric_reference_version = "v1"
+```
+
+The evaluation CLI supports policy override for re-evaluation:
+```bash
+python -m src.evaluation \
+    --session results/.../pbt_results_XXXX.json \
+    --scoring-policy feature_driven_v2
+```
+
+## CLI Reference
+
+```bash
+python -m src.evaluation \
+    --session <path>           # Required: path to tuning session JSON
+    --repetitions <N>          # Default: 5
+    --no-docker                # Use bare-metal instead of Docker
+    --scoring-policy <id>      # Override: fixed_v1 or feature_driven_v2
+    --output <path>            # Custom output path for comparison report
+```
+
+## Output: ComparisonReport
+
+JSON report saved to `results/{workload}/comparisons/{tier}/`:
+```json
+{
+  "session_file": "...",
+  "benchmark": "sysbench",
+  "repetitions": 5,
+  "environment": "docker",
+  "default_results": [...],
+  "tuned_results": [...],
+  "statistics": {
+    "primary": { "statistic": ..., "p_value": ..., "effect_size": ... },
+    "secondary": { ... },
+    "bootstrap_ci": { "lower": ..., "upper": ... }
+  }
+}
+```
+
+## Code Locations
+
+| Component | File |
+|-----------|------|
+| CLI entry point | `src/evaluation/__main__.py` |
+| Session loader | `src/evaluation/loader.py` |
+| Comparison runner | `src/evaluation/runner.py` |
+| Statistical analysis | `src/evaluation/statistics.py` |
+| Type definitions | `src/evaluation/types.py` |
+| Exceptions | `src/evaluation/exceptions.py` |
+| Docker image | `docker/eval.Dockerfile` |
+| Runbook | `docs/EVALUATION_RUNBOOK.md` |
+
+## Common Pitfalls
+
+1. **Scoring policy mismatch**: If the session used `feature_driven_v2` but evaluation defaults to `fixed_v1`, scores won't be comparable — check session metadata
+2. **Insufficient repetitions**: Wilcoxon requires ≥5 paired observations; <10 gives wide CIs
+3. **Bare-metal noise**: Background processes inflate variance — always prefer Docker for publication results
+4. **Fresh containers**: Each run MUST start from a clean state; reusing containers introduces warm-cache bias

--- a/.claude/skills/scoring-pipeline/SKILL.md
+++ b/.claude/skills/scoring-pipeline/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: scoring-pipeline
+description: >
+  Feature-driven scoring pipeline (scoring-v2) including the CompositeScorer, QuantileUtilityNormalizer,
+  FeatureDrivenWeightModel, scoring policies (fixed_v1, feature_driven_v2), workload feature extraction,
+  reliability gating, drift detection, and saturation expansion. Use this skill whenever working on
+  score computation, metric normalization, metric weighting, scoring policies, workload features,
+  calibration, rescoring, normalization drift, saturation detection, or any code in src/utils/scoring/,
+  src/utils/metrics.py, or src/utils/rescoring.py. Also use when debugging score values, investigating
+  why a worker scored unexpectedly, or modifying the scoring contract.
+---
+
+# Scoring Pipeline (v2)
+
+The scoring pipeline converts raw `PerformanceMetrics` into a single scalar reward
+signal for the PBT evolutionary loop.
+
+## Scoring Contract
+
+```
+S = 100 × G × Σ(w_i × u_i)
+```
+
+Where:
+- **G** ∈ [0, 1] — reliability gate (0 on fatal failure or high error rate)
+- **w_i** — metric weight from the active policy (Σw_i = 1)
+- **u_i** ∈ [0, 1] — normalized utility from the quantile normalizer
+- **S** ∈ [0, 100] — final bounded score
+
+## Two Scoring Policies
+
+| Policy | ID | Type | Metrics |
+|--------|----|------|---------|
+| Legacy | `fixed_v1` | Static weights per workload type | 6 metrics (latency_p50/p95/p99, throughput, memory_util, error_rate) |
+| Feature-Driven | `feature_driven_v2` | Dynamic weights from workload features | 10 metrics (adds variance, tail_amp, pressure, scan_eff, buffer_miss) |
+
+### fixed_v1 Weights (hardcoded)
+- OLTP: latency_p95=0.50, throughput=0.30, memory=0.05, error=0.15
+- OLAP: latency_p95=0.80, memory=0.05, error=0.15
+- Mixed: latency_p95=0.40, throughput=0.40, memory=0.05, error=0.15
+
+### feature_driven_v2 Weight Computation
+1. **Extract features** via `WorkloadFeatureExtractor` (10 canonical features)
+2. **Compute logits**: `w_i = base_i + Σ_j(M_ij × f_j)` — `working_set_millions` passes through `log1p()` to prevent softmax domination
+3. **Temperature-scaled softmax** (numerically stable)
+4. **Floor constraint**: `W_i = α_i + (1 - Σα) × S_i` — guarantees minimum weight for critical metrics
+
+V2 floors: latency_p95=0.10, throughput=0.10, error_rate=0.05, latency_p99=0.05 (total=0.30)
+
+## Normalization (QuantileUtilityNormalizer)
+
+Uses robust p05/p95 quantile anchors (NOT min/max) to prevent single-outlier score collapse.
+
+### Key Behaviors
+- **Calibration**: `fit()` computes anchors from observed metric distributions; requires metric whitelist to avoid noisy non-scoring fields
+- **Metric direction**: Heuristic from name — latency/variance/error = lower-is-better; throughput/efficiency = higher-is-better
+- **Naturally bounded metrics**: error_rate, memory_pressure, buffer_miss_rate, scan_efficiency bypass quantile anchoring (already [0,1])
+- **NEVER_ZERO filter**: latency_p99/p95/p50, latency_variance, tail_amplification filter out zero observations (extraction artifacts)
+- **Drift detection**: Tracks out-of-support rate per metric; triggers recalibration when rate exceeds threshold (default 20%)
+- **Saturation detection**: `detect_metric_saturation()` finds metrics where ≥2 workers hit the same bound
+- **Anchor expansion**: `expand_metric_anchor()` widens the saturated side by 20% of current range
+- **Export/import**: `export_state()` / `import_state()` for reproducible rescoring
+
+### Calibration Flow in Population
+```
+Generation 0: Evaluate all workers → raw metrics collected
+              fit() normalizer with metric_whitelist = policy metrics
+              Calibration complete → is_calibrated = True
+
+Generation 1+: score_vector() produces utilities
+               update() tracks history + out-of-support counts
+               needs_recalibration() → if True, rebuild dataset + refit
+               detect_metric_saturation() → if saturated, expand_metric_anchor()
+```
+
+## Reliability Gate
+
+```python
+if failure_type is not None:     return 0.0   # Fatal failure
+if error_rate >= threshold:       return 0.0   # Too many errors (default: 5%)
+if error_rate > 0:                return 1.0 - (error_rate / threshold)  # Linear decay
+else:                             return 1.0   # Clean run
+```
+
+## Workload Feature Extraction
+
+10 canonical features extracted per benchmark type:
+
+| Feature | Description | Range |
+|---------|-------------|-------|
+| `read_ratio` / `write_ratio` | R/W split | [0, 1] |
+| `olap_complexity` | Query complexity score | [0, 1] |
+| `join_intensity` | JOIN clause prevalence | [0, 1] |
+| `aggregation_intensity` | GROUP BY/AGG prevalence | [0, 1] |
+| `sort_intensity` | ORDER BY prevalence | [0, 1] |
+| `concurrency_pressure` | threads/cpu_cores ratio | [0, 1] |
+| `working_set_millions` | Total rows / 1M | [0, ∞) |
+| `query_mix_entropy` | Normalized Shannon entropy | [0, 1] |
+| `tail_latency_sensitivity` | Tail latency importance | [0, 1] |
+
+Extractors: `extract_sysbench_features()`, `extract_tpch_features()`, `extract_template_features()`
+
+## Code Locations
+
+| Component | File |
+|-----------|------|
+| Composite scorer | `src/utils/scoring/scorer.py` |
+| Normalizer | `src/utils/scoring/normalization.py` |
+| Weight model | `src/utils/scoring/weights.py` |
+| Policies | `src/utils/scoring/policies.py` |
+| Workload features | `src/utils/scoring/workload_features.py` |
+| Contracts | `src/utils/scoring/contracts.py` |
+| Constants | `src/utils/scoring/constants.py` |
+| Legacy metrics | `src/utils/metrics.py` |
+| Post-hoc rescoring | `src/utils/rescoring.py` |
+
+## Common Pitfalls
+
+1. **Don't add non-scoring fields to normalizer calibration** — always pass `metric_whitelist` matching the active policy's `metrics` list to `fit()`
+2. **Don't use raw min/max** — the normalizer intentionally clips at quantile anchors to prevent outlier collapse
+3. **Check `is_calibrated` before scoring** — Generation 0 falls back to `fallback_utilities` (typically legacy scoring) before calibration completes
+4. **Weight floors must sum to < 1.0** — the remaining mass is distributed by softmax
+5. **Scorer caches weights at construction** — if features change, create a new `CompositeScorer` instance


### PR DESCRIPTION
## Overview

This PR introduces a comprehensive onboarding workflow and domain knowledge skills for AI agents interacting with the repository. Given the complexity of the custom PBT tuning architecture, multi-instance orchestration, and scoring pipeline, it is critical that agents load specific context rather than guessing standard patterns.

The new `/start-session` workflow acts as a mandatory bootstrap checklist whenever an agent starts a new session in the codebase.

## Changes Included

* **`start-session.md` workflow**: Instructs the agent to map their initial task to the required domain knowledge and load those skills explicitly.
* **`codebase-architecture` skill**: A complete navigational map of `src/` packages, data flow, dependency graphs, and documentation indexing.
* **`scoring-pipeline` skill**: Encodes the domain knowledge for the feature-driven scoring-v2 pipeline (CompositeScorer, QuantileUtilityNormalizer, floor-constrained softmax weights, and drift detection).
* **`evaluation-suite` skill**: Details the `src/evaluation/` post-hoc pipeline, Docker vs. bare-metal isolation, and the Wilcoxon/Bootstrap CI statistical framework.
* **`environment-backends` skill**: Explains the `DatabaseEnvironment` abstraction, port allocation (5440+), and PostgreSQL lifecycle management.
* **`dev-workflow` skill**: Standardizes the CI gates (`make check-all`), `ruff` linting rules, `mypy` scopes, and pytest testing structure.

## Impact

By forcing AI agents to load these skills at the start of a session, we dramatically reduce hallucinations regarding:
- Custom PostgreSQL configuration representation (fractional hardware bounds)
- The unique PBT multi-objective scoring formula
- Evaluation isolation constraints
- Development formatting and testing requirements
