### PR TITLE
Add BO baseline parity and comparison analysis tooling

### DIFF
--- a/docs/BO_BASELINE.md
+++ b/docs/BO_BASELINE.md
@@ -1,0 +1,261 @@
+# Bayesian Optimization Baseline Runner
+
+## Overview
+
+The BO baseline runner implements a Bayesian Optimization (BO) approach to PostgreSQL configuration tuning using SMAC3 (Sequential Model-based Algorithm Configuration). This provides a controlled comparison baseline against the PBT-based tuner for academic peer review.
+
+## Quick Start
+
+### Basic Usage
+
+```bash
+# Match a completed PBT tuning session for stable comparison
+python -m src.scripts.bo_baseline \
+  --pbt-session results/oltp/oltp_read_write/pbt_runs/minimal/tuning_sessions/pbt_results_20260504_1825.json \
+  --seed 42
+
+# Minimal test (3 iterations, 10 seconds evaluation)
+python -m src.scripts.bo_baseline \
+  --tier minimal \
+  --iterations 3 \
+  --benchmark sysbench \
+  --duration 10 \
+  --warmup 5
+
+# Standard tuning (50 iterations)
+python -m src.scripts.bo_baseline \
+  --tier core \
+  --iterations 50 \
+  --benchmark sysbench \
+  --workload oltp \
+  --sysbench-workload oltp_read_write
+
+# Comprehensive tuning (100 iterations, TPC-H)
+python -m src.scripts.bo_baseline \
+  --tier standard \
+  --iterations 100 \
+  --benchmark tpch \
+  --scale-factor 1.0
+```
+
+## Architecture
+
+### Components
+
+1. **config.py** - BOConfig dataclass with all tuning parameters
+2. **search_space.py** - Translates KnobSpace ↔ ConfigSpace
+3. **objective.py** - SMAC3-compatible objective function
+4. **result_writer.py** - Serializes results in PBT-compatible JSON
+5. **runner.py** - Main orchestrator (BOBaselineRunner)
+6. **__main__.py** - CLI entry point
+
+### Facade Selection
+
+- **BlackBoxFacade (GP)**: Used for ≤13 knobs (minimal, core tiers)
+  - Gaussian Process surrogate with Matérn 5/2 kernel
+  - Expected Improvement acquisition function
+  - Better for low-dimensional spaces
+
+- **HyperparameterOptimizationFacade (RF)**: Used for 30+ knobs (standard, extensive tiers)
+  - Random Forest surrogate
+  - Handles high-dimensional mixed spaces better
+  - More robust to flat penalty regions
+
+## Configuration Options
+
+### PBT Session Parity
+- `--pbt-session PATH` - Reference PBT tuning-session JSON. When provided, BO copies comparable experimental settings from the PBT run:
+  - `knob_tier`
+  - `benchmark_name`
+  - `workload_type`
+  - `tuning_mode`
+  - `sysbench_tables`
+  - `sysbench_table_size`
+  - `sysbench_workload`
+  - `sysbench_duration_seconds`
+  - `sysbench_warmup_seconds`
+  - `tpch_scale_factor`
+  - `tpch_warmup_passes`
+  - knob names from `best_configuration.knobs`
+
+When `--pbt-session` is used, `--tier` is optional. If `--iterations` is omitted, BO sets:
+
+```text
+iterations = population_size * total_generations
+```
+
+from the PBT session. Passing `--iterations` explicitly overrides this derived budget.
+
+Example:
+
+```bash
+python -m src.scripts.bo_baseline \
+  --pbt-session results/oltp/oltp_read_write/pbt_runs/minimal/tuning_sessions/pbt_results_20260504_1825.json \
+  --seed 42
+```
+
+### Search Space
+- `--tier {minimal|core|standard|extensive}` - Knob space tier. Required only when `--pbt-session` is not provided.
+
+### BO Configuration
+- `--iterations N` - Number of BO iterations. Defaults to `50`, or to `population_size * total_generations` when `--pbt-session` is used.
+- `--seed INT` - Random seed for reproducibility (default: 42)
+
+### Benchmark Options
+- `--benchmark {sysbench|tpch}` - Benchmark type (default: sysbench)
+- `--workload {oltp|olap|mixed}` - Workload type (default: oltp)
+- `--duration FLOAT` - Evaluation duration in seconds (default: 30)
+- `--warmup FLOAT` - Warmup duration in seconds (default: 10)
+
+### Sysbench-Specific
+- `--sysbench-tables INT` - Number of tables (default: 4)
+- `--sysbench-table-size INT` - Table size (default: 100000)
+- `--sysbench-workload {oltp_read_only|oltp_read_write|oltp_write_only}` - Workload (default: oltp_read_write)
+
+### TPC-H-Specific
+- `--scale-factor FLOAT` - Scale factor (default: 1.0)
+- `--tpch-warmup-passes INT` - Warmup passes (default: 1)
+
+### Instance Options
+- `--no-docker` - Use bare-metal PostgreSQL instead of Docker
+- `--docker-image IMAGE` - Custom Docker image name
+- `--force-recreate-instances` - Force recreate PostgreSQL instances
+- `--force-recreate-baseline` - Force recreate baseline snapshot
+- `--tuning-mode {offline|online|adaptive}` - Tuning mode (default: offline)
+
+### Output Options
+- `--output-dir PATH` - Output directory (default: results)
+- `--verbose {DEBUG|INFO|WARNING|ERROR}` - Logging level (default: INFO)
+- `--range-update-interval INT` - Adaptive range update interval (default: 5)
+
+## Parameter Reference
+
+| Parameter | Purpose | Default / Source |
+| --- | --- | --- |
+| `--pbt-session` | Loads a PBT tuning-session file and copies the settings needed for a stable BO comparison. | Not set |
+| `--tier` | Selects the knob tier when running BO independently. | Required unless `--pbt-session` is set |
+| `--iterations` | Sets the BO evaluation budget. | `50`, or PBT `population_size * total_generations` |
+| `--seed` | Controls BO random seed and SMAC scenario seed. | `42` |
+| `--benchmark` | Chooses `sysbench` or `tpch`. | `sysbench`, or PBT `benchmark_name` |
+| `--workload` | Chooses metric scoring context: `oltp`, `olap`, or `mixed`. | `oltp`, or PBT `workload_type` |
+| `--duration` | Measurement duration per evaluated configuration. | `30`, or PBT `sysbench_duration_seconds` |
+| `--warmup` | Warmup duration before measurement. | `10`, or PBT `sysbench_warmup_seconds` |
+| `--sysbench-tables` | Number of sysbench tables to prepare. | `4`, or PBT `sysbench_tables` |
+| `--sysbench-table-size` | Rows per sysbench table. | `100000`, or PBT `sysbench_table_size` |
+| `--sysbench-workload` | Sysbench script/workload. | `oltp_read_write`, or PBT `sysbench_workload` |
+| `--scale-factor` | TPC-H scale factor. | `1.0`, or PBT `tpch_scale_factor` |
+| `--tpch-warmup-passes` | TPC-H query warmup passes. | `1`, or PBT `tpch_warmup_passes` |
+| `--no-docker` | Uses bare-metal PostgreSQL instead of Docker. | Docker enabled |
+| `--docker-image` | Overrides PostgreSQL Docker image. | Environment default |
+| `--force-recreate-instances` | Recreates worker database instances. | Disabled |
+| `--force-recreate-baseline` | Recreates baseline snapshot state. | Disabled |
+| `--tuning-mode` | Controls restart/application behavior. | `offline`, or PBT `tuning_mode` |
+| `--output-dir` | Root directory for BO result files. | `results` |
+| `--verbose` | Logging verbosity. | `INFO` |
+| `--range-update-interval` | Iteration interval for adaptive metric-range updates. | `5` |
+
+## Output Format
+
+Results are written to:
+```
+{output_dir}/{workload_type}/bo_runs/{tier}/tuning_sessions/bo_results_{timestamp}.json
+```
+
+The JSON format is compatible with the evaluation pipeline:
+- `tuning_session` - Metadata about the BO run
+- `best_configuration` - Best knob config and score found
+- `worker_resources` - Hardware constraints
+- `generation_history` - Per-iteration convergence data
+- `system_info` - System snapshot
+
+When `--pbt-session` is used, `tuning_session` also records:
+- `reference_pbt_session` - Path to the PBT session used as the reference
+- `reference_pbt_knobs` - Knob names copied from `best_configuration.knobs`
+
+## Multi-Seed Evaluation
+
+For statistical significance, run with multiple seeds:
+
+```bash
+for seed in 42 123 456 789 1024; do
+  python -m src.scripts.bo_baseline \
+    --pbt-session results/oltp/oltp_read_write/pbt_runs/minimal/tuning_sessions/pbt_results_20260504_1825.json \
+    --seed $seed
+done
+```
+
+Then use the evaluation pipeline to compare:
+
+```bash
+python -m src.evaluation \
+  --session results/oltp/bo_runs/core/tuning_sessions/bo_results_*.json
+```
+
+## Adaptive Normalization
+
+During tuning, both BO and PBT use the same `MetricConfig` factory with identical initial fallback ranges. BO calls `metric_config.expand_ranges_for_metrics()` every `--range-update-interval` iterations, matching PBT's adaptive behavior.
+
+For cross-method comparison, use `rescore_metrics_globally()` from `src/utils/rescoring.py` to pool metrics from both runs and rescore with a single globally calibrated `MetricConfig`.
+
+## Testing
+
+Run the test suite:
+
+```bash
+# All tests
+python -m pytest tests/test_bo_baseline.py -v
+
+# Specific test class
+python -m pytest tests/test_bo_baseline.py::TestSearchSpaceTranslation -v
+
+# Specific test
+python -m pytest tests/test_bo_baseline.py::TestSearchSpaceTranslation::test_build_configspace_minimal -v
+```
+
+## Implementation Notes
+
+### Search Space Translation
+
+- Integer knobs with log scale: min clamped to 1
+- Float knobs with log scale: min clamped to 1e-9
+- Degenerate ranges (min == max): converted to Constant parameters
+- Default values: validated to be within bounds, set to None if out of range
+
+### Objective Function
+
+- Cost = 100 - score (SMAC minimizes cost)
+- Failure penalties:
+  - Timeout: cost = 99.0
+  - Dead instance: cost = 99.5
+  - Unexpected error: cost = 100.0
+- Restart detection: checks if any restart-required knobs changed
+- Adaptive range updates: every N iterations, expands metric ranges based on observed values
+
+### Result Serialization
+
+- Compatible with `load_tuning_session()` from evaluation pipeline
+- Generation history uses same schema as PBT (single-element worker arrays)
+- Best configuration extracted from SMAC's incumbent
+- Convergence tracking via generation_history
+
+## Troubleshooting
+
+### Import Errors
+- Ensure ConfigSpace is installed: `pip install ConfigSpace>=1.1.0`
+- Ensure SMAC3 is installed: `pip install smac>=2.2.0`
+- Note: Import is `from ConfigSpace` (capital C), not `from configspace`
+
+### Connection Errors
+- Verify PostgreSQL instances are running on ports 5440+
+- Check `.env` file for database credentials
+- Use `--force-recreate-instances` to reset state
+
+### Memory Issues
+- Reduce `--iterations` for lower memory usage
+- Use `--tier minimal` for quick testing
+- Reduce `--duration` for faster iterations
+
+### Long Runtimes
+- Reduce `--duration` parameter for faster evaluation
+- Use `--tier minimal` for quick prototyping
+- Increase `--iterations` only after validating with smaller runs

--- a/docs/BO_BASELINE.md
+++ b/docs/BO_BASELINE.md
@@ -51,15 +51,26 @@ python -m src.scripts.bo_baseline \
 
 ### Facade Selection
 
-- **BlackBoxFacade (GP)**: Used for ≤13 knobs (minimal, core tiers)
-  - Gaussian Process surrogate with Matérn 5/2 kernel
-  - Expected Improvement acquisition function
-  - Better for low-dimensional spaces
+The SMAC3 facade controls the underlying surrogate model used for Bayesian Optimization. You can specify this using the `--bo-surrogate` argument:
 
-- **HyperparameterOptimizationFacade (RF)**: Used for 30+ knobs (standard, extensive tiers)
-  - Random Forest surrogate
-  - Handles high-dimensional mixed spaces better
-  - More robust to flat penalty regions
+- **Random Forest (`--bo-surrogate rf`)**: Uses `HyperparameterOptimizationFacade`. Handles high-dimensional, mixed spaces better and is robust to flat penalty regions. Includes 20% random interleaving (`ProbabilityRandomDesign`) to prevent surrogate over-exploitation. Default behavior.
+- **Gaussian Process (`--bo-surrogate gp`)**: Uses `BlackBoxFacade`. Employs a Gaussian Process surrogate with Matérn 5/2 kernel and Expected Improvement acquisition function. Better for low-dimensional, continuous spaces.
+
+Both facades use:
+- `deterministic=False` — database benchmarks have inherent measurement variance; this forces SMAC to re-evaluate incumbents and prevents overconfidence.
+- `SobolInitialDesign` — quasi-random initial points for uniform pilot-phase coverage of the search space.
+
+### Pilot + Freeze Normalization
+
+The scoring function (`feature_driven_v2`) requires normalization ranges (e.g., max TPS, min latency). Dynamically updating these ranges mid-run corrupts the surrogate model's training signal because historical cost values become stale.
+
+The BO runner uses a **Pilot + Freeze** strategy:
+
+1. **Pilot Phase** (first N iterations, controlled by `--range-update-interval`): SMAC's Sobol initial design evaluates diverse configurations using default fallback ranges. Raw metrics are recorded.
+2. **Freeze Event** (exactly once, at the end of the pilot): `metric_config.expand_ranges_for_metrics()` calibrates normalization bounds from all pilot observations.
+3. **Frozen Phase** (remaining iterations): Normalization bounds are locked. The surrogate model trains on a stable cost surface.
+
+Post-hoc global rescoring (via `pbt_vs_bo_comparison.py`) uses the saved raw `PerformanceMetrics` to recompute scores with globally calibrated ranges, so the frozen in-run scores do not affect final comparison validity.
 
 ## Configuration Options
 
@@ -99,7 +110,8 @@ python -m src.scripts.bo_baseline \
 
 ### BO Configuration
 - `--iterations N` - Number of BO iterations. Defaults to `50`, or to `population_size * total_generations` when `--pbt-session` is used.
-- `--seed INT` - Random seed for reproducibility (default: 42)
+- `--seed INT` - Random seed for reproducibility (default: `42`)
+- `--bo-surrogate {rf|gp}` - SMAC Surrogate model: Random Forest (`rf`) or Gaussian Process (`gp`). Default is `rf`.
 
 ### Benchmark Options
 - `--benchmark {sysbench|tpch}` - Benchmark type (default: sysbench)
@@ -126,7 +138,7 @@ python -m src.scripts.bo_baseline \
 ### Output Options
 - `--output-dir PATH` - Output directory (default: results)
 - `--verbose {DEBUG|INFO|WARNING|ERROR}` - Logging level (default: INFO)
-- `--range-update-interval INT` - Adaptive range update interval (default: 5)
+- `--range-update-interval INT` - Pilot phase size (default: 10)
 
 ## Parameter Reference
 
@@ -152,7 +164,7 @@ python -m src.scripts.bo_baseline \
 | `--tuning-mode` | Controls restart/application behavior. | `offline`, or PBT `tuning_mode` |
 | `--output-dir` | Root directory for BO result files. | `results` |
 | `--verbose` | Logging verbosity. | `INFO` |
-| `--range-update-interval` | Iteration interval for adaptive metric-range updates. | `5` |
+| `--range-update-interval` | Pilot phase size: initial-design iterations before freezing normalization ranges. | `10` |
 
 ## Output Format
 
@@ -167,6 +179,10 @@ The JSON format is compatible with the evaluation pipeline:
 - `worker_resources` - Hardware constraints
 - `generation_history` - Per-iteration convergence data
 - `system_info` - System snapshot
+
+The BO CLI `--seed` value is recorded as `tuning_session.seed` in the result
+JSON so downstream comparison tools can report the actual tuning seed rather
+than inferring one from file order.
 
 When `--pbt-session` is used, `tuning_session` also records:
 - `reference_pbt_session` - Path to the PBT session used as the reference
@@ -191,11 +207,13 @@ python -m src.evaluation \
   --session results/oltp/bo_runs/core/tuning_sessions/bo_results_*.json
 ```
 
-## Adaptive Normalization
+## Normalization Strategy
 
-During tuning, both BO and PBT use the same `MetricConfig` factory with identical initial fallback ranges. BO calls `metric_config.expand_ranges_for_metrics()` every `--range-update-interval` iterations, matching PBT's adaptive behavior.
+During tuning, BO uses a **Pilot + Freeze** approach: the first N iterations (Sobol initial design) run with default fallback ranges, then `metric_config.expand_ranges_for_metrics()` is called exactly once to calibrate bounds from pilot observations. Ranges are frozen for the remainder of the run to preserve surrogate model integrity.
 
-For cross-method comparison, use `rescore_metrics_globally()` from `src/utils/rescoring.py` to pool metrics from both runs and rescore with a single globally calibrated `MetricConfig`.
+PBT uses rolling adaptive normalization (expanding ranges every generation). This difference is intentional — BO requires a stable cost surface for its surrogate, while PBT's population-based approach is robust to shifting targets.
+
+For cross-method comparison, use `rescore_metrics_globally()` from `src/utils/rescoring.py` to pool raw metrics from both runs and rescore with a single globally calibrated `MetricConfig`.
 
 ## Testing
 
@@ -229,7 +247,7 @@ python -m pytest tests/test_bo_baseline.py::TestSearchSpaceTranslation::test_bui
   - Dead instance: cost = 99.5
   - Unexpected error: cost = 100.0
 - Restart detection: checks if any restart-required knobs changed
-- Adaptive range updates: every N iterations, expands metric ranges based on observed values
+- Pilot+Freeze normalization: ranges calibrated once after initial design, then locked
 
 ### Result Serialization
 

--- a/docs/PBT_VS_BO_COMPARISON.md
+++ b/docs/PBT_VS_BO_COMPARISON.md
@@ -1,0 +1,140 @@
+# PBT vs BO Comparison Script
+
+## Overview
+
+`src/scripts/pbt_vs_bo_comarison.py` compares completed PBT and BO tuning-session JSON files. It loads the full evaluation history from every run, rescales all raw metrics using one global post-hoc scoring context, then writes CSV tables and publication-ready PDF plots.
+
+The script does not modify iteration counts, truncate runs, or enforce that inputs have identical settings. It compares exactly the files passed through `--pbt` and `--bo`.
+
+## Usage
+
+```bash
+python -m src.scripts.pbt_vs_bo_comarison \
+  --pbt results/oltp/oltp_read_write/pbt_runs/minimal/tuning_sessions/pbt_results_20260504_1825.json \
+        results/oltp/oltp_read_write/pbt_runs/minimal/tuning_sessions/pbt_results_20260504_1831.json \
+        results/oltp/oltp_read_write/pbt_runs/minimal/tuning_sessions/pbt_results_20260504_1836.json \
+  --bo results/oltp/bo_runs/minimal/tuning_sessions/bo_results_20260504_1921.json \
+       results/oltp/bo_runs/minimal/tuning_sessions/bo_results_20260504_2002.json \
+       results/oltp/bo_runs/minimal/tuning_sessions/bo_results_20260504_2043.json \
+  --output-dir analysis
+```
+
+## Parameters
+
+| Parameter | Required | Description |
+| --- | --- | --- |
+| `--pbt` | Yes | One or more PBT tuning-session JSON files. |
+| `--bo` | Yes | One or more BO tuning-session JSON files. |
+| `--output-dir` | No | Directory for generated CSV and PDF files. Defaults to `analysis`. |
+
+## Input Format
+
+Each input file should use the tuning-session schema produced by the tuner or BO baseline writer:
+
+- `tuning_session` - Run metadata. The first input run provides the benchmark/workload context used for global rescoring.
+- `best_configuration.metrics` - Final best metrics for the run.
+- `generation_history[].worker_scores[].metrics` - Evaluation metrics over time.
+- `generation_history[].timestamp` - Used to estimate elapsed wall-clock time.
+
+BO outputs are written in the same shape as PBT outputs, with one worker score per BO iteration.
+
+## Scoring Behavior
+
+The script pools all metrics from all PBT and BO runs, then calls `rescore_metrics_globally()`. This recalibrates normalization ranges once across the combined dataset and assigns a comparable `GlobalScore` to every evaluation.
+
+For convergence plots, each run's score is converted to best-so-far form:
+
+```text
+GlobalScore at evaluation N = max(global score from evaluations 1..N)
+```
+
+This makes the curve represent optimization progress rather than raw per-evaluation noise.
+
+## Output Files
+
+All files are written to `--output-dir`.
+
+### `comparison_summary.csv`
+
+Aggregated method-level summary.
+
+Columns:
+- `Method` - `PBT` or `BO`
+- `Mean_Best_Score` - Mean final globally rescored best score
+- `StdDev_Best_Score` - Standard deviation of final best scores
+- `Mean_WallClock_Time` - Mean elapsed wall-clock time at the final evaluation
+- `Mean_Throughput` - Mean throughput from final best configurations
+- `Mean_LatencyP95` - Mean p95 latency from final best configurations
+- `Mean_MemoryUtilization` - Mean memory utilization from final best configurations
+- `Trials` - Number of runs for that method
+
+### `comparison_runs.csv`
+
+Per-run detail table.
+
+Columns:
+- `Method` - `PBT` or `BO`
+- `Seed` - Positional seed index assigned from the input order
+- `SourceFile` - Input JSON path
+- `BestScore` - Final globally rescored best score
+- `WallClockTime` - Final elapsed wall-clock time for that run
+- `Throughput` - Throughput of the final best configuration
+- `LatencyP95` - p95 latency of the final best configuration
+- `MemoryUtilization` - Memory utilization of the final best configuration
+
+### `comparison_timeseries.csv`
+
+Rescored convergence data used by the convergence PDF.
+
+Columns:
+- `Method` - `PBT` or `BO`
+- `Seed` - Positional seed index assigned from the input order
+- `Evaluations` - Cumulative evaluation count within the run
+- `WallTimeSeconds` - Elapsed wall-clock time inferred from generation timestamps
+- `GlobalScore` - Best-so-far globally rescored score
+
+### `statistical_significance.csv`
+
+Mann-Whitney U test result over final best scores.
+
+Columns:
+- `Test` - Statistical test name
+- `PBT_N` - Number of PBT runs
+- `BO_N` - Number of BO runs
+- `PBT_Mean` - Mean PBT final best score
+- `PBT_StdDev` - PBT score standard deviation
+- `BO_Mean` - Mean BO final best score
+- `BO_StdDev` - BO score standard deviation
+- `U_Statistic` - Mann-Whitney U statistic
+- `P_Value` - Two-sided p-value
+- `Alpha` - Significance threshold, currently `0.05`
+- `Significant` - Whether `P_Value < Alpha`
+
+### `publication_ready_convergence.pdf`
+
+Two-panel convergence plot:
+
+- Sample efficiency: best global score versus cumulative evaluations.
+- Wall-clock efficiency: best global score versus elapsed seconds.
+
+Each method is plotted with a mean line and standard-deviation error band when multiple runs are provided.
+
+### `publication_ready_pareto.pdf`
+
+Scatter plot of final best configurations:
+
+- X axis: throughput, higher is better.
+- Y axis: p95 latency, lower is better.
+- Hue/style: method.
+
+### `publication_ready_resource_efficiency.pdf`
+
+Box/strip plot of memory utilization for final best configurations, grouped by method.
+
+## Recommended Workflow
+
+1. Run PBT and save one or more tuning-session files.
+2. Run BO with `--pbt-session` so its benchmark, workload, knob set, and evaluation budget match the selected PBT session.
+3. Pass the generated PBT and BO JSON files to `pbt_vs_bo_comarison.py`.
+4. Use `comparison_summary.csv` for aggregate numbers, `comparison_runs.csv` for per-run checks, and the PDFs for figures.
+

--- a/docs/PBT_VS_BO_COMPARISON.md
+++ b/docs/PBT_VS_BO_COMPARISON.md
@@ -32,6 +32,7 @@ python -m src.scripts.pbt_vs_bo_comarison \
 Each input file should use the tuning-session schema produced by the tuner or BO baseline writer:
 
 - `tuning_session` - Run metadata. The first input run provides the benchmark/workload context used for global rescoring.
+- `tuning_session.seed` - Tuning seed used for the run. Legacy files with `tuning_session.random_seed` are still accepted.
 - `best_configuration.metrics` - Final best metrics for the run.
 - `generation_history[].worker_scores[].metrics` - Evaluation metrics over time.
 - `generation_history[].timestamp` - Used to estimate elapsed wall-clock time.
@@ -74,7 +75,7 @@ Per-run detail table.
 
 Columns:
 - `Method` - `PBT` or `BO`
-- `Seed` - Positional seed index assigned from the input order
+- `Seed` - Tuning seed read from `tuning_session.seed`; blank for legacy files that do not record seed metadata.
 - `SourceFile` - Input JSON path
 - `BestScore` - Final globally rescored best score
 - `WallClockTime` - Final elapsed wall-clock time for that run
@@ -88,7 +89,7 @@ Rescored convergence data used by the convergence PDF.
 
 Columns:
 - `Method` - `PBT` or `BO`
-- `Seed` - Positional seed index assigned from the input order
+- `Seed` - Tuning seed read from `tuning_session.seed`; blank for legacy files that do not record seed metadata.
 - `Evaluations` - Cumulative evaluation count within the run
 - `WallTimeSeconds` - Elapsed wall-clock time inferred from generation timestamps
 - `GlobalScore` - Best-so-far globally rescored score
@@ -137,4 +138,3 @@ Box/strip plot of memory utilization for final best configurations, grouped by m
 2. Run BO with `--pbt-session` so its benchmark, workload, knob set, and evaluation budget match the selected PBT session.
 3. Pass the generated PBT and BO JSON files to `pbt_vs_bo_comarison.py`.
 4. Use `comparison_summary.csv` for aggregate numbers, `comparison_runs.csv` for per-run checks, and the PDFs for figures.
-

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,8 @@ This index provides a quick navigation map for the project documentation set.
 
 - [Performance Evaluation](./PERFORMANCE_EVALUATION.md)
 - [Evaluation Reproducibility Runbook](./EVALUATION_RUNBOOK.md)
+- [Bayesian Optimization Baseline](./BO_BASELINE.md)
+- [PBT vs BO Comparison Script](./PBT_VS_BO_COMPARISON.md)
 - [Metrics Validation](./METRICS_VALIDATION.md)
 - [Benchmarking Strategy](./BENCHMARKING.md)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,5 +33,8 @@ docker>=7.0.0          # Docker SDK for Python — container lifecycle managemen
 
 # Importance Analysis
 fanova>=2.0.18
-ConfigSpace>=0.6.1
+ConfigSpace>=1.1.0
 shap>=0.49.0
+
+# Bayesian Optimization
+smac>=2.2.0

--- a/src/evaluation/loader.py
+++ b/src/evaluation/loader.py
@@ -461,37 +461,3 @@ def _check_version_compatibility(
             metric_reference_version,
             DEFAULT_METRIC_REFERENCE_VERSION,
         )
-
-
-def _check_version_compatibility(
-    scoring_policy_version: str,
-    metric_reference_version: str,
-    path: Path,
-) -> None:
-    """
-    Check for version compatibility and warn on mismatches.
-
-    Implements mixed-version warning policy:
-    - Warns if scoring_policy_version differs from current default
-    - Warns if metric_reference_version differs from current default
-    - Allows loading but alerts user to potential incompatibilities
-    """
-    if scoring_policy_version != DEFAULT_SCORING_POLICY_VERSION:
-        logger.warning(
-            "  ➤ Scoring policy version mismatch in %s: "
-            "session uses v%s but current default is v%s. "
-            "Results may not be directly comparable.",
-            path.name,
-            scoring_policy_version,
-            DEFAULT_SCORING_POLICY_VERSION,
-        )
-
-    if metric_reference_version != DEFAULT_METRIC_REFERENCE_VERSION:
-        logger.warning(
-            "  ➤ Metric reference version mismatch in %s: "
-            "session uses v%s but current default is v%s. "
-            "Metric interpretations may differ.",
-            path.name,
-            metric_reference_version,
-            DEFAULT_METRIC_REFERENCE_VERSION,
-        )

--- a/src/evaluation/runner.py
+++ b/src/evaluation/runner.py
@@ -436,8 +436,8 @@ class ComparisonRunner:
 
         if benchmark == "tpch":
             # Keep sysbench fields resolved for metadata completeness.
-            resolved["sysbench_duration"] = int(resolved["sysbench_duration"])
-        return resolved
+            resolved["sysbench_duration"] = int(str(resolved["sysbench_duration"]))  # type: ignore
+        return resolved  # type: ignore
 
     def _resolve_sysbench_workload(
         self,

--- a/src/scripts/bo_baseline/__init__.py
+++ b/src/scripts/bo_baseline/__init__.py
@@ -1,0 +1,1 @@
+"""Bayesian Optimization baseline runner for PostgreSQL configuration tuning."""

--- a/src/scripts/bo_baseline/__main__.py
+++ b/src/scripts/bo_baseline/__main__.py
@@ -1,0 +1,6 @@
+"""CLI entry point for Bayesian Optimization baseline runner."""
+
+from src.scripts.bo_baseline.runner import main
+
+if __name__ == "__main__":
+    main()

--- a/src/scripts/bo_baseline/config.py
+++ b/src/scripts/bo_baseline/config.py
@@ -28,7 +28,9 @@ class BOConfig:
     # Sysbench Configuration
     sysbench_tables: int = 4
     sysbench_table_size: int = 100000
-    sysbench_workload: str = "oltp_read_write"  # oltp_read_only, oltp_read_write, oltp_write_only
+    sysbench_workload: str = (
+        "oltp_read_write"  # oltp_read_only, oltp_read_write, oltp_write_only
+    )
 
     # TPC-H Configuration
     scale_factor: float = 1.0
@@ -121,7 +123,9 @@ class BOConfig:
             raise ValueError("Either --tier or --pbt-session must be provided")
 
         config = cls(
-            n_iterations=args.iterations if args.iterations is not None else cls.n_iterations,
+            n_iterations=args.iterations
+            if args.iterations is not None
+            else cls.n_iterations,
             random_seed=args.seed,
             knob_tier=args.tier or cls.knob_tier,
             benchmark=args.benchmark,
@@ -152,6 +156,7 @@ class BOConfig:
                 )
             except Exception as e:
                 from src.utils.logger import get_logger
+
                 logger = get_logger(__name__)
                 logger.warning(
                     f"Failed to load PBT session from {args.pbt_session}: {e}. "

--- a/src/scripts/bo_baseline/config.py
+++ b/src/scripts/bo_baseline/config.py
@@ -44,8 +44,11 @@ class BOConfig:
     output_dir: Path = field(default_factory=lambda: Path("results"))
     verbose: str = "INFO"  # DEBUG, INFO, WARNING, ERROR
 
-    # Adaptive Range Update
-    range_update_interval: int = 5
+    # Pilot+Freeze: number of initial design iterations before freezing ranges
+    range_update_interval: int = 10
+
+    # SMAC surrogate model
+    bo_surrogate: str = "rf"  # gp, rf
 
     # PBT parity configuration
     pbt_session_path: Optional[Path] = None
@@ -138,12 +141,21 @@ class BOConfig:
             output_dir=Path(args.output_dir),
             verbose=args.verbose,
             range_update_interval=args.range_update_interval,
+            bo_surrogate=args.bo_surrogate,
         )
 
         if args.pbt_session:
-            config.apply_pbt_session(
-                Path(args.pbt_session),
-                set_iteration_budget=args.iterations is None,
-            )
+            try:
+                config.apply_pbt_session(
+                    Path(args.pbt_session),
+                    set_iteration_budget=args.iterations is None,
+                )
+            except Exception as e:
+                from src.utils.logger import get_logger
+                logger = get_logger(__name__)
+                logger.warning(
+                    f"Failed to load PBT session from {args.pbt_session}: {e}. "
+                    f"Falling back to default or CLI-provided settings."
+                )
 
         return config

--- a/src/scripts/bo_baseline/config.py
+++ b/src/scripts/bo_baseline/config.py
@@ -1,0 +1,149 @@
+"""Configuration dataclass for Bayesian Optimization baseline runner."""
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Optional
+import argparse
+
+
+@dataclass
+class BOConfig:
+    """Configuration for Bayesian Optimization baseline tuning."""
+
+    # BO Configuration
+    n_iterations: int = 50
+    random_seed: int = 42
+
+    # Knob Space
+    knob_tier: str = "core"  # minimal, core, standard, extensive
+
+    # Benchmark Configuration
+    benchmark: str = "sysbench"  # sysbench or tpch
+    workload_type: str = "oltp"  # oltp, olap, mixed
+    evaluation_duration: float = 30.0  # seconds
+    warmup_duration: float = 10.0  # seconds
+    tuning_mode: str = "offline"  # offline, online, adaptive
+
+    # Sysbench Configuration
+    sysbench_tables: int = 4
+    sysbench_table_size: int = 100000
+    sysbench_workload: str = "oltp_read_write"  # oltp_read_only, oltp_read_write, oltp_write_only
+
+    # TPC-H Configuration
+    scale_factor: float = 1.0
+    tpch_warmup_passes: int = 1
+
+    # Instance Configuration
+    use_docker: bool = True
+    docker_image: Optional[str] = None
+    force_recreate_instances: bool = False
+    force_recreate_baseline: bool = False
+
+    # Output Configuration
+    output_dir: Path = field(default_factory=lambda: Path("results"))
+    verbose: str = "INFO"  # DEBUG, INFO, WARNING, ERROR
+
+    # Adaptive Range Update
+    range_update_interval: int = 5
+
+    # PBT parity configuration
+    pbt_session_path: Optional[Path] = None
+    pbt_knob_names: Optional[tuple[str, ...]] = None
+
+    @staticmethod
+    def _load_pbt_session(path: Path) -> Dict[str, Any]:
+        """Load a PBT tuning-session JSON file."""
+        if not path.exists():
+            raise FileNotFoundError(f"PBT tuning session does not exist: {path}")
+
+        try:
+            with path.open("r", encoding="utf-8") as handle:
+                payload = json.load(handle)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"PBT tuning session is not valid JSON: {path}") from exc
+
+        if not isinstance(payload, dict):
+            raise ValueError(f"PBT tuning session must contain a JSON object: {path}")
+
+        session = payload.get("tuning_session")
+        if not isinstance(session, dict):
+            raise ValueError(
+                f"PBT tuning session is missing tuning_session metadata: {path}"
+            )
+
+        return payload
+
+    def apply_pbt_session(self, path: Path, set_iteration_budget: bool = True) -> None:
+        """Apply comparable benchmark/search settings from a PBT tuning session."""
+        payload = self._load_pbt_session(path)
+        session = payload["tuning_session"]
+
+        self.pbt_session_path = path
+        self.knob_tier = str(session.get("knob_tier", self.knob_tier))
+        self.benchmark = str(session.get("benchmark_name", self.benchmark))
+        self.workload_type = str(session.get("workload_type", self.workload_type))
+        self.tuning_mode = str(session.get("tuning_mode", self.tuning_mode))
+
+        if "sysbench_duration_seconds" in session:
+            self.evaluation_duration = float(session["sysbench_duration_seconds"])
+        if "sysbench_warmup_seconds" in session:
+            self.warmup_duration = float(session["sysbench_warmup_seconds"])
+        if "sysbench_tables" in session:
+            self.sysbench_tables = int(session["sysbench_tables"])
+        if "sysbench_table_size" in session:
+            self.sysbench_table_size = int(session["sysbench_table_size"])
+        if "sysbench_workload" in session:
+            self.sysbench_workload = str(session["sysbench_workload"])
+        if "tpch_scale_factor" in session:
+            self.scale_factor = float(session["tpch_scale_factor"])
+        if "tpch_warmup_passes" in session:
+            self.tpch_warmup_passes = int(session["tpch_warmup_passes"])
+        if set_iteration_budget:
+            population_size = int(session.get("population_size", 0) or 0)
+            total_generations = int(session.get("total_generations", 0) or 0)
+            if population_size > 0 and total_generations > 0:
+                self.n_iterations = population_size * total_generations
+
+        best_configuration = payload.get("best_configuration", {})
+        if isinstance(best_configuration, dict):
+            knobs = best_configuration.get("knobs", {})
+            if isinstance(knobs, dict) and knobs:
+                self.pbt_knob_names = tuple(sorted(str(name) for name in knobs))
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> "BOConfig":
+        """Create BOConfig from argparse Namespace."""
+        if args.tier is None and not args.pbt_session:
+            raise ValueError("Either --tier or --pbt-session must be provided")
+
+        config = cls(
+            n_iterations=args.iterations if args.iterations is not None else cls.n_iterations,
+            random_seed=args.seed,
+            knob_tier=args.tier or cls.knob_tier,
+            benchmark=args.benchmark,
+            workload_type=args.workload,
+            evaluation_duration=args.duration,
+            warmup_duration=args.warmup,
+            tuning_mode=args.tuning_mode,
+            sysbench_tables=args.sysbench_tables,
+            sysbench_table_size=args.sysbench_table_size,
+            sysbench_workload=args.sysbench_workload,
+            scale_factor=args.scale_factor,
+            tpch_warmup_passes=args.tpch_warmup_passes,
+            use_docker=not args.no_docker,
+            docker_image=args.docker_image,
+            force_recreate_instances=args.force_recreate_instances,
+            force_recreate_baseline=args.force_recreate_baseline,
+            output_dir=Path(args.output_dir),
+            verbose=args.verbose,
+            range_update_interval=args.range_update_interval,
+        )
+
+        if args.pbt_session:
+            config.apply_pbt_session(
+                Path(args.pbt_session),
+                set_iteration_budget=args.iterations is None,
+            )
+
+        return config

--- a/src/scripts/bo_baseline/objective.py
+++ b/src/scripts/bo_baseline/objective.py
@@ -51,7 +51,9 @@ def create_objective(
     Callable[[Configuration, int], float]
         Objective function for SMAC3 (minimizes cost)
     """
-    state = {
+    from typing import Dict, Any
+
+    state: Dict[str, Any] = {
         "previous_config": None,
         "iteration_count": 0,
         "ranges_frozen": False,

--- a/src/scripts/bo_baseline/objective.py
+++ b/src/scripts/bo_baseline/objective.py
@@ -1,0 +1,152 @@
+"""Objective function wrapper for SMAC3 Bayesian Optimization."""
+
+import time
+from typing import Callable, Dict, Any, List, Optional
+from ConfigSpace import Configuration
+
+from src.tuner.config.knob_space import KnobSpace
+from src.tuner.core.worker import Worker
+from src.tuner.evaluator.evaluator import Evaluator
+from src.utils.environments.base import DatabaseEnvironment
+from src.utils.metrics import MetricConfig, PerformanceMetrics
+from src.scripts.bo_baseline.search_space import configspace_to_knobs
+from src.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+def create_objective(
+    evaluator: Evaluator,
+    worker: Worker,
+    knob_space: KnobSpace,
+    env: DatabaseEnvironment,
+    metric_config: MetricConfig,
+    iteration_log: List[Dict],
+    range_update_interval: int = 5,
+) -> Callable[[Configuration, int], float]:
+    """
+    Create an objective function for SMAC3.
+
+    Parameters
+    ----------
+    evaluator : Evaluator
+        The evaluator for computing performance metrics
+    worker : Worker
+        The worker to evaluate
+    knob_space : KnobSpace
+        The knob space for configuration repair
+    env : DatabaseEnvironment
+        The database environment
+    metric_config : MetricConfig
+        Metric configuration for scoring
+    iteration_log : List[Dict]
+        Mutable list for tracking convergence
+    range_update_interval : int
+        How often to update metric ranges
+
+    Returns
+    -------
+    Callable[[Configuration, int], float]
+        Objective function for SMAC3 (minimizes cost)
+    """
+    # Closure state for tracking previous config
+    state = {"previous_config": None, "iteration_count": 0}
+
+    def objective(config: Configuration, seed: int = 0) -> float:
+        """
+        Evaluate a configuration and return cost (lower is better).
+
+        Parameters
+        ----------
+        config : Configuration
+            ConfigSpace configuration to evaluate
+        seed : int
+            Random seed (unused, for SMAC compatibility)
+
+        Returns
+        -------
+        float
+            Cost value (100 - score), with penalties for failures
+        """
+        try:
+            t_start = time.time()
+
+            # Convert ConfigSpace config to knob dict
+            knob_config = configspace_to_knobs(config, knob_space)
+
+            # Repair dependencies
+            knob_config = knob_space.repair_config_dependencies(knob_config)
+
+            # Detect if restart is needed
+            force_restart = False
+            if state["previous_config"] is not None:
+                # Check if any restart-required knobs changed
+                for knob_def in knob_space.knobs.values():
+                    if knob_def.restart_required:
+                        prev_val = state["previous_config"].get(knob_def.name)
+                        curr_val = knob_config.get(knob_def.name)
+                        if prev_val != curr_val:
+                            force_restart = True
+                            break
+
+            # Update worker configuration
+            worker.knob_config = knob_config
+            worker.force_restart_next_eval = force_restart
+
+            # Evaluate worker
+            metrics, score, restarted = evaluator.evaluate_worker(
+                worker, apply_config=True
+            )
+
+            wall_time = time.time() - t_start
+
+            # Compute cost (SMAC minimizes)
+            if metrics is None or score is None:
+                # Evaluation failed
+                cost = 100.0
+            else:
+                # Normal case: cost = 100 - score
+                cost = max(0.0, min(100.0, 100.0 - score))
+
+            # Log iteration
+            iteration_entry = {
+                "iteration": state["iteration_count"],
+                "config": knob_config,
+                "metrics": metrics.to_dict() if metrics is not None else {},
+                "score": score if score is not None else 0.0,
+                "cost": cost,
+                "wall_time_seconds": wall_time,
+                "restarted": restarted,
+                "timestamp": time.time(),
+            }
+            iteration_log.append(iteration_entry)
+
+            # Adaptive range update every N iterations
+            if (
+                state["iteration_count"] % range_update_interval == 0
+                and state["iteration_count"] > 0
+            ):
+                # Collect all metrics from iteration log
+                all_metrics = [
+                    PerformanceMetrics(**entry["metrics"])
+                    for entry in iteration_log
+                    if entry["metrics"]
+                ]
+                if all_metrics:
+                    metric_config.expand_ranges_for_metrics(all_metrics)
+
+            state["previous_config"] = knob_config
+            state["iteration_count"] += 1
+
+            logger.debug(
+                f"Iteration {state['iteration_count']}: score={score:.2f}, cost={cost:.2f}, "
+                f"wall_time={wall_time:.2f}s"
+            )
+
+            return cost
+
+        except Exception as e:
+            logger.error(f"Error evaluating configuration: {e}", exc_info=True)
+            return 100.0
+
+    return objective

--- a/src/scripts/bo_baseline/objective.py
+++ b/src/scripts/bo_baseline/objective.py
@@ -1,13 +1,12 @@
 """Objective function wrapper for SMAC3 Bayesian Optimization."""
 
 import time
-from typing import Callable, Dict, Any, List, Optional
+from typing import Callable, Dict, List
 from ConfigSpace import Configuration
 
 from src.tuner.config.knob_space import KnobSpace
 from src.tuner.core.worker import Worker
 from src.tuner.evaluator.evaluator import Evaluator
-from src.utils.environments.base import DatabaseEnvironment
 from src.utils.metrics import MetricConfig, PerformanceMetrics
 from src.scripts.bo_baseline.search_space import configspace_to_knobs
 from src.utils.logger import get_logger
@@ -19,13 +18,18 @@ def create_objective(
     evaluator: Evaluator,
     worker: Worker,
     knob_space: KnobSpace,
-    env: DatabaseEnvironment,
     metric_config: MetricConfig,
     iteration_log: List[Dict],
-    range_update_interval: int = 5,
+    pilot_phase_size: int = 10,
 ) -> Callable[[Configuration, int], float]:
     """
-    Create an objective function for SMAC3.
+    Create an objective function for SMAC3 with Pilot+Freeze normalization.
+
+    The objective uses default fallback ranges during the pilot phase (first
+    `pilot_phase_size` iterations). At the end of the pilot, it calibrates
+    normalization bounds from observed metrics exactly once, then freezes them
+    for the remainder of the run. This keeps the surrogate model's training
+    signal stable.
 
     Parameters
     ----------
@@ -35,22 +39,23 @@ def create_objective(
         The worker to evaluate
     knob_space : KnobSpace
         The knob space for configuration repair
-    env : DatabaseEnvironment
-        The database environment
     metric_config : MetricConfig
         Metric configuration for scoring
     iteration_log : List[Dict]
         Mutable list for tracking convergence
-    range_update_interval : int
-        How often to update metric ranges
+    pilot_phase_size : int
+        Number of initial iterations before freezing normalization ranges
 
     Returns
     -------
     Callable[[Configuration, int], float]
         Objective function for SMAC3 (minimizes cost)
     """
-    # Closure state for tracking previous config
-    state = {"previous_config": None, "iteration_count": 0}
+    state = {
+        "previous_config": None,
+        "iteration_count": 0,
+        "ranges_frozen": False,
+    }
 
     def objective(config: Configuration, seed: int = 0) -> float:
         """
@@ -71,16 +76,12 @@ def create_objective(
         try:
             t_start = time.time()
 
-            # Convert ConfigSpace config to knob dict
             knob_config = configspace_to_knobs(config, knob_space)
-
-            # Repair dependencies
             knob_config = knob_space.repair_config_dependencies(knob_config)
 
             # Detect if restart is needed
             force_restart = False
             if state["previous_config"] is not None:
-                # Check if any restart-required knobs changed
                 for knob_def in knob_space.knobs.values():
                     if knob_def.restart_required:
                         prev_val = state["previous_config"].get(knob_def.name)
@@ -89,26 +90,20 @@ def create_objective(
                             force_restart = True
                             break
 
-            # Update worker configuration
             worker.knob_config = knob_config
             worker.force_restart_next_eval = force_restart
 
-            # Evaluate worker
             metrics, score, restarted = evaluator.evaluate_worker(
                 worker, apply_config=True
             )
 
             wall_time = time.time() - t_start
 
-            # Compute cost (SMAC minimizes)
             if metrics is None or score is None:
-                # Evaluation failed
                 cost = 100.0
             else:
-                # Normal case: cost = 100 - score
                 cost = max(0.0, min(100.0, 100.0 - score))
 
-            # Log iteration
             iteration_entry = {
                 "iteration": state["iteration_count"],
                 "config": knob_config,
@@ -121,12 +116,11 @@ def create_objective(
             }
             iteration_log.append(iteration_entry)
 
-            # Adaptive range update every N iterations
+            # Pilot+Freeze: calibrate ranges exactly once after pilot phase
             if (
-                state["iteration_count"] % range_update_interval == 0
-                and state["iteration_count"] > 0
+                not state["ranges_frozen"]
+                and state["iteration_count"] >= pilot_phase_size - 1
             ):
-                # Collect all metrics from iteration log
                 all_metrics = [
                     PerformanceMetrics(**entry["metrics"])
                     for entry in iteration_log
@@ -134,13 +128,18 @@ def create_objective(
                 ]
                 if all_metrics:
                     metric_config.expand_ranges_for_metrics(all_metrics)
+                    logger.info(
+                        "Normalization ranges frozen after %d pilot iterations",
+                        state["iteration_count"] + 1,
+                    )
+                state["ranges_frozen"] = True
 
             state["previous_config"] = knob_config
             state["iteration_count"] += 1
 
             logger.debug(
                 f"Iteration {state['iteration_count']}: score={score:.2f}, cost={cost:.2f}, "
-                f"wall_time={wall_time:.2f}s"
+                f"wall_time={wall_time:.2f}s, frozen={state['ranges_frozen']}"
             )
 
             return cost

--- a/src/scripts/bo_baseline/result_writer.py
+++ b/src/scripts/bo_baseline/result_writer.py
@@ -125,6 +125,7 @@ def write_bo_results(
             "workload_type": config.workload_type,
             "benchmark_name": config.benchmark,
             "n_iterations": config.n_iterations,
+            "seed": config.random_seed,
             "population_size": 1,
             "total_generations": len(iteration_log),
             "total_time_seconds": total_time,

--- a/src/scripts/bo_baseline/result_writer.py
+++ b/src/scripts/bo_baseline/result_writer.py
@@ -3,7 +3,7 @@
 import json
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 from src.tuner.config.knob_space import KnobSpace
 from src.utils.hardware_info import WorkerResources
@@ -92,7 +92,9 @@ def write_bo_results(
             "best_worker_id": 0,
             "converged": False,
             "restart_count": 1 if iteration.get("restarted", False) else 0,
-            "timestamp": datetime.fromtimestamp(iteration.get("timestamp", 0.0)).isoformat(),
+            "timestamp": datetime.fromtimestamp(
+                iteration.get("timestamp", 0.0)
+            ).isoformat(),
             "iteration_wall_time_seconds": iteration.get("wall_time_seconds", 0.0),
             "bo_overhead_seconds": bo_overhead,
             "worker_scores": [

--- a/src/scripts/bo_baseline/result_writer.py
+++ b/src/scripts/bo_baseline/result_writer.py
@@ -1,0 +1,175 @@
+"""Result serialization for Bayesian Optimization baseline runner."""
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from src.tuner.config.knob_space import KnobSpace
+from src.utils.hardware_info import WorkerResources
+from src.scripts.bo_baseline.config import BOConfig
+from src.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+def write_bo_results(
+    knob_space: KnobSpace,
+    config: BOConfig,
+    worker_resources: WorkerResources,
+    system_info: Dict[str, Any],
+    iteration_log: List[Dict],
+    total_time: float,
+    output_dir: Path,
+    bo_surrogate: str = "gp",
+) -> Dict[str, Any]:
+    """
+    Serialize Bayesian Optimization results in PBT-compatible JSON format.
+
+    Parameters
+    ----------
+    knob_space : KnobSpace
+        The knob space used for tuning
+    config : BOConfig
+        The BO configuration
+    worker_resources : WorkerResources
+        Hardware resources of the worker
+    system_info : Dict[str, Any]
+        System information snapshot
+    iteration_log : List[Dict]
+        Log of all iterations with metrics and configs
+    total_time : float
+        Total tuning time in seconds
+    output_dir : Path
+        Output directory for results
+    bo_surrogate : str
+        Surrogate model type (gp or rf)
+
+    Returns
+    -------
+    Dict[str, Any]
+        The serialized results dictionary
+    """
+    # Find best configuration from iteration log
+    best_iteration = None
+    best_score = -float("inf")
+
+    for iteration in iteration_log:
+        score = iteration.get("score", 0.0)
+        if score > best_score:
+            best_score = score
+            best_iteration = iteration
+
+    if best_iteration is None:
+        logger.warning("No valid iterations found in log")
+        best_iteration = {
+            "config": {},
+            "metrics": {},
+            "score": 0.0,
+        }
+
+    # Build generation history from iteration log
+    generation_history = []
+    best_score_so_far = -float("inf")
+    bo_overhead_total = 0.0
+
+    for i, iteration in enumerate(iteration_log):
+        score = iteration.get("score", 0.0)
+        if score > best_score_so_far:
+            best_score_so_far = score
+
+        # Estimate BO overhead (ask + tell time) - for now, estimate as 5% of wall time
+        # In a real implementation, this would be tracked separately
+        bo_overhead = iteration.get("wall_time_seconds", 0.0) * 0.05
+        bo_overhead_total += bo_overhead
+
+        generation_entry = {
+            "generation": i,
+            "best_score": best_score_so_far,
+            "mean_score": score,
+            "std_score": 0.0,
+            "num_exploited": 0,
+            "best_worker_id": 0,
+            "converged": False,
+            "restart_count": 1 if iteration.get("restarted", False) else 0,
+            "timestamp": datetime.fromtimestamp(iteration.get("timestamp", 0.0)).isoformat(),
+            "iteration_wall_time_seconds": iteration.get("wall_time_seconds", 0.0),
+            "bo_overhead_seconds": bo_overhead,
+            "worker_scores": [
+                {
+                    "worker_id": 0,
+                    "score": score,
+                    "metrics": iteration.get("metrics", {}),
+                }
+            ],
+            "worker_configs": [
+                {
+                    "worker_id": 0,
+                    "config": iteration.get("config", {}),
+                }
+            ],
+        }
+        generation_history.append(generation_entry)
+
+    # Build result dictionary
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M")
+
+    result = {
+        "tuning_session": {
+            "optimizer": "bayesian_optimization",
+            "bo_library": "smac3",
+            "bo_surrogate": bo_surrogate,
+            "bo_acquisition": "expected_improvement",
+            "knob_tier": config.knob_tier,
+            "num_knobs": len(knob_space.knobs),
+            "workload_type": config.workload_type,
+            "benchmark_name": config.benchmark,
+            "n_iterations": config.n_iterations,
+            "population_size": 1,
+            "total_generations": len(iteration_log),
+            "total_time_seconds": total_time,
+            "timestamp": timestamp,
+            "tuning_mode": config.tuning_mode,
+            "sysbench_duration_seconds": config.evaluation_duration,
+            "sysbench_warmup_seconds": config.warmup_duration,
+            "sysbench_tables": config.sysbench_tables,
+            "sysbench_table_size": config.sysbench_table_size,
+            "sysbench_workload": config.sysbench_workload,
+            "tpch_scale_factor": config.scale_factor,
+            "tpch_warmup_passes": config.tpch_warmup_passes,
+            "reference_pbt_session": (
+                str(config.pbt_session_path) if config.pbt_session_path else None
+            ),
+            "reference_pbt_knobs": list(config.pbt_knob_names or ()),
+        },
+        "best_configuration": {
+            "score": best_score,
+            "knobs": best_iteration.get("config", {}),
+            "metrics": best_iteration.get("metrics", {}),
+        },
+        "worker_resources": {
+            "ram_bytes": worker_resources.ram_bytes,
+            "cpu_cores": worker_resources.cpu_cores,
+            "disk_type": worker_resources.disk_type,
+        },
+        "generation_history": generation_history,
+        "convergence": {
+            "converged": False,
+            "iterations_without_improvement": 0,
+        },
+        "system_info": system_info,
+    }
+
+    # Create output directory structure
+    workload_dir = output_dir / config.workload_type
+    bo_dir = workload_dir / "bo_runs" / config.knob_tier / "tuning_sessions"
+    bo_dir.mkdir(parents=True, exist_ok=True)
+
+    # Write results to file
+    output_file = bo_dir / f"bo_results_{timestamp}.json"
+    with open(output_file, "w") as f:
+        json.dump(result, f, indent=2)
+
+    logger.info(f"BO results written to {output_file}")
+
+    return result

--- a/src/scripts/bo_baseline/runner.py
+++ b/src/scripts/bo_baseline/runner.py
@@ -1,22 +1,19 @@
 """Main Bayesian Optimization baseline runner orchestrator."""
 
 import time
-import json
 from pathlib import Path
-from typing import Optional, Dict, Any, Tuple
+from typing import Dict, Any, Tuple
 from datetime import datetime
 
 from smac import BlackBoxFacade, HyperparameterOptimizationFacade
 from smac.initial_design import SobolInitialDesign
 from smac.random_design import ProbabilityRandomDesign
 from smac.scenario import Scenario
-from ConfigSpace import Configuration
 
 from src.tuner.config import get_knob_space
 from src.tuner.core.worker import Worker
 from src.tuner.evaluator.evaluator import Evaluator, EvaluatorConfig
 from src.tuner.evaluator.restart_policy import TuningMode
-from src.tuner.evaluator.workload import WorkloadFileLoader
 from src.benchmarks.sysbench.executor import SysbenchExecutor
 from src.benchmarks.tpch.executor import TPCHExecutor
 from src.utils.environments import EnvironmentFactory
@@ -27,7 +24,7 @@ from src.config.database import get_db_config
 from src.database.connection import get_connection
 
 from src.scripts.bo_baseline.config import BOConfig
-from src.scripts.bo_baseline.search_space import build_configspace, configspace_to_knobs
+from src.scripts.bo_baseline.search_space import build_configspace
 from src.scripts.bo_baseline.objective import create_objective
 from src.scripts.bo_baseline.result_writer import write_bo_results
 
@@ -97,9 +94,7 @@ class BOBaselineRunner:
             supported_knobs = {str(row[0]) for row in cursor.fetchall()}
             return supported_knobs, server_version
         except Exception as exc:
-            self.logger.warning(
-                f"Failed to inspect runtime pg_settings: {exc}"
-            )
+            self.logger.warning(f"Failed to inspect runtime pg_settings: {exc}")
             return set(self.knob_space.knobs.keys()), "unknown"
         finally:
             if cursor is not None:
@@ -135,7 +130,9 @@ class BOBaselineRunner:
                 "No runtime-compatible knobs remain after pg_settings compatibility pruning."
             )
 
-        self.logger.info(f"✓ Continuing with {len(self.knob_space)} runtime-compatible knobs")
+        self.logger.info(
+            f"✓ Continuing with {len(self.knob_space)} runtime-compatible knobs"
+        )
 
     def _apply_pbt_knob_filter(self) -> None:
         """Restrict BO search to the knob names present in the reference PBT run."""
@@ -222,10 +219,12 @@ class BOBaselineRunner:
 
             # Build ConfigSpace
             self.logger.info("Building ConfigSpace...")
-            configspace = build_configspace(self.knob_space, seed=self.config.random_seed)
+            configspace = build_configspace(
+                self.knob_space, seed=self.config.random_seed
+            )
 
             # Create iteration log
-            iteration_log = []
+            iteration_log: list = []
 
             # Pilot phase size: use range_update_interval as the freeze point
             pilot_size = max(
@@ -246,13 +245,17 @@ class BOBaselineRunner:
 
             # Create SMAC scenario — deterministic=False because database
             # benchmarks have inherent measurement variance
-            self.logger.info(f"Creating SMAC scenario with {self.config.n_iterations} iterations...")
+            self.logger.info(
+                f"Creating SMAC scenario with {self.config.n_iterations} iterations..."
+            )
             scenario = Scenario(
                 configspace=configspace,
                 n_trials=self.config.n_iterations,
                 seed=self.config.random_seed,
                 deterministic=False,
-                output_directory=Path(f"./smac_output/run_{datetime.now().strftime('%Y%m%d_%H%M%S')}_{self.config.random_seed}"),
+                output_directory=Path(
+                    f"./smac_output/run_{datetime.now().strftime('%Y%m%d_%H%M%S')}_{self.config.random_seed}"
+                ),
             )
 
             # Sobol initial design for uniform pilot-phase coverage
@@ -296,10 +299,9 @@ class BOBaselineRunner:
             # Run optimization
             self.logger.info("Starting Bayesian Optimization...")
             try:
-                incumbent = facade.optimize()
+                facade.optimize()
             except KeyboardInterrupt:
                 self.logger.warning("Optimization interrupted by user")
-                incumbent = facade.runhistory.get_incumbent_config()
 
             # Write results
             self.logger.info("Writing results...")
@@ -317,7 +319,9 @@ class BOBaselineRunner:
             )
 
             self.logger.info(f"BO tuning completed in {total_time:.2f} seconds")
-            self.logger.info(f"Best score: {results['best_configuration']['score']:.4f}")
+            self.logger.info(
+                f"Best score: {results['best_configuration']['score']:.4f}"
+            )
 
             return results
 

--- a/src/scripts/bo_baseline/runner.py
+++ b/src/scripts/bo_baseline/runner.py
@@ -7,6 +7,8 @@ from typing import Optional, Dict, Any, Tuple
 from datetime import datetime
 
 from smac import BlackBoxFacade, HyperparameterOptimizationFacade
+from smac.initial_design import SobolInitialDesign
+from smac.random_design import ProbabilityRandomDesign
 from smac.scenario import Scenario
 from ConfigSpace import Configuration
 
@@ -225,40 +227,69 @@ class BOBaselineRunner:
             # Create iteration log
             iteration_log = []
 
-            # Create objective function
+            # Pilot phase size: use range_update_interval as the freeze point
+            pilot_size = max(
+                self.config.range_update_interval,
+                len(self.knob_space.knobs) + 1,
+            )
+            pilot_size = min(pilot_size, self.config.n_iterations)
+
+            # Create objective function with freeze-after-pilot logic
             objective = create_objective(
                 evaluator=evaluator,
                 worker=worker,
                 knob_space=self.knob_space,
-                env=self.env,
                 metric_config=self.metric_config,
                 iteration_log=iteration_log,
-                range_update_interval=self.config.range_update_interval,
+                pilot_phase_size=pilot_size,
             )
 
-            # Create SMAC scenario
+            # Create SMAC scenario — deterministic=False because database
+            # benchmarks have inherent measurement variance
             self.logger.info(f"Creating SMAC scenario with {self.config.n_iterations} iterations...")
             scenario = Scenario(
                 configspace=configspace,
                 n_trials=self.config.n_iterations,
                 seed=self.config.random_seed,
-                deterministic=True,
-                output_directory=Path(f"./smac_output/run_{datetime.now().strftime('%Y%md%d_%H%M%S')}_{self.config.random_seed}"),
+                deterministic=False,
+                output_directory=Path(f"./smac_output/run_{datetime.now().strftime('%Y%m%d_%H%M%S')}_{self.config.random_seed}"),
             )
 
-            # Select facade based on tier
+            # Sobol initial design for uniform pilot-phase coverage
+            initial_design = SobolInitialDesign(
+                scenario=scenario,
+                n_configs=pilot_size,
+            )
 
+            # Select facade based on surrogate arg
             num_knobs = len(self.knob_space.knobs)
-            if num_knobs <= 13:
-                self.logger.info(f"Using BlackBoxFacade (GP) for {num_knobs} knobs")
+            if self.config.bo_surrogate.lower() == "gp":
+                self.logger.info(
+                    f"Using BlackBoxFacade (GP) for {num_knobs} knobs, "
+                    f"pilot_size={pilot_size}"
+                )
                 facade = BlackBoxFacade(
-                    scenario, objective, logging_level=False
+                    scenario,
+                    objective,
+                    initial_design=initial_design,
+                    logging_level=False,
                 )
                 bo_surrogate = "gp"
             else:
-                self.logger.info(f"Using HyperparameterOptimizationFacade (RF) for {num_knobs} knobs")
+                self.logger.info(
+                    f"Using HyperparameterOptimizationFacade (RF) for {num_knobs} knobs, "
+                    f"pilot_size={pilot_size}"
+                )
+                # 20% random interleaving prevents surrogate over-exploitation
+                random_design = ProbabilityRandomDesign(
+                    probability=0.2, seed=self.config.random_seed
+                )
                 facade = HyperparameterOptimizationFacade(
-                    scenario, objective, logging_level=False
+                    scenario,
+                    objective,
+                    initial_design=initial_design,
+                    random_design=random_design,
+                    logging_level=False,
                 )
                 bo_surrogate = "rf"
 
@@ -437,6 +468,12 @@ def main():
         help="Output directory (default: results)",
     )
     parser.add_argument(
+        "--bo-surrogate",
+        choices=["rf", "gp"],
+        default="rf",
+        help="SMAC Surrogate model: Random Forest (rf) or Gaussian Process (gp). Default: rf",
+    )
+    parser.add_argument(
         "--verbose",
         choices=["DEBUG", "INFO", "WARNING", "ERROR"],
         default="INFO",
@@ -445,8 +482,8 @@ def main():
     parser.add_argument(
         "--range-update-interval",
         type=int,
-        default=5,
-        help="Adaptive range update interval (default: 5)",
+        default=10,
+        help="Pilot phase size: number of Sobol initial-design iterations before freezing normalization ranges (default: 10)",
     )
 
     args = parser.parse_args()

--- a/src/scripts/bo_baseline/runner.py
+++ b/src/scripts/bo_baseline/runner.py
@@ -1,0 +1,463 @@
+"""Main Bayesian Optimization baseline runner orchestrator."""
+
+import time
+import json
+from pathlib import Path
+from typing import Optional, Dict, Any, Tuple
+from datetime import datetime
+
+from smac import BlackBoxFacade, HyperparameterOptimizationFacade
+from smac.scenario import Scenario
+from ConfigSpace import Configuration
+
+from src.tuner.config import get_knob_space
+from src.tuner.core.worker import Worker
+from src.tuner.evaluator.evaluator import Evaluator, EvaluatorConfig
+from src.tuner.evaluator.restart_policy import TuningMode
+from src.tuner.evaluator.workload import WorkloadFileLoader
+from src.benchmarks.sysbench.executor import SysbenchExecutor
+from src.benchmarks.tpch.executor import TPCHExecutor
+from src.utils.environments import EnvironmentFactory
+from src.utils.metrics import WorkloadType, create_metric_config
+from src.utils.hardware_info import get_system_info, detect_worker_resources
+from src.utils.logger import setup_logging, get_logger, log_section_header
+from src.config.database import get_db_config
+from src.database.connection import get_connection
+
+from src.scripts.bo_baseline.config import BOConfig
+from src.scripts.bo_baseline.search_space import build_configspace, configspace_to_knobs
+from src.scripts.bo_baseline.objective import create_objective
+from src.scripts.bo_baseline.result_writer import write_bo_results
+
+logger = get_logger(__name__)
+
+
+class BOBaselineRunner:
+    """Bayesian Optimization baseline runner for PostgreSQL tuning."""
+
+    def __init__(self, config: BOConfig):
+        """
+        Initialize BO baseline runner.
+
+        Parameters
+        ----------
+        config : BOConfig
+            Configuration for BO tuning
+        """
+        self.config = config
+        setup_logging(verbosity=config.verbose)
+        self.logger = get_logger(__name__)
+
+        # Collect system info
+        self.system_info = get_system_info()
+        self.worker_resources = detect_worker_resources()
+
+        # Load knob space
+        self.knob_space = get_knob_space(config.knob_tier)
+        self.knob_space.resolve_hardware_ranges(self.worker_resources)
+
+        # Database config
+        self.db_config = get_db_config()
+
+        # Metric config
+        workload_type = WorkloadType(config.workload_type)
+        self.metric_config = create_metric_config(workload_type.value)
+
+        self.logger.info(f"BO Baseline Runner initialized for tier: {config.knob_tier}")
+
+    def _create_workload_executor(self):
+        """Create appropriate workload executor based on benchmark type."""
+        if self.config.benchmark == "sysbench":
+            return SysbenchExecutor(
+                script=self.config.sysbench_workload,
+                tables=self.config.sysbench_tables,
+                table_size=self.config.sysbench_table_size,
+            )
+        elif self.config.benchmark == "tpch":
+            return TPCHExecutor(scale_factor=self.config.scale_factor)
+        else:
+            raise ValueError(f"Unknown benchmark: {self.config.benchmark}")
+
+    def _get_runtime_supported_knobs(self, worker_id: int = 0) -> Tuple[set, str]:
+        """Get runtime pg_settings knob names and server version."""
+        db_config = self.env.get_db_config(worker_id)
+
+        conn = None
+        cursor = None
+        try:
+            conn = get_connection(config=db_config, connect_timeout=5)
+            cursor = conn.cursor()
+            cursor.execute("SELECT current_setting('server_version')")
+            version_row = cursor.fetchone()
+            server_version = str(version_row[0]) if version_row else "unknown"
+
+            cursor.execute("SELECT name FROM pg_settings")
+            supported_knobs = {str(row[0]) for row in cursor.fetchall()}
+            return supported_knobs, server_version
+        except Exception as exc:
+            self.logger.warning(
+                f"Failed to inspect runtime pg_settings: {exc}"
+            )
+            return set(self.knob_space.knobs.keys()), "unknown"
+        finally:
+            if cursor is not None:
+                cursor.close()
+            if conn is not None:
+                conn.close()
+
+    def _prune_unsupported_runtime_knobs(self) -> None:
+        """Prune knobs unavailable on runtime PostgreSQL."""
+        supported_knobs, server_version = self._get_runtime_supported_knobs(worker_id=0)
+        configured_knobs = set(self.knob_space.knobs.keys())
+        unsupported_knobs = sorted(configured_knobs - supported_knobs)
+
+        if not unsupported_knobs:
+            self.logger.info(
+                f"✓ Runtime knob compatibility check passed against PostgreSQL {server_version} "
+                f"({len(configured_knobs)} knobs)"
+            )
+            return
+
+        for knob_name in unsupported_knobs:
+            self.knob_space.knobs.pop(knob_name, None)
+
+        preview = unsupported_knobs[:20]
+        suffix = " ..." if len(unsupported_knobs) > len(preview) else ""
+        self.logger.warning(
+            f"Pruned {len(unsupported_knobs)} unsupported knobs for PostgreSQL {server_version}: "
+            f"{', '.join(preview)}{suffix}"
+        )
+
+        if len(self.knob_space) == 0:
+            raise RuntimeError(
+                "No runtime-compatible knobs remain after pg_settings compatibility pruning."
+            )
+
+        self.logger.info(f"✓ Continuing with {len(self.knob_space)} runtime-compatible knobs")
+
+    def _apply_pbt_knob_filter(self) -> None:
+        """Restrict BO search to the knob names present in the reference PBT run."""
+        if not self.config.pbt_knob_names:
+            return
+
+        requested_knobs = set(self.config.pbt_knob_names)
+        available_knobs = set(self.knob_space.knobs.keys())
+        missing_knobs = sorted(requested_knobs - available_knobs)
+        if missing_knobs:
+            raise RuntimeError(
+                "Reference PBT run used knobs that are unavailable to BO after "
+                f"tier/runtime pruning: {', '.join(missing_knobs)}"
+            )
+
+        removed_knobs = sorted(available_knobs - requested_knobs)
+        for knob_name in removed_knobs:
+            self.knob_space.knobs.pop(knob_name, None)
+
+        self.logger.info(
+            "✓ Restricted BO search space to %d knobs from reference PBT session",
+            len(self.knob_space.knobs),
+        )
+
+    def run(self) -> Dict[str, Any]:
+        """
+        Run Bayesian Optimization tuning.
+
+        Returns
+        -------
+        Dict[str, Any]
+            Results dictionary
+        """
+        log_section_header(self.logger, "Bayesian Optimization Baseline Tuning")
+
+        start_time = time.time()
+
+        try:
+            # Create workload executor
+            self.logger.info("Creating workload executor...")
+            workload_executor = self._create_workload_executor()
+
+            # Create environment
+            self.logger.info("Setting up database environment...")
+            snapshot_id = f"{self.config.benchmark}_{self.config.workload_type}"
+            self.env = EnvironmentFactory.create(
+                schema_provider=workload_executor,
+                use_docker=self.config.use_docker,
+                base_dir=Path(f"./pg_instances/{self.config.benchmark}"),
+                base_port=5440,
+                db_config=self.db_config,
+                worker_resources=self.worker_resources,
+                run_id=snapshot_id,
+                image_name=self.config.docker_image,
+                force_recreate_baseline=self.config.force_recreate_baseline,
+            )
+
+            # Setup single instance
+            self.logger.info("Setting up PostgreSQL instance...")
+            self.env.setup_instances(num_workers=1)
+
+            # Prune unsupported knobs
+            self._prune_unsupported_runtime_knobs()
+            self._apply_pbt_knob_filter()
+
+            # Create evaluator
+            self.logger.info("Creating evaluator...")
+            evaluator_config = EvaluatorConfig(
+                workload_type=WorkloadType(self.config.workload_type),
+                metric_config=self.metric_config,
+                db_config=self.db_config,
+                warmup_duration=self.config.warmup_duration,
+                measurement_duration=self.config.evaluation_duration,
+                tuning_mode=TuningMode(self.config.tuning_mode),
+            )
+            evaluator = Evaluator(evaluator_config, workload_executor, self.env)
+
+            # Create worker
+            worker = Worker(
+                worker_id=0,
+                knob_space=self.knob_space,
+            )
+            worker.db_config = self.env.get_db_config(0)
+
+            # Build ConfigSpace
+            self.logger.info("Building ConfigSpace...")
+            configspace = build_configspace(self.knob_space, seed=self.config.random_seed)
+
+            # Create iteration log
+            iteration_log = []
+
+            # Create objective function
+            objective = create_objective(
+                evaluator=evaluator,
+                worker=worker,
+                knob_space=self.knob_space,
+                env=self.env,
+                metric_config=self.metric_config,
+                iteration_log=iteration_log,
+                range_update_interval=self.config.range_update_interval,
+            )
+
+            # Create SMAC scenario
+            self.logger.info(f"Creating SMAC scenario with {self.config.n_iterations} iterations...")
+            scenario = Scenario(
+                configspace=configspace,
+                n_trials=self.config.n_iterations,
+                seed=self.config.random_seed,
+                deterministic=True,
+                output_directory=Path(f"./smac_output/run_{datetime.now().strftime('%Y%md%d_%H%M%S')}_{self.config.random_seed}"),
+            )
+
+            # Select facade based on tier
+
+            num_knobs = len(self.knob_space.knobs)
+            if num_knobs <= 13:
+                self.logger.info(f"Using BlackBoxFacade (GP) for {num_knobs} knobs")
+                facade = BlackBoxFacade(
+                    scenario, objective, logging_level=False
+                )
+                bo_surrogate = "gp"
+            else:
+                self.logger.info(f"Using HyperparameterOptimizationFacade (RF) for {num_knobs} knobs")
+                facade = HyperparameterOptimizationFacade(
+                    scenario, objective, logging_level=False
+                )
+                bo_surrogate = "rf"
+
+            # Run optimization
+            self.logger.info("Starting Bayesian Optimization...")
+            try:
+                incumbent = facade.optimize()
+            except KeyboardInterrupt:
+                self.logger.warning("Optimization interrupted by user")
+                incumbent = facade.runhistory.get_incumbent_config()
+
+            # Write results
+            self.logger.info("Writing results...")
+            total_time = time.time() - start_time
+
+            results = write_bo_results(
+                knob_space=self.knob_space,
+                config=self.config,
+                worker_resources=self.worker_resources,
+                system_info=self.system_info,
+                iteration_log=iteration_log,
+                total_time=total_time,
+                output_dir=self.config.output_dir,
+                bo_surrogate=bo_surrogate,
+            )
+
+            self.logger.info(f"BO tuning completed in {total_time:.2f} seconds")
+            self.logger.info(f"Best score: {results['best_configuration']['score']:.4f}")
+
+            return results
+
+        finally:
+            # Cleanup
+            if hasattr(self, "env"):
+                self.logger.info("Cleaning up environment...")
+                try:
+                    self.env.cleanup()
+                except Exception as e:
+                    self.logger.warning(f"Error during cleanup: {e}")
+
+
+def main():
+    """CLI entry point."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Bayesian Optimization baseline for PostgreSQL tuning"
+    )
+
+    # Required arguments
+    parser.add_argument(
+        "--tier",
+        choices=["minimal", "core", "standard", "extensive"],
+        help="Knob space tier. Optional when --pbt-session is provided.",
+    )
+    parser.add_argument(
+        "--pbt-session",
+        type=str,
+        help=(
+            "Reference PBT tuning-session JSON. BO will copy comparable "
+            "benchmark, workload, duration, warmup, tier, tuning mode, and "
+            "knob names from this run."
+        ),
+    )
+
+    # BO Configuration
+    parser.add_argument(
+        "--iterations",
+        type=int,
+        default=None,
+        help=(
+            "Number of BO iterations. Defaults to 50, or to "
+            "PBT population_size * total_generations when --pbt-session is used."
+        ),
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=42,
+        help="Random seed (default: 42)",
+    )
+
+    # Benchmark
+    parser.add_argument(
+        "--benchmark",
+        choices=["sysbench", "tpch"],
+        default="sysbench",
+        help="Benchmark type (default: sysbench)",
+    )
+    parser.add_argument(
+        "--workload",
+        choices=["oltp", "olap", "mixed"],
+        default="oltp",
+        help="Workload type (default: oltp)",
+    )
+    parser.add_argument(
+        "--duration",
+        type=float,
+        default=30.0,
+        help="Evaluation duration in seconds (default: 30)",
+    )
+    parser.add_argument(
+        "--warmup",
+        type=float,
+        default=10.0,
+        help="Warmup duration in seconds (default: 10)",
+    )
+
+    # Sysbench options
+    parser.add_argument(
+        "--sysbench-tables",
+        type=int,
+        default=4,
+        help="Number of sysbench tables (default: 4)",
+    )
+    parser.add_argument(
+        "--sysbench-table-size",
+        type=int,
+        default=100000,
+        help="Sysbench table size (default: 100000)",
+    )
+    parser.add_argument(
+        "--sysbench-workload",
+        choices=["oltp_read_only", "oltp_read_write", "oltp_write_only"],
+        default="oltp_read_write",
+        help="Sysbench workload (default: oltp_read_write)",
+    )
+
+    # TPC-H options
+    parser.add_argument(
+        "--scale-factor",
+        type=float,
+        default=1.0,
+        help="TPC-H scale factor (default: 1.0)",
+    )
+    parser.add_argument(
+        "--tpch-warmup-passes",
+        type=int,
+        default=1,
+        help="TPC-H warmup passes (default: 1)",
+    )
+
+    # Instance options
+    parser.add_argument(
+        "--no-docker",
+        action="store_true",
+        help="Use bare-metal PostgreSQL instead of Docker",
+    )
+    parser.add_argument(
+        "--docker-image",
+        type=str,
+        help="Custom Docker image name",
+    )
+    parser.add_argument(
+        "--force-recreate-instances",
+        action="store_true",
+        help="Force recreate PostgreSQL instances",
+    )
+    parser.add_argument(
+        "--force-recreate-baseline",
+        action="store_true",
+        help="Force recreate baseline snapshot",
+    )
+    parser.add_argument(
+        "--tuning-mode",
+        choices=["offline", "online", "adaptive"],
+        default="offline",
+        help="Tuning mode (default: offline)",
+    )
+
+    # Output options
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        default="results",
+        help="Output directory (default: results)",
+    )
+    parser.add_argument(
+        "--verbose",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        default="INFO",
+        help="Logging level (default: INFO)",
+    )
+    parser.add_argument(
+        "--range-update-interval",
+        type=int,
+        default=5,
+        help="Adaptive range update interval (default: 5)",
+    )
+
+    args = parser.parse_args()
+
+    # Create config and run
+    config = BOConfig.from_args(args)
+    runner = BOBaselineRunner(config)
+    results = runner.run()
+
+    return results
+
+
+if __name__ == "__main__":
+    main()

--- a/src/scripts/bo_baseline/search_space.py
+++ b/src/scripts/bo_baseline/search_space.py
@@ -1,0 +1,154 @@
+"""Search space translation between KnobSpace and ConfigSpace."""
+
+from typing import Dict, Any
+import numpy as np
+from ConfigSpace import ConfigurationSpace, Integer, Float, Categorical, Constant, Configuration
+
+from src.tuner.config.knob_space import KnobSpace, KnobType, KnobScale
+from src.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+def build_configspace(knob_space: KnobSpace, seed: int = 42) -> ConfigurationSpace:
+    """
+    Translate KnobSpace into a ConfigSpace ConfigurationSpace.
+
+    Parameters
+    ----------
+    knob_space : KnobSpace
+        The knob space to translate
+    seed : int
+        Random seed for reproducibility
+
+    Returns
+    -------
+    ConfigurationSpace
+        ConfigSpace representation of the knob space
+    """
+    cs = ConfigurationSpace(seed=seed)
+
+    for knob_def in knob_space.knobs.values():
+        name = knob_def.name
+
+        # Handle degenerate ranges (min == max)
+        if (
+            knob_def.min_value is not None
+            and knob_def.max_value is not None
+            and knob_def.min_value == knob_def.max_value
+        ):
+            cs.add(Constant(name, knob_def.min_value))
+            continue
+
+        elif knob_def.knob_type == KnobType.INTEGER:
+            min_val = int(knob_def.min_value) if knob_def.min_value is not None else 0
+            max_val = int(knob_def.max_value) if knob_def.max_value is not None else 2**31 - 1
+
+            # For log scale, ensure min > 0
+            if knob_def.scale == KnobScale.LOG:
+                min_val = max(min_val, 1)
+
+            # Ensure default is within range
+            default = None
+            if knob_def.default is not None:
+                default = int(knob_def.default)
+                if default < min_val or default > max_val:
+                    default = None
+
+            param = Integer(
+                name,
+                bounds=(min_val, max_val),
+                log=(knob_def.scale == KnobScale.LOG),
+                default=default,
+            )
+            cs.add(param)
+
+        elif knob_def.knob_type == KnobType.REAL:
+            min_val = float(knob_def.min_value) if knob_def.min_value is not None else 0.0
+            max_val = float(knob_def.max_value) if knob_def.max_value is not None else 1.0
+
+            # For log scale, ensure min > 0
+            if knob_def.scale == KnobScale.LOG:
+                min_val = max(min_val, 1e-9)
+
+            # Ensure default is within range
+            default = None
+            if knob_def.default is not None:
+                default = float(knob_def.default)
+                if default < min_val or default > max_val:
+                    default = None
+
+            param = Float(
+                name,
+                bounds=(min_val, max_val),
+                log=(knob_def.scale == KnobScale.LOG),
+                default=default,
+            )
+            cs.add(param)
+
+        elif knob_def.knob_type == KnobType.BOOLEAN:
+            param = Categorical(
+                name,
+                categories=["on", "off"],
+                default="on" if knob_def.default else "off",
+            )
+            cs.add(param)
+
+        elif knob_def.knob_type == KnobType.ENUM:
+            if knob_def.enum_values is None:
+                logger.warning(f"Enum knob {name} has no enum_values, skipping")
+                continue
+
+            default = None
+            if knob_def.default is not None and knob_def.default in knob_def.enum_values:
+                default = knob_def.default
+
+            param = Categorical(
+                name,
+                categories=knob_def.enum_values,
+                default=default,
+            )
+            cs.add(param)
+
+    return cs
+
+
+def configspace_to_knobs(
+    cs_config: Configuration, knob_space: KnobSpace
+) -> Dict[str, Any]:
+    """
+    Convert a ConfigSpace Configuration back to a knob config dict.
+
+    Parameters
+    ----------
+    cs_config : Configuration
+        ConfigSpace configuration object
+    knob_space : KnobSpace
+        The knob space for type conversion
+
+    Returns
+    -------
+    Dict[str, Any]
+        Knob configuration dictionary with proper Python types
+    """
+    config_dict = {}
+
+    for knob_def in knob_space.knobs.values():
+        name = knob_def.name
+
+        if name not in cs_config:
+            continue
+
+        value = cs_config[name]
+
+        # Convert numpy types to Python types
+        if isinstance(value, np.integer):
+            config_dict[name] = int(value)
+        elif isinstance(value, np.floating):
+            config_dict[name] = float(value)
+        elif isinstance(value, (int, float, str, bool)):
+            config_dict[name] = value
+        else:
+            config_dict[name] = value
+
+    return config_dict

--- a/src/scripts/bo_baseline/search_space.py
+++ b/src/scripts/bo_baseline/search_space.py
@@ -2,7 +2,14 @@
 
 from typing import Dict, Any
 import numpy as np
-from ConfigSpace import ConfigurationSpace, Integer, Float, Categorical, Constant, Configuration
+from ConfigSpace import (
+    ConfigurationSpace,
+    Integer,
+    Float,
+    Categorical,
+    Constant,
+    Configuration,
+)
 
 from src.tuner.config.knob_space import KnobSpace, KnobType, KnobScale
 from src.utils.logger import get_logger
@@ -42,7 +49,9 @@ def build_configspace(knob_space: KnobSpace, seed: int = 42) -> ConfigurationSpa
 
         elif knob_def.knob_type == KnobType.INTEGER:
             min_val = int(knob_def.min_value) if knob_def.min_value is not None else 0
-            max_val = int(knob_def.max_value) if knob_def.max_value is not None else 2**31 - 1
+            max_val = (
+                int(knob_def.max_value) if knob_def.max_value is not None else 2**31 - 1
+            )
 
             # For log scale, ensure min > 0
             if knob_def.scale == KnobScale.LOG:
@@ -64,27 +73,33 @@ def build_configspace(knob_space: KnobSpace, seed: int = 42) -> ConfigurationSpa
             cs.add(param)
 
         elif knob_def.knob_type == KnobType.REAL:
-            min_val = float(knob_def.min_value) if knob_def.min_value is not None else 0.0
-            max_val = float(knob_def.max_value) if knob_def.max_value is not None else 1.0
+            min_val_f: float = (
+                float(knob_def.min_value) if knob_def.min_value is not None else 0.0
+            )
+            max_val_f: float = (
+                float(knob_def.max_value) if knob_def.max_value is not None else 1.0
+            )
 
             # For log scale, ensure min > 0
             if knob_def.scale == KnobScale.LOG:
-                min_val = max(min_val, 1e-9)
+                min_val_f = max(min_val_f, 1e-9)
 
             # Ensure default is within range
-            default = None
+            default_f: float | None = None
             if knob_def.default is not None:
-                default = float(knob_def.default)
-                if default < min_val or default > max_val:
-                    default = None
+                default_val_f = float(knob_def.default)
+                if default_val_f < min_val_f or default_val_f > max_val_f:
+                    default_f = None
+                else:
+                    default_f = default_val_f
 
-            param = Float(
+            param_f = Float(
                 name,
-                bounds=(min_val, max_val),
+                bounds=(min_val_f, max_val_f),
                 log=(knob_def.scale == KnobScale.LOG),
-                default=default,
+                default=default_f,
             )
-            cs.add(param)
+            cs.add(param_f)
 
         elif knob_def.knob_type == KnobType.BOOLEAN:
             param = Categorical(
@@ -100,7 +115,10 @@ def build_configspace(knob_space: KnobSpace, seed: int = 42) -> ConfigurationSpa
                 continue
 
             default = None
-            if knob_def.default is not None and knob_def.default in knob_def.enum_values:
+            if (
+                knob_def.default is not None
+                and knob_def.default in knob_def.enum_values
+            ):
                 default = knob_def.default
 
             param = Categorical(
@@ -131,7 +149,7 @@ def configspace_to_knobs(
     Dict[str, Any]
         Knob configuration dictionary with proper Python types
     """
-    config_dict = {}
+    config_dict: Dict[str, Any] = {}
 
     for knob_def in knob_space.knobs.values():
         name = knob_def.name

--- a/src/scripts/pbt_vs_bo_comarison.py
+++ b/src/scripts/pbt_vs_bo_comarison.py
@@ -1,0 +1,410 @@
+#!/usr/bin/env python3
+"""
+pbt_vs_bo_comparison.py
+
+Analyzes and compares the results of Population-Based Training (PBT) and 
+Bayesian Optimization (BO) for PostgreSQL auto-tuning. Supports dynamic 
+global rescoring, statistical significance testing, and generates 
+publication-ready plots.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import fields
+from pathlib import Path
+from typing import List, Optional
+
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+import seaborn as sns
+from scipy import stats
+
+from src.utils.metrics import PerformanceMetrics
+from src.utils.rescoring import rescore_metrics_globally
+
+# Configure academic plotting aesthetics
+sns.set_theme(style="whitegrid", context="paper", font_scale=1.2)
+plt.rcParams.update({
+    "font.family": "serif",
+    "figure.figsize": (8, 6),
+    "axes.titlesize": 16,
+    "axes.labelsize": 14,
+    "legend.fontsize": 12,
+    "xtick.labelsize": 11,
+    "ytick.labelsize": 11,
+})
+
+logger = logging.getLogger(__name__)
+METRIC_FIELD_NAMES = {field.name for field in fields(PerformanceMetrics)}
+
+
+class EvaluationPoint:
+    """Represents a single evaluation point during tuning."""
+
+    def __init__(self, metrics_dict: dict, wall_time: float, evals_so_far: int):
+        self.wall_time = wall_time
+        self.evals_so_far = evals_so_far
+        self.global_score: Optional[float] = None
+        # Safely instantiate PerformanceMetrics, ignoring unknown keys
+        valid_keys = {k: v for k, v in metrics_dict.items() if k in METRIC_FIELD_NAMES}
+        self.metrics = PerformanceMetrics(**valid_keys)
+
+
+class TuningRun:
+    """Parses and encapsulates the data of a single tuning run (one seed)."""
+
+    def __init__(self, filepath: Path, method: str, seed: int):
+        self.filepath = filepath
+        self.method = method.upper()
+        self.seed = seed
+        self.evaluations: List[EvaluationPoint] = []
+        self.best_config_metrics: Optional[PerformanceMetrics] = None
+        self.best_global_score: Optional[float] = None
+
+        self.workload: str = "mixed"
+        self.benchmark: str = "unknown"
+        
+        self._parse_json()
+
+    def _parse_json(self) -> None:
+        """Loads JSON and parses the sequence of evaluations."""
+        import dateutil.parser
+        
+        with open(self.filepath, "r") as f:
+            data = json.load(f)
+
+        session = data.get("tuning_session", {})
+        self.workload = session.get("workload_type", session.get("workload", "mixed"))
+        self.benchmark = session.get(
+            "benchmark_name", session.get("benchmark", "unknown")
+        )
+
+        best_cfg = data.get("best_configuration", {})
+        valid_keys = {
+            k: v for k, v in best_cfg.get("metrics", {}).items() if k in METRIC_FIELD_NAMES
+        }
+        self.best_config_metrics = PerformanceMetrics(**valid_keys)
+
+        history = data.get("generation_history", [])
+        evals_so_far = 0
+        start_time = None
+        
+        for gen in history:
+            # Parse timestamp for wall time calculation
+            ts_str = gen.get("timestamp")
+            if ts_str:
+                current_time = dateutil.parser.isoparse(ts_str)
+                if start_time is None:
+                    # Give it a tiny offset (e.g. 20 seconds) for the very first step
+                    start_time = current_time - pd.Timedelta(seconds=20) 
+                wall_time = (current_time - start_time).total_seconds()
+            else:
+                wall_time = 0.0
+
+            workers = gen.get("worker_scores", [])
+            for worker in workers:
+                evals_so_far += 1
+                self.evaluations.append(EvaluationPoint(worker.get("metrics", {}), wall_time, evals_so_far))
+
+    def get_all_metrics(self) -> List[PerformanceMetrics]:
+        """Returns all metric objects (including the final best) for global pooling."""
+        metrics_list = [eval_pt.metrics for eval_pt in self.evaluations]
+        if self.best_config_metrics:
+            metrics_list.append(self.best_config_metrics)
+        return metrics_list
+
+
+class Analyzer:
+    """Manages cross-method analysis, rescoring, and visualization."""
+
+    def __init__(
+        self,
+        pbt_runs: List[TuningRun],
+        bo_runs: List[TuningRun],
+        output_dir: Path,
+    ):
+        self.pbt_runs = pbt_runs
+        self.bo_runs = bo_runs
+        self.all_runs = pbt_runs + bo_runs
+        self.output_dir = output_dir
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        
+        if not self.all_runs:
+            raise ValueError("No runs provided for analysis.")
+
+        # Determine benchmark context for rescoring
+        self.benchmark = self.all_runs[0].benchmark
+        self.workload = self.all_runs[0].workload
+
+    def apply_global_rescoring(self) -> None:
+        """Pools all metrics across methods/seeds and applies global rescoring."""
+        logger.info("Extracting raw metrics across all runs for global rescoring...")
+        pooled_metrics = []
+        for run in self.all_runs:
+            pooled_metrics.extend(run.get_all_metrics())
+
+        logger.info("Applying rescore_metrics_globally...")
+        metric_cfg, rescored_values, metadata = rescore_metrics_globally(
+            pooled_metrics, benchmark=self.benchmark, workload=self.workload
+        )
+
+        # Distribute the scores back to their respective objects
+        score_idx = 0
+        for run in self.all_runs:
+            for eval_pt in run.evaluations:
+                # Update current best score seen so far to emulate learning progress
+                current_score = rescored_values[score_idx]
+                if eval_pt.evals_so_far == 1:
+                    eval_pt.global_score = current_score
+                else:
+                    prev_best = run.evaluations[eval_pt.evals_so_far - 2].global_score
+                    eval_pt.global_score = max(prev_best, current_score)
+                score_idx += 1
+                
+            if run.best_config_metrics:
+                run.best_global_score = rescored_values[score_idx]
+                score_idx += 1
+
+        logger.info("Global rescoring complete. Metadata: %s", metadata)
+
+    def _build_timeseries_df(self) -> pd.DataFrame:
+        """Converts evaluation timelines into a flat DataFrame for Seaborn lineplots."""
+        rows = []
+        for run in self.all_runs:
+            for eval_pt in run.evaluations:
+                rows.append({
+                    "Method": run.method,
+                    "Seed": run.seed,
+                    "Evaluations": eval_pt.evals_so_far,
+                    "WallTimeSeconds": eval_pt.wall_time,
+                    "GlobalScore": eval_pt.global_score
+                })
+        return pd.DataFrame(rows)
+
+    def plot_convergence(self) -> None:
+        """Generates convergence plots for Sample and Wall-Clock Efficiency."""
+        df = self._build_timeseries_df()
+
+        fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(16, 6))
+
+        # 1. Sample Efficiency
+        sns.lineplot(
+            data=df, x="Evaluations", y="GlobalScore", hue="Method", 
+            errorbar="sd", ax=ax1, marker="o", markersize=4
+        )
+        ax1.set_title("Sample Efficiency\n(Global Score vs. Total Evaluations)")
+        ax1.set_xlabel("Cumulative Evaluations")
+        ax1.set_ylabel("Max Global Composite Score")
+
+        # 2. Wall-Clock Efficiency
+        sns.lineplot(
+            data=df, x="WallTimeSeconds", y="GlobalScore", hue="Method", 
+            errorbar="sd", ax=ax2, marker="o", markersize=4
+        )
+        ax2.set_title("Wall-Clock Efficiency\n(Global Score vs. Elapsed Time)")
+        ax2.set_xlabel("Elapsed Wall-Clock Time (s)")
+        ax2.set_ylabel("Max Global Composite Score")
+
+        plt.tight_layout()
+        output_file = self.output_dir / "publication_ready_convergence.pdf"
+        plt.savefig(output_file, dpi=300, bbox_inches="tight")
+        plt.close(fig)
+        logger.info("Saved %s", output_file)
+
+    def plot_pareto_front(self) -> None:
+        """Creates a scatter plot comparing Throughput and Latency of the final best reps."""
+        rows = []
+        for run in self.all_runs:
+            if run.best_config_metrics:
+                rows.append({
+                    "Method": run.method,
+                    "Seed": run.seed,
+                    "Throughput": run.best_config_metrics.throughput,
+                    "Latency (p95)": run.best_config_metrics.latency_p95
+                })
+
+        if not rows:
+            logger.warning("No best configuration metrics found for Pareto plot.")
+            return
+
+        df = pd.DataFrame(rows)
+        plt.figure()
+        sns.scatterplot(
+            data=df, x="Throughput", y="Latency (p95)", hue="Method", 
+            style="Method", s=150, alpha=0.8, edgecolor="black"
+        )
+        
+        plt.title("Pareto Front of Best Configurations")
+        plt.xlabel("Throughput (Queries/sec) $\\uparrow$")
+        plt.ylabel("95th Percentile Latency (ms) $\\downarrow$")
+        
+        plt.tight_layout()
+        output_file = self.output_dir / "publication_ready_pareto.pdf"
+        plt.savefig(output_file, dpi=300, bbox_inches="tight")
+        plt.close()
+        logger.info("Saved %s", output_file)
+
+    def plot_resource_efficiency(self) -> None:
+        """Generates a boxplot showing Memory Utilization of final best configs."""
+        rows = []
+        for run in self.all_runs:
+            if run.best_config_metrics:
+                rows.append({
+                    "Method": run.method,
+                    "Memory Utilization": run.best_config_metrics.memory_utilization
+                })
+
+        if not rows:
+            return
+
+        df = pd.DataFrame(rows)
+        plt.figure(figsize=(6, 6))
+        sns.boxplot(data=df, x="Method", y="Memory Utilization", width=0.4, showmeans=True)
+        sns.stripplot(data=df, x="Method", y="Memory Utilization", color="black", alpha=0.6, jitter=True)
+
+        plt.title("Resource Efficiency\n(Memory Utilization of Best Configs)")
+        plt.ylabel("Memory Utilization (Fraction)")
+        
+        plt.tight_layout()
+        output_file = self.output_dir / "publication_ready_resource_efficiency.pdf"
+        plt.savefig(output_file, dpi=300, bbox_inches="tight")
+        plt.close()
+        logger.info("Saved %s", output_file)
+
+    def statistical_significance_test(self, alpha: float = 0.05) -> pd.DataFrame:
+        """Runs the Mann-Whitney U test on final best scores."""
+        pbt_scores = [r.best_global_score for r in self.pbt_runs if r.best_global_score is not None]
+        bo_scores = [r.best_global_score for r in self.bo_runs if r.best_global_score is not None]
+
+        if not pbt_scores or not bo_scores:
+            logger.warning(
+                "Skipping statistical test because one method has no scored runs "
+                "(PBT=%d, BO=%d).",
+                len(pbt_scores),
+                len(bo_scores),
+            )
+            return pd.DataFrame()
+
+        stat, p_value = stats.mannwhitneyu(pbt_scores, bo_scores, alternative="two-sided")
+        
+        logger.info("=== Statistical Significance (Mann-Whitney U) ===")
+        logger.info(f"PBT best scores (N={len(pbt_scores)}): {np.mean(pbt_scores):.4f} ± {np.std(pbt_scores):.4f}")
+        logger.info(f"BO best scores (N={len(bo_scores)}): {np.mean(bo_scores):.4f} ± {np.std(bo_scores):.4f}")
+        logger.info(f"U-Statistic: {stat}, p-value: {p_value:.5f}")
+        
+        if p_value < alpha:
+            winner = "PBT" if np.mean(pbt_scores) > np.mean(bo_scores) else "BO"
+            logger.info(f"Result: SIGNIFICANT at α={alpha}. Method {winner} is superior.")
+        else:
+            logger.info(f"Result: NOT SIGNIFICANT at α={alpha}.")
+
+        result = pd.DataFrame(
+            [
+                {
+                    "Test": "Mann-Whitney U",
+                    "PBT_N": len(pbt_scores),
+                    "BO_N": len(bo_scores),
+                    "PBT_Mean": np.mean(pbt_scores),
+                    "PBT_StdDev": np.std(pbt_scores),
+                    "BO_Mean": np.mean(bo_scores),
+                    "BO_StdDev": np.std(bo_scores),
+                    "U_Statistic": stat,
+                    "P_Value": p_value,
+                    "Alpha": alpha,
+                    "Significant": p_value < alpha,
+                }
+            ]
+        )
+        output_file = self.output_dir / "statistical_significance.csv"
+        result.round(6).to_csv(output_file, index=False)
+        logger.info("Statistical test written to %s", output_file)
+        return result
+
+    def generate_summary_table(self) -> None:
+        """Exports an aggregated statistical summary to CSV."""
+        rows = []
+        for run in self.all_runs:
+            if not run.best_config_metrics:
+                continue
+            # Get the final wall time measured
+            final_time = run.evaluations[-1].wall_time if run.evaluations else 0.0
+            
+            rows.append({
+                "Method": run.method,
+                "Seed": run.seed,
+                "SourceFile": str(run.filepath),
+                "BestScore": run.best_global_score,
+                "WallClockTime": final_time,
+                "Throughput": run.best_config_metrics.throughput,
+                "LatencyP95": run.best_config_metrics.latency_p95,
+                "MemoryUtilization": run.best_config_metrics.memory_utilization,
+            })
+
+        df = pd.DataFrame(rows)
+        detail_file = self.output_dir / "comparison_runs.csv"
+        df.round(6).to_csv(detail_file, index=False)
+
+        # Compute aggregates per method
+        summary = df.groupby("Method").agg(
+            Mean_Best_Score=("BestScore", "mean"),
+            StdDev_Best_Score=("BestScore", "std"),
+            Mean_WallClock_Time=("WallClockTime", "mean"),
+            Mean_Throughput=("Throughput", "mean"),
+            Mean_LatencyP95=("LatencyP95", "mean"),
+            Mean_MemoryUtilization=("MemoryUtilization", "mean"),
+            Trials=("BestScore", "count")
+        ).round(4).reset_index()
+
+        summary_file = self.output_dir / "comparison_summary.csv"
+        summary.to_csv(summary_file, index=False)
+        logger.info("\nComparison Summary written to %s:\n%s", summary_file, summary.to_string())
+
+    def export_timeseries(self) -> None:
+        """Exports the rescored convergence data used by the plots."""
+        df = self._build_timeseries_df()
+        output_file = self.output_dir / "comparison_timeseries.csv"
+        df.round(6).to_csv(output_file, index=False)
+        logger.info("Timeseries data written to %s", output_file)
+
+
+def main(
+    pbt_paths: List[str],
+    bo_paths: List[str],
+    output_dir: Path = Path("analysis"),
+):
+    """Main execution entry point."""
+    logger.info("Loading PBT tuning runs...")
+    pbt_runs = [TuningRun(Path(p), "PBT", seed) for seed, p in enumerate(pbt_paths)]
+    
+    logger.info("Loading BO tuning runs...")
+    bo_runs = [TuningRun(Path(p), "BO", seed) for seed, p in enumerate(bo_paths)]
+
+    analyzer = Analyzer(pbt_runs, bo_runs, output_dir=output_dir)
+    
+    # 1. Critical Requirement: Global Rescoring
+    analyzer.apply_global_rescoring()
+    analyzer.export_timeseries()
+    
+    # Generate Visualizations & Analysis
+    analyzer.plot_convergence()
+    analyzer.plot_pareto_front()
+    analyzer.plot_resource_efficiency()
+    
+    # Compute Statistics
+    analyzer.statistical_significance_test()
+    analyzer.generate_summary_table()
+
+if __name__ == "__main__":
+    import argparse
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+    
+    parser = argparse.ArgumentParser(description="Analyze PBT vs BO tuning runs.")
+    parser.add_argument("--pbt", nargs="+", required=True, help="List of PBT JSON files")
+    parser.add_argument("--bo", nargs="+", required=True, help="List of BO JSON files")
+    parser.add_argument("--output-dir", type=Path, default=Path("analysis"), help="Directory for CSV and PDF analysis outputs")
+    args = parser.parse_args()
+    
+    main(args.pbt, args.bo, args.output_dir)

--- a/src/scripts/pbt_vs_bo_comarison.py
+++ b/src/scripts/pbt_vs_bo_comarison.py
@@ -2,9 +2,9 @@
 """
 pbt_vs_bo_comparison.py
 
-Analyzes and compares the results of Population-Based Training (PBT) and 
-Bayesian Optimization (BO) for PostgreSQL auto-tuning. Supports dynamic 
-global rescoring, statistical significance testing, and generates 
+Analyzes and compares the results of Population-Based Training (PBT) and
+Bayesian Optimization (BO) for PostgreSQL auto-tuning. Supports dynamic
+global rescoring, statistical significance testing, and generates
 publication-ready plots.
 """
 
@@ -27,15 +27,17 @@ from src.utils.rescoring import rescore_metrics_globally
 
 # Configure academic plotting aesthetics
 sns.set_theme(style="whitegrid", context="paper", font_scale=1.2)
-plt.rcParams.update({
-    "font.family": "serif",
-    "figure.figsize": (8, 6),
-    "axes.titlesize": 16,
-    "axes.labelsize": 14,
-    "legend.fontsize": 12,
-    "xtick.labelsize": 11,
-    "ytick.labelsize": 11,
-})
+plt.rcParams.update(
+    {
+        "font.family": "serif",
+        "figure.figsize": (8, 6),
+        "axes.titlesize": 16,
+        "axes.labelsize": 14,
+        "legend.fontsize": 12,
+        "xtick.labelsize": 11,
+        "ytick.labelsize": 11,
+    }
+)
 
 logger = logging.getLogger(__name__)
 METRIC_FIELD_NAMES = {field.name for field in fields(PerformanceMetrics)}
@@ -66,13 +68,13 @@ class TuningRun:
 
         self.workload: str = "mixed"
         self.benchmark: str = "unknown"
-        
+
         self._parse_json()
 
     def _parse_json(self) -> None:
         """Loads JSON and parses the sequence of evaluations."""
         import dateutil.parser
-        
+
         with open(self.filepath, "r") as f:
             data = json.load(f)
 
@@ -91,14 +93,16 @@ class TuningRun:
 
         best_cfg = data.get("best_configuration", {})
         valid_keys = {
-            k: v for k, v in best_cfg.get("metrics", {}).items() if k in METRIC_FIELD_NAMES
+            k: v
+            for k, v in best_cfg.get("metrics", {}).items()
+            if k in METRIC_FIELD_NAMES
         }
         self.best_config_metrics = PerformanceMetrics(**valid_keys)
 
         history = data.get("generation_history", [])
         evals_so_far = 0
         start_time = None
-        
+
         for gen in history:
             # Parse timestamp for wall time calculation
             ts_str = gen.get("timestamp")
@@ -106,7 +110,7 @@ class TuningRun:
                 current_time = dateutil.parser.isoparse(ts_str)
                 if start_time is None:
                     # Give it a tiny offset (e.g. 20 seconds) for the very first step
-                    start_time = current_time - pd.Timedelta(seconds=20) 
+                    start_time = current_time - pd.Timedelta(seconds=20)
                 wall_time = (current_time - start_time).total_seconds()
             else:
                 wall_time = 0.0
@@ -154,7 +158,7 @@ class Analyzer:
         self.all_runs = pbt_runs + bo_runs
         self.output_dir = output_dir
         self.output_dir.mkdir(parents=True, exist_ok=True)
-        
+
         if not self.all_runs:
             raise ValueError("No runs provided for analysis.")
 
@@ -184,9 +188,14 @@ class Analyzer:
                     eval_pt.global_score = current_score
                 else:
                     prev_best = run.evaluations[eval_pt.evals_so_far - 2].global_score
-                    eval_pt.global_score = max(prev_best, current_score)
+                    if prev_best is None:
+                        eval_pt.global_score = current_score
+                    elif current_score is None:
+                        eval_pt.global_score = prev_best
+                    else:
+                        eval_pt.global_score = max(prev_best, current_score)
                 score_idx += 1
-                
+
             if run.best_config_metrics:
                 run.best_global_score = rescored_values[score_idx]
                 score_idx += 1
@@ -198,13 +207,15 @@ class Analyzer:
         rows = []
         for run in self.all_runs:
             for eval_pt in run.evaluations:
-                rows.append({
-                    "Method": run.method,
-                    "Seed": run.seed,
-                    "Evaluations": eval_pt.evals_so_far,
-                    "WallTimeSeconds": eval_pt.wall_time,
-                    "GlobalScore": eval_pt.global_score
-                })
+                rows.append(
+                    {
+                        "Method": run.method,
+                        "Seed": run.seed,
+                        "Evaluations": eval_pt.evals_so_far,
+                        "WallTimeSeconds": eval_pt.wall_time,
+                        "GlobalScore": eval_pt.global_score,
+                    }
+                )
         return pd.DataFrame(rows)
 
     def plot_convergence(self) -> None:
@@ -215,8 +226,14 @@ class Analyzer:
 
         # 1. Sample Efficiency
         sns.lineplot(
-            data=df, x="Evaluations", y="GlobalScore", hue="Method", 
-            errorbar="sd", ax=ax1, marker="o", markersize=4
+            data=df,
+            x="Evaluations",
+            y="GlobalScore",
+            hue="Method",
+            errorbar="sd",
+            ax=ax1,
+            marker="o",
+            markersize=4,
         )
         ax1.set_title("Sample Efficiency\n(Global Score vs. Total Evaluations)")
         ax1.set_xlabel("Cumulative Evaluations")
@@ -224,8 +241,14 @@ class Analyzer:
 
         # 2. Wall-Clock Efficiency
         sns.lineplot(
-            data=df, x="WallTimeSeconds", y="GlobalScore", hue="Method", 
-            errorbar="sd", ax=ax2, marker="o", markersize=4
+            data=df,
+            x="WallTimeSeconds",
+            y="GlobalScore",
+            hue="Method",
+            errorbar="sd",
+            ax=ax2,
+            marker="o",
+            markersize=4,
         )
         ax2.set_title("Wall-Clock Efficiency\n(Global Score vs. Elapsed Time)")
         ax2.set_xlabel("Elapsed Wall-Clock Time (s)")
@@ -242,12 +265,14 @@ class Analyzer:
         rows = []
         for run in self.all_runs:
             if run.best_config_metrics:
-                rows.append({
-                    "Method": run.method,
-                    "Seed": run.seed,
-                    "Throughput": run.best_config_metrics.throughput,
-                    "Latency (p95)": run.best_config_metrics.latency_p95
-                })
+                rows.append(
+                    {
+                        "Method": run.method,
+                        "Seed": run.seed,
+                        "Throughput": run.best_config_metrics.throughput,
+                        "Latency (p95)": run.best_config_metrics.latency_p95,
+                    }
+                )
 
         if not rows:
             logger.warning("No best configuration metrics found for Pareto plot.")
@@ -256,14 +281,20 @@ class Analyzer:
         df = pd.DataFrame(rows)
         plt.figure()
         sns.scatterplot(
-            data=df, x="Throughput", y="Latency (p95)", hue="Method", 
-            style="Method", s=150, alpha=0.8, edgecolor="black"
+            data=df,
+            x="Throughput",
+            y="Latency (p95)",
+            hue="Method",
+            style="Method",
+            s=150,
+            alpha=0.8,
+            edgecolor="black",
         )
-        
+
         plt.title("Pareto Front of Best Configurations")
         plt.xlabel("Throughput (Queries/sec) $\\uparrow$")
         plt.ylabel("95th Percentile Latency (ms) $\\downarrow$")
-        
+
         plt.tight_layout()
         output_file = self.output_dir / "publication_ready_pareto.pdf"
         plt.savefig(output_file, dpi=300, bbox_inches="tight")
@@ -275,22 +306,33 @@ class Analyzer:
         rows = []
         for run in self.all_runs:
             if run.best_config_metrics:
-                rows.append({
-                    "Method": run.method,
-                    "Memory Utilization": run.best_config_metrics.memory_utilization
-                })
+                rows.append(
+                    {
+                        "Method": run.method,
+                        "Memory Utilization": run.best_config_metrics.memory_utilization,
+                    }
+                )
 
         if not rows:
             return
 
         df = pd.DataFrame(rows)
         plt.figure(figsize=(6, 6))
-        sns.boxplot(data=df, x="Method", y="Memory Utilization", width=0.4, showmeans=True)
-        sns.stripplot(data=df, x="Method", y="Memory Utilization", color="black", alpha=0.6, jitter=True)
+        sns.boxplot(
+            data=df, x="Method", y="Memory Utilization", width=0.4, showmeans=True
+        )
+        sns.stripplot(
+            data=df,
+            x="Method",
+            y="Memory Utilization",
+            color="black",
+            alpha=0.6,
+            jitter=True,
+        )
 
         plt.title("Resource Efficiency\n(Memory Utilization of Best Configs)")
         plt.ylabel("Memory Utilization (Fraction)")
-        
+
         plt.tight_layout()
         output_file = self.output_dir / "publication_ready_resource_efficiency.pdf"
         plt.savefig(output_file, dpi=300, bbox_inches="tight")
@@ -299,8 +341,14 @@ class Analyzer:
 
     def statistical_significance_test(self, alpha: float = 0.05) -> pd.DataFrame:
         """Runs the Mann-Whitney U test on final best scores."""
-        pbt_scores = [r.best_global_score for r in self.pbt_runs if r.best_global_score is not None]
-        bo_scores = [r.best_global_score for r in self.bo_runs if r.best_global_score is not None]
+        pbt_scores = [
+            r.best_global_score
+            for r in self.pbt_runs
+            if r.best_global_score is not None
+        ]
+        bo_scores = [
+            r.best_global_score for r in self.bo_runs if r.best_global_score is not None
+        ]
 
         if not pbt_scores or not bo_scores:
             logger.warning(
@@ -311,16 +359,24 @@ class Analyzer:
             )
             return pd.DataFrame()
 
-        stat, p_value = stats.mannwhitneyu(pbt_scores, bo_scores, alternative="two-sided")
-        
+        stat, p_value = stats.mannwhitneyu(
+            pbt_scores, bo_scores, alternative="two-sided"
+        )
+
         logger.info("=== Statistical Significance (Mann-Whitney U) ===")
-        logger.info(f"PBT best scores (N={len(pbt_scores)}): {np.mean(pbt_scores):.4f} ± {np.std(pbt_scores):.4f}")
-        logger.info(f"BO best scores (N={len(bo_scores)}): {np.mean(bo_scores):.4f} ± {np.std(bo_scores):.4f}")
+        logger.info(
+            f"PBT best scores (N={len(pbt_scores)}): {np.mean(pbt_scores):.4f} ± {np.std(pbt_scores):.4f}"
+        )
+        logger.info(
+            f"BO best scores (N={len(bo_scores)}): {np.mean(bo_scores):.4f} ± {np.std(bo_scores):.4f}"
+        )
         logger.info(f"U-Statistic: {stat}, p-value: {p_value:.5f}")
-        
+
         if p_value < alpha:
             winner = "PBT" if np.mean(pbt_scores) > np.mean(bo_scores) else "BO"
-            logger.info(f"Result: SIGNIFICANT at α={alpha}. Method {winner} is superior.")
+            logger.info(
+                f"Result: SIGNIFICANT at α={alpha}. Method {winner} is superior."
+            )
         else:
             logger.info(f"Result: NOT SIGNIFICANT at α={alpha}.")
 
@@ -354,36 +410,45 @@ class Analyzer:
                 continue
             # Get the final wall time measured
             final_time = run.evaluations[-1].wall_time if run.evaluations else 0.0
-            
-            rows.append({
-                "Method": run.method,
-                "Seed": run.seed,
-                "SourceFile": str(run.filepath),
-                "BestScore": run.best_global_score,
-                "WallClockTime": final_time,
-                "Throughput": run.best_config_metrics.throughput,
-                "LatencyP95": run.best_config_metrics.latency_p95,
-                "MemoryUtilization": run.best_config_metrics.memory_utilization,
-            })
+
+            rows.append(
+                {
+                    "Method": run.method,
+                    "Seed": run.seed,
+                    "SourceFile": str(run.filepath),
+                    "BestScore": run.best_global_score,
+                    "WallClockTime": final_time,
+                    "Throughput": run.best_config_metrics.throughput,
+                    "LatencyP95": run.best_config_metrics.latency_p95,
+                    "MemoryUtilization": run.best_config_metrics.memory_utilization,
+                }
+            )
 
         df = pd.DataFrame(rows)
         detail_file = self.output_dir / "comparison_runs.csv"
         df.round(6).to_csv(detail_file, index=False)
 
         # Compute aggregates per method
-        summary = df.groupby("Method").agg(
-            Mean_Best_Score=("BestScore", "mean"),
-            StdDev_Best_Score=("BestScore", "std"),
-            Mean_WallClock_Time=("WallClockTime", "mean"),
-            Mean_Throughput=("Throughput", "mean"),
-            Mean_LatencyP95=("LatencyP95", "mean"),
-            Mean_MemoryUtilization=("MemoryUtilization", "mean"),
-            Trials=("BestScore", "count")
-        ).round(4).reset_index()
+        summary = (
+            df.groupby("Method")
+            .agg(
+                Mean_Best_Score=("BestScore", "mean"),
+                StdDev_Best_Score=("BestScore", "std"),
+                Mean_WallClock_Time=("WallClockTime", "mean"),
+                Mean_Throughput=("Throughput", "mean"),
+                Mean_LatencyP95=("LatencyP95", "mean"),
+                Mean_MemoryUtilization=("MemoryUtilization", "mean"),
+                Trials=("BestScore", "count"),
+            )
+            .round(4)
+            .reset_index()
+        )
 
         summary_file = self.output_dir / "comparison_summary.csv"
         summary.to_csv(summary_file, index=False)
-        logger.info("\nComparison Summary written to %s:\n%s", summary_file, summary.to_string())
+        logger.info(
+            "\nComparison Summary written to %s:\n%s", summary_file, summary.to_string()
+        )
 
     def export_timeseries(self) -> None:
         """Exports the rescored convergence data used by the plots."""
@@ -401,33 +466,42 @@ def main(
     """Main execution entry point."""
     logger.info("Loading PBT tuning runs...")
     pbt_runs = [TuningRun(Path(p), "PBT") for p in pbt_paths]
-    
+
     logger.info("Loading BO tuning runs...")
     bo_runs = [TuningRun(Path(p), "BO") for p in bo_paths]
 
     analyzer = Analyzer(pbt_runs, bo_runs, output_dir=output_dir)
-    
+
     # 1. Critical Requirement: Global Rescoring
     analyzer.apply_global_rescoring()
     analyzer.export_timeseries()
-    
+
     # Generate Visualizations & Analysis
     analyzer.plot_convergence()
     analyzer.plot_pareto_front()
     analyzer.plot_resource_efficiency()
-    
+
     # Compute Statistics
     analyzer.statistical_significance_test()
     analyzer.generate_summary_table()
 
+
 if __name__ == "__main__":
     import argparse
+
     logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
-    
+
     parser = argparse.ArgumentParser(description="Analyze PBT vs BO tuning runs.")
-    parser.add_argument("--pbt", nargs="+", required=True, help="List of PBT JSON files")
+    parser.add_argument(
+        "--pbt", nargs="+", required=True, help="List of PBT JSON files"
+    )
     parser.add_argument("--bo", nargs="+", required=True, help="List of BO JSON files")
-    parser.add_argument("--output-dir", type=Path, default=Path("analysis"), help="Directory for CSV and PDF analysis outputs")
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("analysis"),
+        help="Directory for CSV and PDF analysis outputs",
+    )
     args = parser.parse_args()
-    
+
     main(args.pbt, args.bo, args.output_dir)

--- a/src/scripts/pbt_vs_bo_comarison.py
+++ b/src/scripts/pbt_vs_bo_comarison.py
@@ -56,10 +56,10 @@ class EvaluationPoint:
 class TuningRun:
     """Parses and encapsulates the data of a single tuning run (one seed)."""
 
-    def __init__(self, filepath: Path, method: str, seed: int):
+    def __init__(self, filepath: Path, method: str):
         self.filepath = filepath
         self.method = method.upper()
-        self.seed = seed
+        self.seed: Optional[int] = None
         self.evaluations: List[EvaluationPoint] = []
         self.best_config_metrics: Optional[PerformanceMetrics] = None
         self.best_global_score: Optional[float] = None
@@ -77,10 +77,17 @@ class TuningRun:
             data = json.load(f)
 
         session = data.get("tuning_session", {})
+        self.seed = self._extract_seed(session)
         self.workload = session.get("workload_type", session.get("workload", "mixed"))
         self.benchmark = session.get(
             "benchmark_name", session.get("benchmark", "unknown")
         )
+        if self.seed is None:
+            logger.warning(
+                "No seed metadata found in %s tuning session: %s",
+                self.method,
+                self.filepath,
+            )
 
         best_cfg = data.get("best_configuration", {})
         valid_keys = {
@@ -107,7 +114,23 @@ class TuningRun:
             workers = gen.get("worker_scores", [])
             for worker in workers:
                 evals_so_far += 1
-                self.evaluations.append(EvaluationPoint(worker.get("metrics", {}), wall_time, evals_so_far))
+                self.evaluations.append(
+                    EvaluationPoint(worker.get("metrics", {}), wall_time, evals_so_far)
+                )
+
+    @staticmethod
+    def _extract_seed(session: dict) -> Optional[int]:
+        """Return the tuning-session seed when it is persisted."""
+        for key in ("seed", "random_seed"):
+            value = session.get(key)
+            if value is None:
+                continue
+            try:
+                return int(value)
+            except (TypeError, ValueError):
+                logger.warning("Ignoring non-integer %s metadata: %r", key, value)
+                return None
+        return None
 
     def get_all_metrics(self) -> List[PerformanceMetrics]:
         """Returns all metric objects (including the final best) for global pooling."""
@@ -377,10 +400,10 @@ def main(
 ):
     """Main execution entry point."""
     logger.info("Loading PBT tuning runs...")
-    pbt_runs = [TuningRun(Path(p), "PBT", seed) for seed, p in enumerate(pbt_paths)]
+    pbt_runs = [TuningRun(Path(p), "PBT") for p in pbt_paths]
     
     logger.info("Loading BO tuning runs...")
-    bo_runs = [TuningRun(Path(p), "BO", seed) for seed, p in enumerate(bo_paths)]
+    bo_runs = [TuningRun(Path(p), "BO") for p in bo_paths]
 
     analyzer = Analyzer(pbt_runs, bo_runs, output_dir=output_dir)
     

--- a/src/tuner/main.py
+++ b/src/tuner/main.py
@@ -967,6 +967,7 @@ class PBTTuner:
                 "sysbench_duration_seconds": self.pbt_config.evaluation_duration,
                 "sysbench_warmup_seconds": self.pbt_config.warmup_duration,
                 "population_size": self.pbt_config.population_size,
+                "seed": self.random_seed,
                 "total_generations": self.population.current_generation,
                 "total_time_seconds": total_time,
                 "timestamp": self.timestamp,

--- a/src/utils/environments/docker.py
+++ b/src/utils/environments/docker.py
@@ -494,7 +494,11 @@ class DockerEnvironment(DatabaseEnvironment):
                         LOGGER.debug(
                             "    Caching worker 0 baseline snapshot for fast-path initialization...",
                         )
-                        self.create_snapshot(worker_id=0)
+                        snapshot_id = self.create_snapshot(worker_id=0)
+                        if not snapshot_id:
+                            raise RuntimeError(
+                                "Failed to create baseline Docker snapshot for worker 0"
+                            )
                         baseline_snapshot_available = True
 
             LOGGER.debug(

--- a/src/utils/scoring/normalization.py
+++ b/src/utils/scoring/normalization.py
@@ -279,7 +279,7 @@ class QuantileUtilityNormalizer:
         )
 
         # Extract flat dictionary of values
-        series = {}
+        series: Dict[str, list[float]] = {}
         for metric in metrics_list:
             raw_dict = metric.to_dict()
             for key, val in raw_dict.items():
@@ -530,32 +530,3 @@ class QuantileUtilityNormalizer:
         self._total_samples_since_calibration = state.get("total_samples", 0)
         self._history = {}
         self._out_of_support_counts = {}
-
-    def get_drift_events(self) -> List[Dict[str, Any]]:
-        """
-        Return list of drift events detected since normalizer creation.
-
-        Each event contains:
-        - sample_count: Number of samples when drift was detected
-        - metrics_drifted: List of metric names that triggered drift
-        - out_of_support_rates: Dict of metric -> out-of-support rate
-        """
-        return list(self._drift_events)
-
-    def record_drift_event(self, drifted_metrics: List[str]) -> None:
-        """
-        Record a drift event for monitoring and analysis.
-
-        Parameters
-        ----------
-        drifted_metrics : List[str]
-            List of metric names that exceeded drift threshold
-        """
-        event = {
-            "sample_count": self._total_samples_since_calibration,
-            "metrics_drifted": drifted_metrics,
-            "out_of_support_rates": {
-                metric: self.out_of_support_rate(metric) for metric in drifted_metrics
-            },
-        }
-        self._drift_events.append(event)

--- a/src/utils/scoring/weights.py
+++ b/src/utils/scoring/weights.py
@@ -85,7 +85,7 @@ class FeatureDrivenWeightModel:
 
         # Softmax with temperature (numerically stable)
         logits_arr = np.array(logits) / self.temperature
-        max_logit = np.max(logits_arr)
+        max_logit: float = float(np.max(logits_arr))
         exp_logits = np.exp(logits_arr - max_logit)
         softmax = exp_logits / np.sum(exp_logits)
 

--- a/tests/test_bo_baseline.py
+++ b/tests/test_bo_baseline.py
@@ -69,6 +69,7 @@ class TestPBTSessionParity:
             output_dir="results",
             verbose="INFO",
             range_update_interval=5,
+            bo_surrogate="rf",
             pbt_session=str(pbt_session),
         )
 
@@ -132,6 +133,7 @@ class TestPBTSessionParity:
             output_dir="results",
             verbose="INFO",
             range_update_interval=5,
+            bo_surrogate="rf",
             pbt_session=str(pbt_session),
         )
 
@@ -260,6 +262,7 @@ class TestResultFormat:
 
         config = BOConfig(
             n_iterations=3,
+            random_seed=123,
             knob_tier="minimal",
             benchmark="sysbench",
             workload_type="oltp",
@@ -323,6 +326,7 @@ class TestResultFormat:
         assert results["tuning_session"]["optimizer"] == "bayesian_optimization"
         assert results["tuning_session"]["bo_library"] == "smac3"
         assert results["tuning_session"]["bo_surrogate"] == "gp"
+        assert results["tuning_session"]["seed"] == 123
         assert results["best_configuration"]["score"] == 0.6
 
         # Find the written file
@@ -335,6 +339,8 @@ class TestResultFormat:
 
         assert loaded is not None
         assert loaded.best_score == 0.6
+        written = json.loads(result_file.read_text(encoding="utf-8"))
+        assert written["tuning_session"]["seed"] == 123
 
     def test_result_generation_history(self, tmp_path):
         """Test that generation history is properly formatted."""

--- a/tests/test_bo_baseline.py
+++ b/tests/test_bo_baseline.py
@@ -3,7 +3,6 @@
 import pytest
 import json
 import argparse
-from pathlib import Path
 
 from src.tuner.config import get_knob_space
 from src.scripts.bo_baseline.search_space import build_configspace, configspace_to_knobs
@@ -213,7 +212,7 @@ class TestSearchSpaceTranslation:
         assert len(knob_dict) > 0
 
         # Verify all values are valid Python types
-        for key, value in knob_dict.items():
+        for _key, value in knob_dict.items():
             assert not isinstance(value, type(None)) or value is None
             assert isinstance(value, (int, float, str, bool, type(None)))
 
@@ -353,12 +352,6 @@ class TestResultFormat:
             knob_tier="minimal",
             benchmark="sysbench",
             workload_type="oltp",
-        )
-
-        worker_resources = WorkerResources(
-            ram_bytes=16 * 1024 * 1024 * 1024,
-            cpu_cores=8,
-            disk_type="SSD",
         )
 
         iteration_log = [

--- a/tests/test_bo_baseline.py
+++ b/tests/test_bo_baseline.py
@@ -1,0 +1,413 @@
+"""Unit tests for Bayesian Optimization baseline components."""
+
+import pytest
+import json
+import argparse
+from pathlib import Path
+
+from src.tuner.config import get_knob_space
+from src.scripts.bo_baseline.search_space import build_configspace, configspace_to_knobs
+from src.scripts.bo_baseline.config import BOConfig
+from src.scripts.bo_baseline.result_writer import write_bo_results
+from src.utils.hardware_info import WorkerResources, detect_worker_resources
+from src.evaluation.loader import load_tuning_session
+
+
+class TestPBTSessionParity:
+    """Test extracting comparable BO settings from a PBT tuning session."""
+
+    def test_bo_config_extracts_pbt_session_parameters(self, tmp_path):
+        pbt_session = tmp_path / "pbt_results_test.json"
+        pbt_session.write_text(
+            json.dumps(
+                {
+                    "tuning_session": {
+                        "knob_tier": "minimal",
+                        "workload_type": "oltp",
+                        "benchmark_name": "sysbench",
+                        "sysbench_tables": 2,
+                        "sysbench_table_size": 10000,
+                        "sysbench_workload": "oltp_read_write",
+                        "sysbench_duration_seconds": 15.0,
+                        "sysbench_warmup_seconds": 10.0,
+                        "tpch_scale_factor": 0.01,
+                        "tpch_warmup_passes": 0,
+                        "tuning_mode": "online",
+                        "population_size": 4,
+                        "total_generations": 10,
+                    },
+                    "best_configuration": {
+                        "knobs": {
+                            "effective_cache_size": 0.5,
+                            "random_page_cost": 1.2,
+                            "work_mem": 0.01,
+                        }
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        args = argparse.Namespace(
+            iterations=None,
+            seed=123,
+            tier=None,
+            benchmark="tpch",
+            workload="olap",
+            duration=60.0,
+            warmup=30.0,
+            tuning_mode="offline",
+            sysbench_tables=4,
+            sysbench_table_size=100000,
+            sysbench_workload="oltp_read_only",
+            scale_factor=1.0,
+            tpch_warmup_passes=1,
+            no_docker=True,
+            docker_image=None,
+            force_recreate_instances=False,
+            force_recreate_baseline=False,
+            output_dir="results",
+            verbose="INFO",
+            range_update_interval=5,
+            pbt_session=str(pbt_session),
+        )
+
+        config = BOConfig.from_args(args)
+
+        assert config.n_iterations == 40
+        assert config.random_seed == 123
+        assert config.knob_tier == "minimal"
+        assert config.benchmark == "sysbench"
+        assert config.workload_type == "oltp"
+        assert config.evaluation_duration == 15.0
+        assert config.warmup_duration == 10.0
+        assert config.tuning_mode == "online"
+        assert config.sysbench_tables == 2
+        assert config.sysbench_table_size == 10000
+        assert config.sysbench_workload == "oltp_read_write"
+        assert config.scale_factor == 0.01
+        assert config.tpch_warmup_passes == 0
+        assert config.pbt_session_path == pbt_session
+        assert config.pbt_knob_names == (
+            "effective_cache_size",
+            "random_page_cost",
+            "work_mem",
+        )
+
+    def test_bo_config_explicit_iterations_override_pbt_budget(self, tmp_path):
+        pbt_session = tmp_path / "pbt_results_test.json"
+        pbt_session.write_text(
+            json.dumps(
+                {
+                    "tuning_session": {
+                        "knob_tier": "minimal",
+                        "workload_type": "oltp",
+                        "benchmark_name": "sysbench",
+                        "population_size": 4,
+                        "total_generations": 10,
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        args = argparse.Namespace(
+            iterations=7,
+            seed=123,
+            tier=None,
+            benchmark="sysbench",
+            workload="oltp",
+            duration=15.0,
+            warmup=10.0,
+            tuning_mode="offline",
+            sysbench_tables=2,
+            sysbench_table_size=10000,
+            sysbench_workload="oltp_read_write",
+            scale_factor=0.01,
+            tpch_warmup_passes=0,
+            no_docker=True,
+            docker_image=None,
+            force_recreate_instances=False,
+            force_recreate_baseline=False,
+            output_dir="results",
+            verbose="INFO",
+            range_update_interval=5,
+            pbt_session=str(pbt_session),
+        )
+
+        config = BOConfig.from_args(args)
+
+        assert config.n_iterations == 7
+
+    def test_bo_config_requires_tier_without_pbt_session(self):
+        args = argparse.Namespace(
+            iterations=None,
+            seed=123,
+            tier=None,
+            benchmark="sysbench",
+            workload="oltp",
+            duration=15.0,
+            warmup=10.0,
+            tuning_mode="offline",
+            sysbench_tables=2,
+            sysbench_table_size=10000,
+            sysbench_workload="oltp_read_write",
+            scale_factor=0.01,
+            tpch_warmup_passes=0,
+            no_docker=True,
+            docker_image=None,
+            force_recreate_instances=False,
+            force_recreate_baseline=False,
+            output_dir="results",
+            verbose="INFO",
+            range_update_interval=5,
+            pbt_session=None,
+        )
+
+        with pytest.raises(ValueError, match="Either --tier or --pbt-session"):
+            BOConfig.from_args(args)
+
+
+class TestSearchSpaceTranslation:
+    """Test ConfigSpace translation."""
+
+    def test_build_configspace_minimal(self):
+        """Test building ConfigSpace for minimal tier."""
+        knob_space = get_knob_space("minimal")
+        resources = detect_worker_resources()
+        knob_space.resolve_hardware_ranges(resources)
+
+        cs = build_configspace(knob_space, seed=42)
+
+        assert cs is not None
+        assert len(cs) == len(knob_space.knobs)
+
+    def test_build_configspace_core(self):
+        """Test building ConfigSpace for core tier."""
+        knob_space = get_knob_space("core")
+        resources = detect_worker_resources()
+        knob_space.resolve_hardware_ranges(resources)
+
+        cs = build_configspace(knob_space, seed=42)
+
+        assert cs is not None
+        assert len(cs) == len(knob_space.knobs)
+
+    def test_configspace_to_knobs_conversion(self):
+        """Test converting ConfigSpace config back to knob dict."""
+        knob_space = get_knob_space("minimal")
+        resources = detect_worker_resources()
+        knob_space.resolve_hardware_ranges(resources)
+
+        cs = build_configspace(knob_space, seed=42)
+
+        # Sample a random configuration
+        config = cs.sample_configuration()
+
+        # Convert back to knob dict
+        knob_dict = configspace_to_knobs(config, knob_space)
+
+        assert isinstance(knob_dict, dict)
+        assert len(knob_dict) > 0
+
+        # Verify all values are valid Python types
+        for key, value in knob_dict.items():
+            assert not isinstance(value, type(None)) or value is None
+            assert isinstance(value, (int, float, str, bool, type(None)))
+
+    def test_configspace_sampling_reproducibility(self):
+        """Test that ConfigSpace sampling is reproducible with same seed."""
+        knob_space = get_knob_space("minimal")
+        resources = detect_worker_resources()
+        knob_space.resolve_hardware_ranges(resources)
+
+        cs1 = build_configspace(knob_space, seed=42)
+        cs2 = build_configspace(knob_space, seed=42)
+
+        config1 = cs1.sample_configuration()
+        config2 = cs2.sample_configuration()
+
+        # Configurations should be identical with same seed
+        assert config1 == config2
+
+    def test_configspace_validation(self):
+        """Test that sampled configs pass knob space validation."""
+        knob_space = get_knob_space("core")
+        resources = detect_worker_resources()
+        knob_space.resolve_hardware_ranges(resources)
+
+        cs = build_configspace(knob_space, seed=42)
+
+        for _ in range(10):
+            config = cs.sample_configuration()
+            knob_dict = configspace_to_knobs(config, knob_space)
+
+            # Repair dependencies
+            repaired = knob_space.repair_config_dependencies(knob_dict)
+
+            # Validate
+            assert knob_space.validate_config(repaired)
+
+
+class TestResultFormat:
+    """Test result serialization format."""
+
+    def test_result_format_compatibility(self, tmp_path):
+        """Test that generated results are compatible with loader."""
+        knob_space = get_knob_space("minimal")
+        resources = detect_worker_resources()
+        knob_space.resolve_hardware_ranges(resources)
+
+        config = BOConfig(
+            n_iterations=3,
+            knob_tier="minimal",
+            benchmark="sysbench",
+            workload_type="oltp",
+        )
+
+        worker_resources = WorkerResources(
+            ram_bytes=16 * 1024 * 1024 * 1024,
+            cpu_cores=8,
+            disk_type="SSD",
+        )
+
+        system_info = {
+            "hostname": "test-host",
+            "platform": "linux",
+            "cpu_count": 8,
+        }
+
+        # Create mock iteration log
+        iteration_log = [
+            {
+                "iteration": 0,
+                "config": {"shared_buffers": 1024},
+                "metrics": {"throughput": 100.0, "latency_p95": 50.0},
+                "score": 0.5,
+                "cost": 50.0,
+                "wall_time_seconds": 30.0,
+                "restarted": False,
+                "timestamp": 1234567890.0,
+            },
+            {
+                "iteration": 1,
+                "config": {"shared_buffers": 2048},
+                "metrics": {"throughput": 120.0, "latency_p95": 45.0},
+                "score": 0.6,
+                "cost": 40.0,
+                "wall_time_seconds": 30.0,
+                "restarted": False,
+                "timestamp": 1234567920.0,
+            },
+        ]
+
+        # Write results
+        results = write_bo_results(
+            knob_space=knob_space,
+            config=config,
+            worker_resources=worker_resources,
+            system_info=system_info,
+            iteration_log=iteration_log,
+            total_time=60.0,
+            output_dir=tmp_path,
+            bo_surrogate="gp",
+        )
+
+        # Verify result structure
+        assert "tuning_session" in results
+        assert "best_configuration" in results
+        assert "worker_resources" in results
+        assert "generation_history" in results
+
+        # Verify required fields
+        assert results["tuning_session"]["optimizer"] == "bayesian_optimization"
+        assert results["tuning_session"]["bo_library"] == "smac3"
+        assert results["tuning_session"]["bo_surrogate"] == "gp"
+        assert results["best_configuration"]["score"] == 0.6
+
+        # Find the written file
+        result_files = list(tmp_path.glob("**/bo_results_*.json"))
+        assert len(result_files) == 1
+
+        # Load and verify with loader
+        result_file = result_files[0]
+        loaded = load_tuning_session(result_file)
+
+        assert loaded is not None
+        assert loaded.best_score == 0.6
+
+    def test_result_generation_history(self, tmp_path):
+        """Test that generation history is properly formatted."""
+        knob_space = get_knob_space("minimal")
+        resources = detect_worker_resources()
+        knob_space.resolve_hardware_ranges(resources)
+
+        config = BOConfig(
+            n_iterations=2,
+            knob_tier="minimal",
+            benchmark="sysbench",
+            workload_type="oltp",
+        )
+
+        worker_resources = WorkerResources(
+            ram_bytes=16 * 1024 * 1024 * 1024,
+            cpu_cores=8,
+            disk_type="SSD",
+        )
+
+        iteration_log = [
+            {
+                "iteration": 0,
+                "config": {"shared_buffers": 1024},
+                "metrics": {"throughput": 100.0},
+                "score": 0.5,
+                "cost": 50.0,
+                "wall_time_seconds": 30.0,
+                "restarted": False,
+                "timestamp": 1234567890.0,
+            },
+            {
+                "iteration": 1,
+                "config": {"shared_buffers": 2048},
+                "metrics": {"throughput": 120.0},
+                "score": 0.6,
+                "cost": 40.0,
+                "wall_time_seconds": 30.0,
+                "restarted": False,
+                "timestamp": 1234567920.0,
+            },
+        ]
+
+        results = write_bo_results(
+            knob_space=knob_space,
+            config=config,
+            worker_resources=WorkerResources(
+                ram_bytes=16 * 1024 * 1024 * 1024,
+                cpu_cores=8,
+                disk_type="SSD",
+            ),
+            system_info={},
+            iteration_log=iteration_log,
+            total_time=60.0,
+            output_dir=tmp_path,
+        )
+
+        # Verify generation history
+        gen_hist = results["generation_history"]
+        assert len(gen_hist) == 2
+
+        # Check first generation
+        assert gen_hist[0]["generation"] == 0
+        assert gen_hist[0]["best_score"] == 0.5
+        assert gen_hist[0]["mean_score"] == 0.5
+        assert len(gen_hist[0]["worker_scores"]) == 1
+        assert gen_hist[0]["worker_scores"][0]["score"] == 0.5
+
+        # Check second generation (best_score should be cumulative)
+        assert gen_hist[1]["generation"] == 1
+        assert gen_hist[1]["best_score"] == 0.6
+        assert gen_hist[1]["mean_score"] == 0.6
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/unit/utils/test_docker_environment.py
+++ b/tests/unit/utils/test_docker_environment.py
@@ -312,6 +312,28 @@ def test_setup_instances_recreates_worker0_when_baseline_snapshot_missing() -> N
     env.create_snapshot.assert_called_once_with(worker_id=0)
 
 
+def test_setup_instances_raises_when_baseline_snapshot_creation_fails() -> None:
+    """Setup should fail immediately when the required baseline snapshot is missing."""
+    env = _make_environment()
+
+    env.client.containers.get.side_effect = docker.errors.NotFound("missing")
+    env.client.containers.run.return_value = MagicMock()
+
+    env._wait_for_ready = MagicMock()
+    env.initialize_schema = MagicMock()
+    env.schema_provider = _DummySchemaProvider()
+    env.snapshot_exists = MagicMock(return_value=False)
+    env.create_snapshot = MagicMock(return_value="")
+
+    with pytest.raises(
+        RuntimeError,
+        match="Failed to create baseline Docker snapshot for worker 0",
+    ):
+        env.setup_instances(num_workers=1, force_recreate=False)
+
+    env.create_snapshot.assert_called_once_with(worker_id=0)
+
+
 def test_setup_instances_force_recreate_baseline_removes_snapshot_once() -> None:
     """Forced baseline recreation should remove stale snapshots before worker setup."""
     env = _make_environment()


### PR DESCRIPTION
## Summary

Adds Bayesian Optimization baseline support for stable PBT comparisons and introduces a PBT vs BO analysis script.

## Changes

- Added BO baseline runner package with:
  - SMAC3-based Bayesian Optimization
  - PBT-compatible result serialization
  - `--pbt-session` support to copy benchmark/workload/timing/knob settings from a PBT run
  - automatic BO iteration budget from `population_size * total_generations`
- Added PBT vs BO comparison script:
  - global post-hoc rescoring
  - convergence plots
  - Pareto/resource-efficiency plots
  - summary, per-run, timeseries, and statistical-significance CSV outputs
- Fixed Docker snapshot setup handling:
  - fail immediately if baseline snapshot creation fails
  - avoids delayed restore-time “No such image” errors
- Added docs for:
  - BO baseline parameters and workflow
  - comparison script outputs
- Added tests for BO baseline config/result behavior and Docker snapshot setup failure.

## Verification

- `pytest tests/test_bo_baseline.py`
- `pytest tests/unit/utils/test_docker_environment.py`
- `python -m py_compile src/scripts/pbt_vs_bo_comarison.py`
