### PR TITLE
feat: lockstep barrier synchronization for workers

### DIFF
--- a/src/tuner/benchmark/orchestrator.py
+++ b/src/tuner/benchmark/orchestrator.py
@@ -49,6 +49,7 @@ from src.tuner.benchmark.workload import WorkloadExecutor
 from src.tuner.core.worker import Worker
 from src.utils.types import TuningMode
 from src.tuner.benchmark.restart_policy import should_restart
+from src.tuner.core.barriers import GenerationBarrier
 from src.utils.applicator import KnobApplicator, ApplicatorConfig
 from src.utils.logger import get_logger
 
@@ -583,6 +584,7 @@ class WorkloadOrchestrator:
         worker: Worker,
         apply_config: bool = True,
         generation: Optional[int] = None,
+        barriers: Optional[GenerationBarrier] = None,
     ) -> tuple[PerformanceMetrics, float, bool]:
         """
         Evaluate a Worker's configuration.
@@ -596,6 +598,10 @@ class WorkloadOrchestrator:
         4. Collect system metrics
         5. Compute composite performance score
 
+        All sub-steps are gated by optional ``GenerationBarrier`` synchronization
+        points (B1–B17) so that workers advance in lockstep when barriers are
+        enabled.
+
         Parameters
         ----------
         worker : Worker
@@ -604,6 +610,10 @@ class WorkloadOrchestrator:
             Whether to apply the worker's configuration
         generation : Optional[int]
             Current generation number (for restart cost calculation)
+        barriers : GenerationBarrier | None
+            Optional lockstep barriers.  When provided and enabled, this
+            method will ``wait()`` at each barrier so all workers stay
+            in phase.
 
         Returns
         -------
@@ -626,13 +636,25 @@ class WorkloadOrchestrator:
             "Evaluating configuration on instance port %d...", worker.port or 0
         )
 
+        # Helper: wait at a named barrier (no-op when barriers is None/disabled).
+        def _barrier(name: str) -> None:
+            if barriers is not None:
+                barriers.wait(name, worker_id=worker.worker_id)
+
+        # Track which barrier we've completed so that on failure we can
+        # drain all remaining barriers to prevent deadlocks.
+        last_completed_barrier: Optional[str] = None
+
         connection = None
         restart_occurred = False
 
         try:
-            # Retry connection with backoff (handles instances in recovery mode)
+            # ── B1: Connect ──────────────────────────────────────────
             connection = self.connect(worker.db_config, max_retries=5, retry_delay=3.0)
+            _barrier("connected")
+            last_completed_barrier = "connected"
 
+            # ── B2: Apply knob configuration ─────────────────────────
             if apply_config and worker.knob_config:
                 applicator_config = ApplicatorConfig(
                     rollback_on_error=False,
@@ -660,25 +682,45 @@ class WorkloadOrchestrator:
                         "Cleared forced-restart marker after successful restart"
                     )
 
+            _barrier("config_applied")
+            last_completed_barrier = "config_applied"
+
+            # ── B3: Restart (if required) ────────────────────────────
+            # Workers that did NOT restart still hit the barrier so the
+            # population stays in sync.
+            if restart_occurred:
+                self.disconnect(connection, worker_id=worker.worker_id)
+                connection = None  # Will reconnect in B4
+
+            _barrier("restarted")
+            last_completed_barrier = "restarted"
+
+            # ── B4: Reconnect after restart ──────────────────────────
+            if restart_occurred or connection is None or connection.closed:
+                connection = self.connect(
+                    worker.db_config, max_retries=5, retry_delay=3.0
+                )
                 if restart_occurred:
-                    self.disconnect(connection, worker_id=worker.worker_id)
-                    # Retry connection after restart (instance may be in recovery)
-                    connection = self.connect(
-                        worker.db_config, max_retries=5, retry_delay=3.0
-                    )
                     worker_logger.debug("Reconnected after restart")
 
-                    if worker.knob_config:
-                        verification = knob_applicator.verify(worker.knob_config)
+            _barrier("reconnected")
+            last_completed_barrier = "reconnected"
 
-                        failed_params = [k for k, v in verification.items() if not v]
-                        if failed_params:
-                            worker_logger.warning(
-                                "Configuration verification failed for %d parameters: %s",
-                                len(failed_params),
-                                failed_params,
-                            )
+            # ── B5: Verify configuration ─────────────────────────────
+            if apply_config and worker.knob_config and restart_occurred:
+                verification = knob_applicator.verify(worker.knob_config)
+                failed_params = [k for k, v in verification.items() if not v]
+                if failed_params:
+                    worker_logger.warning(
+                        "Configuration verification failed for %d parameters: %s",
+                        len(failed_params),
+                        failed_params,
+                    )
 
+            _barrier("config_verified")
+            last_completed_barrier = "config_verified"
+
+            # ── B6: Capture pg_stat_database BEFORE ──────────────────
             try:
                 stats_before = None
                 if connection and not connection.closed:
@@ -701,10 +743,26 @@ class WorkloadOrchestrator:
                     except Exception as e:
                         worker_logger.debug("Failed to capture initial stats: %s", e)
 
+                _barrier("pre_stats_captured")
+                last_completed_barrier = "pre_stats_captured"
+
+                # ── B7: Ensure benchmark ready ───────────────────────
                 if isinstance(self.workload_executor, BenchmarkExecutor):
                     self._ensure_benchmark_ready(
                         worker.db_config, worker_logger=worker_logger
                     )
+
+                _barrier("benchmark_ready")
+                last_completed_barrier = "benchmark_ready"
+
+                # ── B8: Warmup + B9: Measurement ─────────────────────
+                if isinstance(self.workload_executor, BenchmarkExecutor):
+                    # External benchmarks (sysbench, tpch) handle warmup
+                    # internally; we still gate with barriers around the
+                    # combined call.
+                    _barrier("warmup_done")
+                    last_completed_barrier = "warmup_done"
+
                     metrics = self.workload_executor.execute(
                         db_config=worker.db_config,
                         worker_id=worker.worker_id,
@@ -714,14 +772,22 @@ class WorkloadOrchestrator:
                         warmup_passes=self.config.warmup_passes,
                     )
                 else:
+                    # Internal workload executor: warmup then measurement.
+                    # Warmup is run first, barrier, then measurement.
                     metrics = self.workload_executor.execute(
                         connection=connection,
                         duration=self.config.measurement_duration,
                         warmup=self.config.warmup_duration,
                         worker_id=worker.worker_id,
                         random_seed=self.config.random_seed,
+                        pre_measurement_callback=lambda: _barrier("warmup_done"),
                     )
+                    last_completed_barrier = "warmup_done"
 
+                _barrier("measurement_done")
+                last_completed_barrier = "measurement_done"
+
+                # ── B10: Capture pg_stat_database AFTER ──────────────
                 stats_after = None
                 if stats_before:
                     try:
@@ -748,7 +814,10 @@ class WorkloadOrchestrator:
                     except Exception as e:
                         worker_logger.debug("Failed to capture final stats: %s", e)
 
-                # Calculate I/O from database statistics (8KB blocks)
+                _barrier("post_stats_captured")
+                last_completed_barrier = "post_stats_captured"
+
+                # ── B11: Compute I/O delta ───────────────────────────
                 if stats_after:
                     try:
                         # Unpack stats arrays
@@ -806,13 +875,24 @@ class WorkloadOrchestrator:
                     except Exception as e:
                         worker_logger.debug("Failed to calculate IO stats: %s", e)
 
+                _barrier("io_computed")
+                last_completed_barrier = "io_computed"
+
             except Exception as e:
                 worker_logger.error("Workload execution failed: %s", e)
                 # Instead of crashing the entire PBT generation, treat as a dead worker
                 metrics = PerformanceMetrics(failure_type="EXECUTION_CRASH")
                 score = self.config.metric_config.compute_score(metrics)
+                # Drain remaining barriers so other threads don't deadlock
+                if barriers is not None and last_completed_barrier is not None:
+                    next_name = barriers.next_barrier_name(last_completed_barrier)
+                    if next_name:
+                        barriers.drain_remaining(
+                            next_name, worker_id=worker.worker_id
+                        )
                 return metrics, score, restart_occurred
 
+            # ── B12: Collect system metrics ──────────────────────────
             system_metrics = self.collect_system_metrics(worker_id=worker.worker_id)
 
             if "cache_hit_ratio" in system_metrics:
@@ -820,31 +900,64 @@ class WorkloadOrchestrator:
             if "memory_utilization" in system_metrics:
                 metrics.memory_utilization = system_metrics["memory_utilization"]
 
-            # Compute memory pressure
-            # Based on memory utilization and cache hit ratio.
-            # High utilization + low cache hits = high pressure
+            _barrier("system_metrics_collected")
+            last_completed_barrier = "system_metrics_collected"
+
+            # ── B13: Compute memory pressure ─────────────────────────
             metrics.memory_pressure = metrics.memory_utilization * (
                 1.0 - metrics.cache_hit_ratio
             )
 
-            # Reliability gate: classify degraded evaluations before scoring
+            _barrier("memory_pressure_computed")
+            last_completed_barrier = "memory_pressure_computed"
+
+            # ── B14: Reliability gate ────────────────────────────────
             self._apply_reliability_gate(metrics, worker_logger)
 
+            _barrier("reliability_gated")
+            last_completed_barrier = "reliability_gated"
+
+            # ── B15: VACUUM ANALYZE ──────────────────────────────────
             # Note: Workload features are refined at generation level after all workers evaluated
             # to avoid race conditions from parallel workers mutating shared state
 
             # Clean up dead tuples from DML operations to prevent bloat between generations
             self._vacuum_after_dml(worker.db_config, worker_id=worker.worker_id)
 
+            _barrier("vacuum_done")
+            last_completed_barrier = "vacuum_done"
+
+            # ── B16: Compute score ───────────────────────────────────
             score = self.config.metric_config.compute_score(metrics)
+
+            _barrier("score_computed")
+            last_completed_barrier = "score_computed"
 
             return metrics, score, restart_occurred
 
+        except Exception as e:
+            # Top-level safety net: drain all remaining barriers.
+            if barriers is not None:
+                if last_completed_barrier is not None:
+                    next_name = barriers.next_barrier_name(last_completed_barrier)
+                    if next_name:
+                        barriers.drain_remaining(
+                            next_name, worker_id=worker.worker_id
+                        )
+                else:
+                    # Failed before hitting any barrier — drain from the first.
+                    barriers.drain_remaining(
+                        "connected", worker_id=worker.worker_id
+                    )
+            raise
+
         finally:
+            # ── B17: Disconnect ──────────────────────────────────────
             self.disconnect(
                 connection,
                 worker_id=worker.worker_id if hasattr(worker, "worker_id") else None,
             )
+            _barrier("disconnected")
 
     # ------------------------------------------------------------------
     # Reliability gate

--- a/src/tuner/benchmark/workload.py
+++ b/src/tuner/benchmark/workload.py
@@ -9,7 +9,7 @@ when the user supplies custom SQL query templates.
 """
 
 from __future__ import annotations
-from typing import Optional
+from typing import Callable, Optional
 from pathlib import Path
 import json
 import subprocess
@@ -175,6 +175,7 @@ class WorkloadExecutor:
         warmup: float = 30.0,
         worker_id: Optional[int] = None,
         random_seed: Optional[int] = None,
+        pre_measurement_callback: Optional[Callable] = None,
     ) -> PerformanceMetrics:
         """
         Execute template queries with optional concurrent execution.
@@ -191,6 +192,10 @@ class WorkloadExecutor:
             Worker ID for logging differentiation
         random_seed : Optional[int]
             Optional random seed for reproducibility
+        pre_measurement_callback : Callable | None
+            Optional callback invoked after warmup completes but before
+            the timed measurement begins.  Used by the barrier system
+            to synchronize workers at the warmup→measurement boundary.
 
         Returns
         -------
@@ -230,6 +235,10 @@ class WorkloadExecutor:
                     work_logger.warning("Warmup query failed: %s", e)
                     connection.rollback()
         cursor.close()
+
+        # Invoke barrier callback between warmup and measurement phases
+        if pre_measurement_callback is not None:
+            pre_measurement_callback()
 
         if self.num_threads > 1:
             work_logger.debug(

--- a/src/tuner/config/tuner_config.py
+++ b/src/tuner/config/tuner_config.py
@@ -111,6 +111,19 @@ class PBTConfig:
         Number of initial evaluations used to calibrate the normalizer before
         switching from uniform priors to data-driven percentile anchors.
         Default: 5
+
+    synchronize_workers : bool
+        When True, insert threading.Barrier synchronization points between
+        every sub-step of parallel worker evaluation so that no worker
+        advances until all workers have completed the current step.
+        This ensures fair resource sharing during measurement.
+        Default: True
+
+    barrier_timeout_seconds : float
+        Maximum seconds each barrier will wait for all workers to arrive
+        before raising BrokenBarrierError and degrading gracefully.
+        Should accommodate Docker worst-case restart latency (~70 s).
+        Default: 120.0
     """
 
     population_size: int = 4
@@ -132,6 +145,8 @@ class PBTConfig:
     scoring_policy_version: Optional[str] = None
     metric_reference_version: Optional[str] = None
     scoring_calibration_evals: int = 5
+    synchronize_workers: bool = True
+    barrier_timeout_seconds: float = 120.0
 
     def __post_init__(self):
         """Validate configuration after initialization"""
@@ -178,6 +193,9 @@ class PBTConfig:
         if self.scoring_calibration_evals < 1:
             raise ValueError("scoring_calibration_evals must be at least 1")
 
+        if self.barrier_timeout_seconds <= 0:
+            raise ValueError("barrier_timeout_seconds must be positive")
+
     @property
     def num_workers_per_quantile(self) -> int:
         """
@@ -213,6 +231,8 @@ class PBTConfig:
             "scoring_policy_version": self.scoring_policy_version,
             "metric_reference_version": self.metric_reference_version,
             "scoring_calibration_evals": self.scoring_calibration_evals,
+            "synchronize_workers": self.synchronize_workers,
+            "barrier_timeout_seconds": self.barrier_timeout_seconds,
         }
 
     def __repr__(self) -> str:
@@ -234,7 +254,9 @@ class PBTConfig:
             f"  scoring_policy={self.scoring_policy},\n"
             f"  scoring_policy_version={self.scoring_policy_version},\n"
             f"  metric_reference_version={self.metric_reference_version},\n"
-            f"  scoring_calibration_evals={self.scoring_calibration_evals}\n"
+            f"  scoring_calibration_evals={self.scoring_calibration_evals},\n"
+            f"  synchronize_workers={self.synchronize_workers},\n"
+            f"  barrier_timeout_seconds={self.barrier_timeout_seconds}\n"
             f")"
         )
 

--- a/src/tuner/core/barriers.py
+++ b/src/tuner/core/barriers.py
@@ -1,0 +1,283 @@
+"""
+Generation Barriers for Lockstep Worker Synchronization
+========================================================
+
+Provides ``threading.Barrier``-based synchronization so that all workers in a
+PBT generation complete each sub-step before any worker advances to the next.
+
+This guarantees **experimental fairness**: every worker's measurement window
+experiences identical contention from other workers, regardless of how long
+individual setup steps (e.g. restart, reconnect) take.
+
+Barrier Points (B1–B17)
+------------------------
+Each barrier corresponds to a discrete sub-step inside
+``WorkloadOrchestrator.evaluate_worker()``:
+
+    B1  connected             — TCP connection established
+    B2  config_applied        — ALTER SYSTEM + pg_reload_conf completed
+    B3  restarted             — PostgreSQL restart finished (or skipped)
+    B4  reconnected           — Post-restart reconnection established
+    B5  config_verified       — SHOW confirms knobs took effect
+    B6  pre_stats_captured    — pg_stat_database baseline snapshot taken
+    B7  benchmark_ready       — Schema/state validated for benchmark
+    B8  warmup_done           — Warmup queries completed
+    B9  measurement_done      — Timed measurement window completed
+    B10 post_stats_captured   — pg_stat_database final snapshot taken
+    B11 io_computed           — I/O delta and buffer stats calculated
+    B12 system_metrics_collected — Memory and cache metrics collected
+    B13 memory_pressure_computed — Derived memory-pressure metric computed
+    B14 reliability_gated     — Reliability classification applied
+    B15 vacuum_done           — Post-DML VACUUM ANALYZE completed
+    B16 score_computed        — Composite performance score computed
+    B17 disconnected          — Connection closed
+
+Usage
+-----
+>>> barriers = GenerationBarrier(num_workers=4, timeout=120.0)
+>>> # Inside each worker thread:
+>>> barriers.wait("connected")  # blocks until all 4 threads arrive
+>>> barriers.wait("config_applied")
+
+Graceful Degradation
+--------------------
+If **any** worker thread crashes, its barrier slots are never filled, which
+would deadlock the remaining threads. Two safeguards prevent this:
+
+1. ``timeout`` — every ``barrier.wait()`` call has a deadline. On timeout,
+   ``BrokenBarrierError`` is raised, the internal ``_broken`` flag is set,
+   and **all subsequent** ``wait()`` calls become instant no-ops.
+
+2. ``drain_remaining(start_from)`` — when a worker catches an exception, it
+   calls this method to release all barriers it hasn't reached yet, so the
+   other threads can proceed.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from typing import Dict, List, Optional
+
+from src.utils.logger import get_logger
+
+LOGGER = get_logger("GenerationBarrier")
+
+# Canonical ordered list of all barrier names.
+BARRIER_NAMES: List[str] = [
+    "connected",               # B1
+    "config_applied",          # B2
+    "restarted",               # B3
+    "reconnected",             # B4
+    "config_verified",         # B5
+    "pre_stats_captured",      # B6
+    "benchmark_ready",         # B7
+    "warmup_done",             # B8
+    "measurement_done",        # B9
+    "post_stats_captured",     # B10
+    "io_computed",             # B11
+    "system_metrics_collected",  # B12
+    "memory_pressure_computed",  # B13
+    "reliability_gated",       # B14
+    "vacuum_done",             # B15
+    "score_computed",          # B16
+    "disconnected",            # B17
+]
+
+
+class GenerationBarrier:
+    """
+    Thread-safe barrier collection for lockstep worker synchronization.
+
+    Parameters
+    ----------
+    num_workers : int
+        Number of worker threads that must arrive at each barrier.
+    timeout : float
+        Maximum seconds to wait at any single barrier before raising
+        ``BrokenBarrierError``.  Default 120 s accommodates Docker
+        restart worst-case (~70 s) with headroom.
+    enabled : bool
+        When ``False``, all ``wait()`` calls are instant no-ops.
+        Used for sequential evaluation or ``--no-sync`` mode.
+    """
+
+    def __init__(
+        self,
+        num_workers: int,
+        timeout: float = 120.0,
+        enabled: bool = True,
+    ) -> None:
+        self._num_workers = num_workers
+        self._timeout = timeout
+        self._enabled = enabled
+        self._broken = False
+
+        # Build one threading.Barrier per sub-step.
+        self._barriers: Dict[str, threading.Barrier] = {}
+        if self._enabled:
+            for name in BARRIER_NAMES:
+                self._barriers[name] = threading.Barrier(
+                    parties=num_workers, timeout=timeout
+                )
+
+        # Index lookup for drain_remaining().
+        self._name_to_index: Dict[str, int] = {
+            name: idx for idx, name in enumerate(BARRIER_NAMES)
+        }
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    @property
+    def enabled(self) -> bool:
+        """Whether barriers are active."""
+        return self._enabled and not self._broken
+
+    @property
+    def broken(self) -> bool:
+        """Whether the barrier set has been broken (timeout or abort)."""
+        return self._broken
+
+    def wait(
+        self,
+        name: str,
+        *,
+        worker_id: Optional[int] = None,
+    ) -> None:
+        """
+        Block until all workers reach barrier *name*.
+
+        Parameters
+        ----------
+        name : str
+            One of the names in ``BARRIER_NAMES``.
+        worker_id : int | None
+            Optional worker ID for log messages.
+
+        Raises
+        ------
+        ValueError
+            If *name* is not a recognized barrier.
+        """
+        if not self._enabled or self._broken:
+            return
+
+        if name not in self._barriers:
+            raise ValueError(
+                f"Unknown barrier name '{name}'. "
+                f"Valid names: {BARRIER_NAMES}"
+            )
+
+        barrier = self._barriers[name]
+        tag = f"Worker-{worker_id}" if worker_id is not None else "worker"
+
+        LOGGER.debug("[%s] waiting at barrier '%s'", tag, name)
+        t0 = time.monotonic()
+
+        try:
+            barrier.wait()
+        except threading.BrokenBarrierError:
+            self._broken = True
+            LOGGER.warning(
+                "[%s] barrier '%s' broken — disabling remaining barriers "
+                "for this generation",
+                tag,
+                name,
+            )
+            return
+
+        elapsed_ms = (time.monotonic() - t0) * 1000
+        LOGGER.debug(
+            "[%s] passed barrier '%s' (waited %.1f ms)", tag, name, elapsed_ms
+        )
+
+    def drain_remaining(
+        self,
+        start_from: str,
+        *,
+        worker_id: Optional[int] = None,
+    ) -> None:
+        """
+        Release all barriers from *start_from* onward (inclusive).
+
+        Call this when a worker fails mid-evaluation so that other threads
+        waiting at later barriers are not deadlocked.  Each barrier is
+        ``wait()``-ed to contribute this thread's "arrival".
+
+        If the barrier set is already broken or disabled, this is a no-op.
+
+        Parameters
+        ----------
+        start_from : str
+            First barrier name to drain (inclusive).
+        worker_id : int | None
+            Optional worker ID for log messages.
+        """
+        if not self._enabled or self._broken:
+            return
+
+        start_idx = self._name_to_index.get(start_from)
+        if start_idx is None:
+            LOGGER.warning(
+                "drain_remaining called with unknown barrier '%s'", start_from
+            )
+            return
+
+        tag = f"Worker-{worker_id}" if worker_id is not None else "worker"
+        remaining = BARRIER_NAMES[start_idx:]
+        LOGGER.debug(
+            "[%s] draining %d remaining barriers starting from '%s'",
+            tag,
+            len(remaining),
+            start_from,
+        )
+
+        for name in remaining:
+            if self._broken:
+                return
+            try:
+                self._barriers[name].wait()
+            except threading.BrokenBarrierError:
+                self._broken = True
+                LOGGER.debug(
+                    "[%s] barrier '%s' broke during drain", tag, name
+                )
+                return
+
+    def reset(self) -> None:
+        """
+        Reset all barriers for reuse in the next generation.
+
+        Must be called from the **main thread** after all worker threads
+        have joined (i.e. after the ``ThreadPoolExecutor`` context exits).
+        """
+        self._broken = False
+        for barrier in self._barriers.values():
+            # Barrier.reset() aborts any still-waiting threads (safety net).
+            try:
+                barrier.reset()
+            except threading.BrokenBarrierError:
+                pass
+            # Recreate a fresh barrier to avoid leftover state.
+        if self._enabled:
+            for name in BARRIER_NAMES:
+                self._barriers[name] = threading.Barrier(
+                    parties=self._num_workers, timeout=self._timeout
+                )
+
+    def next_barrier_name(self, current: str) -> Optional[str]:
+        """Return the barrier name after *current*, or ``None`` if last."""
+        idx = self._name_to_index.get(current)
+        if idx is None or idx + 1 >= len(BARRIER_NAMES):
+            return None
+        return BARRIER_NAMES[idx + 1]
+
+    def __repr__(self) -> str:
+        status = "enabled" if self.enabled else ("broken" if self._broken else "disabled")
+        return (
+            f"GenerationBarrier(workers={self._num_workers}, "
+            f"timeout={self._timeout}s, status={status})"
+        )

--- a/src/tuner/core/population.py
+++ b/src/tuner/core/population.py
@@ -36,6 +36,7 @@ from src.tuner.core.evolution import (
     get_population_statistics,
     check_convergence,
 )
+from src.tuner.core.barriers import GenerationBarrier
 from src.tuner.config.knob_space import KnobSpace
 from src.utils.environments import DatabaseEnvironment
 from src.utils.metrics import PerformanceMetrics
@@ -336,6 +337,8 @@ class Population:
         evaluate_fn: Callable[[Worker], tuple[PerformanceMetrics, float]],
         parallel: bool = True,
         max_workers: Optional[int] = None,
+        synchronize_workers: bool = False,
+        barrier_timeout: float = 120.0,
     ) -> None:
         """
         Evaluate all workers in the current generation.
@@ -358,6 +361,11 @@ class Population:
             Whether to evaluate workers in parallel
         max_workers : Optional[int]
             Maximum number of parallel threads. Defaults to population_size.
+        synchronize_workers : bool, default=False
+            When True and parallel, insert threading.Barrier sync points
+            between every sub-step so workers advance in lockstep.
+        barrier_timeout : float, default=120.0
+            Timeout in seconds for each barrier wait.
 
         Example
         -------
@@ -370,15 +378,32 @@ class Population:
         >>> population.evaluate_generation(my_evaluate, parallel=True)
         """
         LOGGER.info(
-            "Evaluating generation %s - %s",
+            "Evaluating generation %s - %s%s",
             self.current_generation,
             "parallel" if parallel else "sequential",
+            " (lockstep sync)" if (parallel and synchronize_workers) else "",
         )
 
+        # Create barriers for lockstep synchronization.
+        # Disabled when running sequentially or when synchronize_workers=False.
+        use_barriers = parallel and synchronize_workers
+        barriers = GenerationBarrier(
+            num_workers=len(self.workers),
+            timeout=barrier_timeout,
+            enabled=use_barriers,
+        )
+        if use_barriers:
+            LOGGER.debug(
+                "Lockstep barriers enabled: %d workers, %.0fs timeout",
+                len(self.workers),
+                barrier_timeout,
+            )
+
         if not parallel:
+            # Sequential mode: barriers are disabled (no-op).
             for worker in self.workers:
                 try:
-                    metrics, score = evaluate_fn(worker)
+                    metrics, score = evaluate_fn(worker, barriers=barriers)
                     worker.update_metrics(metrics, score)
                     worker_logger = get_logger(
                         "PopulationWorker", worker_id=worker.worker_id
@@ -395,9 +420,9 @@ class Population:
         else:
             max_workers = max_workers or self.config.population_size
             with ThreadPoolExecutor(max_workers=max_workers) as executor:
-                # Submit all evaluation tasks
+                # Submit all evaluation tasks (barrier object shared across threads)
                 future_to_worker = {
-                    executor.submit(evaluate_fn, worker): worker
+                    executor.submit(evaluate_fn, worker, barriers=barriers): worker
                     for worker in self.workers
                 }
 
@@ -817,6 +842,8 @@ class Population:
         parallel: bool = True,
         require_ready: bool = True,
         max_workers: Optional[int] = None,
+        synchronize_workers: bool = False,
+        barrier_timeout: float = 120.0,
     ) -> GenerationResult:
         """
         Execute one complete PBT generation.
@@ -839,6 +866,11 @@ class Population:
             Maximum parallel workers for evaluation. When less than
             population_size, workers evaluate in batches. If None,
             defaults to population_size.
+        synchronize_workers : bool, default=False
+            When True and parallel, insert lockstep barriers between every
+            sub-step of worker evaluation for experimental fairness.
+        barrier_timeout : float, default=120.0
+            Timeout per barrier in seconds.
 
         Returns
         -------
@@ -914,7 +946,11 @@ class Population:
                 raise
 
         self.evaluate_generation(
-            evaluate_fn, parallel=parallel, max_workers=max_workers
+            evaluate_fn,
+            parallel=parallel,
+            max_workers=max_workers,
+            synchronize_workers=synchronize_workers,
+            barrier_timeout=barrier_timeout,
         )
 
         rescued = self.rescue_dead_workers(evaluate_fn)

--- a/src/tuner/main.py
+++ b/src/tuner/main.py
@@ -62,6 +62,7 @@ from src.tuner.config import (
 )
 from src.tuner.core.population import Population, PopulationConfig
 from src.tuner.core.worker import Worker
+from src.tuner.core.barriers import GenerationBarrier
 from src.tuner.benchmark.orchestrator import (
     WorkloadOrchestrator,
     WorkloadOrchestratorConfig,
@@ -555,7 +556,12 @@ class PBTTuner:
         # Fallback (should not be reached if Enum is exhaustive)
         raise ValueError(f"Unknown workload type: {workload_type}")
 
-    def evaluate_worker(self, worker: Worker) -> Tuple[PerformanceMetrics, float]:
+    def evaluate_worker(
+        self,
+        worker: Worker,
+        *,
+        barriers: Optional[GenerationBarrier] = None,
+    ) -> Tuple[PerformanceMetrics, float]:
         """
         Evaluate a single worker.
 
@@ -565,6 +571,8 @@ class PBTTuner:
         ----------
         worker : Worker
             Worker to evaluate
+        barriers : GenerationBarrier | None
+            Optional lockstep barriers for synchronized evaluation.
 
         Returns
         -------
@@ -577,7 +585,8 @@ class PBTTuner:
             self.orchestrator.worker_id = f"Worker-{worker.worker_id}"
 
             metrics, score, restart_occurred = self.orchestrator.evaluate_worker(
-                worker, apply_config=True, generation=self.current_generation
+                worker, apply_config=True, generation=self.current_generation,
+                barriers=barriers,
             )
 
             # Track restart occurrence (will be logged once per generation, not per worker)
@@ -608,6 +617,10 @@ class PBTTuner:
             return metrics, score
 
         except (ConnectionError, psycopg2.Error) as e:
+            # Safety: drain any remaining barriers not already drained by orchestrator
+            if barriers is not None:
+                barriers.drain_remaining("connected", worker_id=worker.worker_id)
+
             recovered = False
             if self.env is None:
                 worker_logger.error(
@@ -641,6 +654,8 @@ class PBTTuner:
             )
 
         except TimeoutError as e:
+            if barriers is not None:
+                barriers.drain_remaining("connected", worker_id=worker.worker_id)
             return self._build_failure_result(
                 worker_logger=worker_logger,
                 reason="timeout",
@@ -650,6 +665,8 @@ class PBTTuner:
             )
 
         except RuntimeError as e:
+            if barriers is not None:
+                barriers.drain_remaining("connected", worker_id=worker.worker_id)
             return self._build_failure_result(
                 worker_logger=worker_logger,
                 reason="runtime",
@@ -659,6 +676,8 @@ class PBTTuner:
             )
 
         except Exception as e:
+            if barriers is not None:
+                barriers.drain_remaining("connected", worker_id=worker.worker_id)
             worker_logger.error(
                 "Unexpected error evaluating worker %s: %s",
                 worker.worker_id,
@@ -727,6 +746,8 @@ class PBTTuner:
             parallel=True,
             require_ready=True,
             max_workers=self.pbt_config.num_parallel_workers,
+            synchronize_workers=self.pbt_config.synchronize_workers,
+            barrier_timeout=self.pbt_config.barrier_timeout_seconds,
         )
         gen_elapsed_time = time.time() - gen_start_time
 
@@ -1346,6 +1367,16 @@ on your hardware, configuration, and workload/benchmark.
         ),
     )
 
+    config_group.add_argument(
+        "--no-sync",
+        action="store_true",
+        help=(
+            "Disable lockstep barrier synchronization between workers. "
+            "By default, workers wait at each sub-step so they advance "
+            "in lockstep for fair resource sharing."
+        ),
+    )
+
     scoring_group = parser.add_argument_group("Scoring & Normalization")
     scoring_group.add_argument(
         "--scoring-policy",
@@ -1684,6 +1715,7 @@ def main():
             if args.scoring_calibration_evals is not None
             else base_config.scoring_calibration_evals
         ),
+        synchronize_workers=not args.no_sync,
         benchmark_config=benchmark_config,
     )
 

--- a/tests/unit/core/test_barriers.py
+++ b/tests/unit/core/test_barriers.py
@@ -1,0 +1,241 @@
+"""
+Unit tests for GenerationBarrier lockstep synchronization.
+
+Tests cover:
+- Basic synchronization across N threads
+- Disabled mode (no-op barriers)
+- Broken barrier graceful degradation
+- drain_remaining prevents deadlock on worker failure
+- reset() for reuse across generations
+"""
+
+import threading
+import time
+from typing import List
+from unittest.mock import patch
+
+import pytest
+
+from src.tuner.core.barriers import GenerationBarrier, BARRIER_NAMES
+
+
+class TestGenerationBarrierBasic:
+    """Test basic barrier synchronization behavior."""
+
+    def test_all_workers_pass_all_barriers(self):
+        """All N threads pass through all 17 barriers without deadlock."""
+        num_workers = 3
+        barriers = GenerationBarrier(num_workers=num_workers, timeout=5.0)
+
+        # Track order: each thread records its passage timestamps
+        arrival_times: dict = {name: [] for name in BARRIER_NAMES}
+        lock = threading.Lock()
+
+        def worker_fn(worker_id: int):
+            for name in BARRIER_NAMES:
+                barriers.wait(name, worker_id=worker_id)
+                with lock:
+                    arrival_times[name].append(time.monotonic())
+
+        threads = [
+            threading.Thread(target=worker_fn, args=(i,))
+            for i in range(num_workers)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10.0)
+
+        # Verify: all workers passed every barrier
+        for name in BARRIER_NAMES:
+            assert len(arrival_times[name]) == num_workers, (
+                f"Barrier '{name}': expected {num_workers} arrivals, "
+                f"got {len(arrival_times[name])}"
+            )
+
+    def test_barriers_enforce_ordering(self):
+        """Workers at barrier N+1 cannot proceed until all pass barrier N."""
+        num_workers = 4
+        barriers = GenerationBarrier(num_workers=num_workers, timeout=5.0)
+
+        # Worker 0 will be delayed at B1 (connected) while others arrive quickly
+        passed_barrier_1: List[int] = []
+        lock = threading.Lock()
+        all_at_barrier = threading.Event()
+
+        def worker_fn(worker_id: int):
+            if worker_id == 0:
+                # Wait for other workers to arrive at barrier first
+                all_at_barrier.wait(timeout=3.0)
+                time.sleep(0.05)  # Slight delay to be last
+
+            barriers.wait("connected", worker_id=worker_id)
+            with lock:
+                passed_barrier_1.append(worker_id)
+
+        threads = []
+        for i in range(num_workers):
+            t = threading.Thread(target=worker_fn, args=(i,))
+            threads.append(t)
+
+        for t in threads:
+            t.start()
+
+        # Give non-delayed workers time to reach barrier
+        time.sleep(0.1)
+        all_at_barrier.set()
+
+        for t in threads:
+            t.join(timeout=10.0)
+
+        # All workers passed (worker 0 didn't block the others indefinitely)
+        assert len(passed_barrier_1) == num_workers
+
+
+class TestGenerationBarrierDisabled:
+    """Test that disabled barriers are no-ops."""
+
+    def test_disabled_barriers_dont_block(self):
+        """When enabled=False, wait() returns immediately even with 1 thread."""
+        barriers = GenerationBarrier(num_workers=4, timeout=5.0, enabled=False)
+
+        # Should not block — only one thread, but barriers are disabled
+        for name in BARRIER_NAMES:
+            barriers.wait(name, worker_id=0)
+
+        assert not barriers.enabled
+
+    def test_disabled_drain_remaining_noop(self):
+        """drain_remaining is a no-op when disabled."""
+        barriers = GenerationBarrier(num_workers=4, timeout=5.0, enabled=False)
+        # Should not raise
+        barriers.drain_remaining("connected", worker_id=0)
+
+
+class TestGenerationBarrierBrokenRecovery:
+    """Test graceful degradation when a barrier breaks."""
+
+    def test_timeout_sets_broken_flag(self):
+        """When a barrier times out, all subsequent waits are no-ops."""
+        # 2 workers, but only 1 will arrive → timeout
+        barriers = GenerationBarrier(num_workers=2, timeout=0.5)
+
+        results = {"timed_out": False, "subsequent_noop": False}
+
+        def lone_worker():
+            barriers.wait("connected", worker_id=0)
+            # After timeout/broken, next barrier should be a no-op
+            barriers.wait("config_applied", worker_id=0)
+            results["subsequent_noop"] = True
+
+        t = threading.Thread(target=lone_worker)
+        t.start()
+        t.join(timeout=3.0)
+
+        assert barriers.broken
+        assert results["subsequent_noop"]
+
+    def test_drain_remaining_unblocks_peers(self):
+        """When one worker drains, other workers waiting are unblocked."""
+        num_workers = 2
+        barriers = GenerationBarrier(num_workers=num_workers, timeout=2.0)
+
+        worker_0_passed = threading.Event()
+        worker_1_passed = threading.Event()
+
+        def worker_0():
+            """Normal worker that waits at 'connected'."""
+            barriers.wait("connected", worker_id=0)
+            worker_0_passed.set()
+
+        def worker_1():
+            """Crashed worker: drains all barriers starting from 'connected'."""
+            # Simulate crash: drain instead of waiting
+            barriers.drain_remaining("connected", worker_id=1)
+            worker_1_passed.set()
+
+        t0 = threading.Thread(target=worker_0)
+        t1 = threading.Thread(target=worker_1)
+        t0.start()
+        t1.start()
+
+        t0.join(timeout=5.0)
+        t1.join(timeout=5.0)
+
+        # Both workers should have passed (worker_1 via drain)
+        assert worker_0_passed.is_set()
+        assert worker_1_passed.is_set()
+
+
+class TestGenerationBarrierReset:
+    """Test reset for multi-generation reuse."""
+
+    def test_reset_allows_reuse(self):
+        """After reset, barriers can be used again for a new generation."""
+        num_workers = 2
+        barriers = GenerationBarrier(num_workers=num_workers, timeout=2.0)
+
+        def run_one_barrier():
+            """Have all workers pass through the first barrier."""
+            passed = []
+            lock = threading.Lock()
+
+            def w(wid):
+                barriers.wait("connected", worker_id=wid)
+                with lock:
+                    passed.append(wid)
+
+            threads = [threading.Thread(target=w, args=(i,)) for i in range(num_workers)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join(timeout=5.0)
+            return passed
+
+        # Generation 1
+        gen1 = run_one_barrier()
+        assert len(gen1) == num_workers
+
+        # Reset for generation 2
+        barriers.reset()
+
+        # Generation 2
+        gen2 = run_one_barrier()
+        assert len(gen2) == num_workers
+
+
+class TestGenerationBarrierEdgeCases:
+    """Test edge cases and error handling."""
+
+    def test_invalid_barrier_name_raises(self):
+        """Passing an unknown barrier name raises ValueError."""
+        barriers = GenerationBarrier(num_workers=1, timeout=1.0)
+        with pytest.raises(ValueError, match="Unknown barrier name"):
+            barriers.wait("nonexistent_barrier", worker_id=0)
+
+    def test_next_barrier_name(self):
+        """next_barrier_name returns correct successor."""
+        barriers = GenerationBarrier(num_workers=1, timeout=1.0, enabled=False)
+        assert barriers.next_barrier_name("connected") == "config_applied"
+        assert barriers.next_barrier_name("disconnected") is None
+        assert barriers.next_barrier_name("unknown") is None
+
+    def test_repr(self):
+        """repr shows meaningful status."""
+        b1 = GenerationBarrier(num_workers=3, timeout=60.0, enabled=True)
+        assert "enabled" in repr(b1)
+
+        b2 = GenerationBarrier(num_workers=3, timeout=60.0, enabled=False)
+        assert "disabled" in repr(b2)
+
+    def test_single_worker_passes_instantly(self):
+        """With num_workers=1, barriers pass immediately (no waiting)."""
+        barriers = GenerationBarrier(num_workers=1, timeout=1.0)
+
+        start = time.monotonic()
+        for name in BARRIER_NAMES:
+            barriers.wait(name, worker_id=0)
+        elapsed = time.monotonic() - start
+
+        # All 17 barriers in well under 1 second for a single worker
+        assert elapsed < 1.0


### PR DESCRIPTION
<html><head></head><body><h2 data-path-to-node="0" style="font-family: &quot;Google Sans&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">Summary</h2><p data-path-to-node="1" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">Adds <code data-path-to-node="1" data-index-in-node="5" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">threading.Barrier</code> synchronization across all 17 sub-steps of the parallel worker evaluation pipeline, ensuring no worker advances to the next step until every worker has completed the current one.</p><h2 data-path-to-node="2" style="font-family: &quot;Google Sans&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">Problem</h2><p data-path-to-node="3" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">During parallel evaluation, workers run independently at their own pace inside a <code data-path-to-node="3" data-index-in-node="81" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">ThreadPoolExecutor</code>. A fast worker might start its measurement while a slow worker is still restarting PostgreSQL. This creates <b data-path-to-node="3" data-index-in-node="208" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">unfair measurement conditions</b> — workers experience different levels of CPU/IO contention depending on what other workers happen to be doing at the same time, making scores non-comparable.</p><h2 data-path-to-node="4" style="font-family: &quot;Google Sans&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">Solution</h2><p data-path-to-node="5" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">Insert a <code data-path-to-node="5" data-index-in-node="9" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">threading.Barrier(parties=N)</code> at every sub-step boundary. All N worker threads must arrive at each barrier before any can proceed, guaranteeing identical contention conditions during every phase — especially the measurement window.</p><h3 data-path-to-node="6" style="font-family: &quot;Google Sans&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">Barrier points (B1–B17)</h3>

B# | Barrier | Ensures all workers have...
-- | -- | --
B1 | connected | Established TCP connection
B2 | config_applied | Applied knob config via ALTER SYSTEM
B3 | restarted | Completed PostgreSQL restart (or skipped)
B4 | reconnected | Re-established connection post-restart
B5 | config_verified | Verified knobs via SHOW
B6 | pre_stats_captured | Taken pg_stat_database baseline
B7 | benchmark_ready | Validated benchmark schema state
B8 | warmup_done | Finished warmup queries
B9 | measurement_done | Completed timed measurement window
B10 | post_stats_captured | Taken pg_stat_database final snapshot
B11 | io_computed | Calculated I/O deltas
B12 | system_metrics_collected | Collected memory/cache metrics
B13 | memory_pressure_computed | Derived memory pressure metric
B14 | reliability_gated | Applied reliability classification
B15 | vacuum_done | Finished post-DML VACUUM ANALYZE
B16 | score_computed | Computed composite score
B17 | disconnected | Closed connection

<h3 data-path-to-node="8" style="font-family: &quot;Google Sans&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">Graceful degradation</h3><ul data-path-to-node="9" style="padding-inline-start: 32px; font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><li style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><p data-path-to-node="9,0,0" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">If a worker crashes mid-evaluation, <code data-path-to-node="9,0,0" data-index-in-node="36" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">drain_remaining()</code> releases all its unvisited barriers so peer threads don't deadlock.</p></li><li style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><p data-path-to-node="9,1,0" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">If a barrier times out (default 120s), all subsequent barriers become no-ops for that generation.</p></li><li style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><p data-path-to-node="9,2,0" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">Works identically for both Docker and bare-metal backends (polymorphic interface).</p></li></ul></body></html>