### PR TITLE
fix: resolve barrier deadlocks in hybrid mode and dead-worker scenarios

### DIFF
--- a/src/tuner/benchmark/orchestrator.py
+++ b/src/tuner/benchmark/orchestrator.py
@@ -645,6 +645,8 @@ class WorkloadOrchestrator:
         # drain all remaining barriers to prevent deadlocks.
         last_completed_barrier: Optional[str] = None
 
+        _barriers_drained = False
+
         connection = None
         restart_occurred = False
 
@@ -890,6 +892,7 @@ class WorkloadOrchestrator:
                         barriers.drain_remaining(
                             next_name, worker_id=worker.worker_id
                         )
+                _barriers_drained = True
                 return metrics, score, restart_occurred
 
             # ── B12: Collect system metrics ──────────────────────────
@@ -949,6 +952,7 @@ class WorkloadOrchestrator:
                     barriers.drain_remaining(
                         "connected", worker_id=worker.worker_id
                     )
+            _barriers_drained = True
             raise
 
         finally:
@@ -957,7 +961,12 @@ class WorkloadOrchestrator:
                 connection,
                 worker_id=worker.worker_id if hasattr(worker, "worker_id") else None,
             )
-            _barrier("disconnected")
+            # Only call the disconnected barrier on the NORMAL path.
+            # Exception handlers already drained all barriers (including
+            # "disconnected") — calling it again would start a new barrier
+            # cycle that can never complete (the other workers already left).
+            if not _barriers_drained:
+                _barrier("disconnected")
 
     # ------------------------------------------------------------------
     # Reliability gate

--- a/src/tuner/config/tuner_config.py
+++ b/src/tuner/config/tuner_config.py
@@ -171,8 +171,6 @@ class PBTConfig:
 
         if self.num_parallel_workers < 1:
             raise ValueError("num_parallel_workers must be at least 1")
-        if self.num_parallel_workers > self.population_size:
-            raise ValueError("num_parallel_workers cannot exceed population_size")
 
         if self.snapshot_restore_interval < 1:
             raise ValueError("snapshot_restore_interval must be at least 1")

--- a/src/tuner/core/barriers.py
+++ b/src/tuner/core/barriers.py
@@ -247,6 +247,29 @@ class GenerationBarrier:
                 )
                 return
 
+    def abort(self) -> None:
+        """
+        Immediately break all barriers, unblocking any waiting threads.
+
+        Call this when a worker is known to be dead and will never arrive
+        at its barriers. Unlike ``drain_remaining`` (which acts as a
+        participant), ``abort`` forces a ``BrokenBarrierError`` on all
+        waiters instantly without requiring the dead thread to cooperate.
+
+        After calling ``abort()``, the barrier set is marked broken and
+        all subsequent ``wait()`` calls are no-ops.
+        """
+        if not self._enabled or self._broken:
+            return
+
+        self._broken = True
+        LOGGER.warning("Barrier set aborted — all barriers broken instantly")
+        for barrier in self._barriers.values():
+            try:
+                barrier.abort()
+            except threading.BrokenBarrierError:
+                pass
+
     def reset(self) -> None:
         """
         Reset all barriers for reuse in the next generation.

--- a/src/tuner/core/population.py
+++ b/src/tuner/core/population.py
@@ -384,26 +384,18 @@ class Population:
             " (lockstep sync)" if (parallel and synchronize_workers) else "",
         )
 
-        # Create barriers for lockstep synchronization.
-        # Disabled when running sequentially or when synchronize_workers=False.
+        # Barrier usage flag — actual barrier objects are created per-batch
+        # in parallel mode to match the number of concurrent threads.
         use_barriers = parallel and synchronize_workers
-        barriers = GenerationBarrier(
-            num_workers=len(self.workers),
-            timeout=barrier_timeout,
-            enabled=use_barriers,
-        )
-        if use_barriers:
-            LOGGER.debug(
-                "Lockstep barriers enabled: %d workers, %.0fs timeout",
-                len(self.workers),
-                barrier_timeout,
-            )
 
         if not parallel:
-            # Sequential mode: barriers are disabled (no-op).
+            # Sequential mode: pass a disabled barrier (all waits are no-ops).
+            disabled_barriers = GenerationBarrier(
+                num_workers=1, timeout=barrier_timeout, enabled=False
+            )
             for worker in self.workers:
                 try:
-                    metrics, score = evaluate_fn(worker, barriers=barriers)
+                    metrics, score = evaluate_fn(worker, barriers=disabled_barriers)
                     worker.update_metrics(metrics, score)
                     worker_logger = get_logger(
                         "PopulationWorker", worker_id=worker.worker_id
@@ -419,31 +411,108 @@ class Population:
                     raise
         else:
             max_workers = max_workers or self.config.population_size
-            with ThreadPoolExecutor(max_workers=max_workers) as executor:
-                # Submit all evaluation tasks (barrier object shared across threads)
-                future_to_worker = {
-                    executor.submit(evaluate_fn, worker, barriers=barriers): worker
-                    for worker in self.workers
-                }
+            num_workers = len(self.workers)
 
-                # Collect results as they complete
-                for future in as_completed(future_to_worker):
-                    worker = future_to_worker[future]
+            # Hybrid mode: when max_workers < population, we must evaluate
+            # in batches.  Barriers synchronize threads *within* a batch
+            # (since only batch-mates run concurrently and contend for
+            # shared hardware resources).
+            if max_workers >= num_workers:
+                # All workers fit in a single batch — original behavior.
+                batches = [self.workers]
+            else:
+                # Chunk workers into batches of max_workers.
+                batches = [
+                    self.workers[i : i + max_workers]
+                    for i in range(0, num_workers, max_workers)
+                ]
+                LOGGER.info(
+                    "Hybrid mode: %d workers evaluated in %d batches of up to %d",
+                    num_workers,
+                    len(batches),
+                    max_workers,
+                )
+
+            for batch_idx, batch in enumerate(batches):
+                # Create batch-local barriers sized to this batch.
+                batch_barriers = GenerationBarrier(
+                    num_workers=len(batch),
+                    timeout=barrier_timeout,
+                    enabled=use_barriers,
+                )
+                if use_barriers and len(batches) > 1:
+                    LOGGER.debug(
+                        "Batch %d/%d: %d workers, barriers enabled",
+                        batch_idx + 1,
+                        len(batches),
+                        len(batch),
+                    )
+
+                with ThreadPoolExecutor(max_workers=len(batch)) as executor:
+                    # Submit all evaluation tasks in this batch
+                    future_to_worker = {
+                        executor.submit(
+                            evaluate_fn, worker, barriers=batch_barriers
+                        ): worker
+                        for worker in batch
+                    }
+
+                    # Collect results as they complete.
+                    # Use a generous timeout to detect truly stuck workers
+                    # (barrier_timeout * num_barriers + headroom).
+                    collection_timeout = (barrier_timeout * len(batch)) + 60.0
+                    completed_futures = set()
+
                     try:
-                        metrics, score = future.result()
-                        worker.update_metrics(metrics, score)
-                        worker_logger = get_logger(
-                            "PopulationWorker", worker_id=worker.worker_id
-                        )
-                        worker_logger.debug(
-                            "score=%.4f, step_count=%s", score, worker.step_count
-                        )
-                    except Exception as e:
-                        worker_logger = get_logger(
-                            "PopulationWorker", worker_id=worker.worker_id
-                        )
-                        worker_logger.error("Error evaluating: %s", e)
-                        raise
+                        for future in as_completed(
+                            future_to_worker, timeout=collection_timeout
+                        ):
+                            completed_futures.add(future)
+                            worker = future_to_worker[future]
+                            try:
+                                metrics, score = future.result()
+                                worker.update_metrics(metrics, score)
+                                worker_logger = get_logger(
+                                    "PopulationWorker",
+                                    worker_id=worker.worker_id,
+                                )
+                                worker_logger.debug(
+                                    "score=%.4f, step_count=%s",
+                                    score,
+                                    worker.step_count,
+                                )
+                            except Exception as e:
+                                worker_logger = get_logger(
+                                    "PopulationWorker",
+                                    worker_id=worker.worker_id,
+                                )
+                                worker_logger.error(
+                                    "Error evaluating: %s", e
+                                )
+                                # Abort barriers so remaining threads unblock
+                                batch_barriers.abort()
+                                raise
+                    except TimeoutError:
+                        # as_completed raised TimeoutError — some futures
+                        # never completed within the generous deadline.
+                        pass
+
+                    # Check for stuck workers that never completed
+                    stuck_futures = set(future_to_worker.keys()) - completed_futures
+                    if stuck_futures:
+                        batch_barriers.abort()
+                        for future in stuck_futures:
+                            stuck_worker = future_to_worker[future]
+                            worker_logger = get_logger(
+                                "PopulationWorker",
+                                worker_id=stuck_worker.worker_id,
+                            )
+                            worker_logger.error(
+                                "Worker stuck — did not complete within %.0fs; "
+                                "aborting barriers and continuing",
+                                collection_timeout,
+                            )
+                            future.cancel()
 
         LOGGER.info("Generation %s evaluation complete", self.current_generation)
 

--- a/tests/unit/core/test_barriers.py
+++ b/tests/unit/core/test_barriers.py
@@ -239,3 +239,155 @@ class TestGenerationBarrierEdgeCases:
 
         # All 17 barriers in well under 1 second for a single worker
         assert elapsed < 1.0
+
+    def test_abort_unblocks_waiting_threads(self):
+        """abort() instantly breaks all barriers, unblocking waiters."""
+        num_workers = 3
+        barriers = GenerationBarrier(num_workers=num_workers, timeout=30.0)
+
+        unblocked = threading.Event()
+        broken_detected = threading.Event()
+
+        def waiting_worker():
+            """Worker that waits at first barrier forever (3 parties, only 1 arrives)."""
+            barriers.wait("connected", worker_id=99)
+            # If we get here, barrier was broken (no-op after abort)
+            unblocked.set()
+
+        def aborter():
+            """Wait briefly then abort."""
+            time.sleep(0.1)
+            barriers.abort()
+
+        t1 = threading.Thread(target=waiting_worker)
+        t2 = threading.Thread(target=aborter)
+        t1.start()
+        t2.start()
+        t1.join(timeout=5.0)
+        t2.join(timeout=5.0)
+
+        assert barriers.broken
+        # After abort, subsequent waits are no-ops
+        barriers.wait("config_applied", worker_id=0)  # Should not block
+
+    def test_abort_on_already_broken_is_noop(self):
+        """Calling abort() on a broken barrier set is harmless."""
+        barriers = GenerationBarrier(num_workers=2, timeout=1.0)
+        barriers.abort()
+        assert barriers.broken
+        barriers.abort()  # Should not raise
+        assert barriers.broken
+
+    def test_abort_on_disabled_is_noop(self):
+        """Calling abort() on a disabled barrier set is harmless."""
+        barriers = GenerationBarrier(num_workers=2, timeout=1.0, enabled=False)
+        barriers.abort()
+        assert not barriers.broken  # Stays not-broken since disabled
+
+
+class TestHybridModeBatching:
+    """Test that barriers work correctly in hybrid mode (pop > parallel workers).
+
+    In hybrid mode, workers are evaluated in batches (each batch sized to
+    max_workers). Barriers must be sized to the batch, not the full population,
+    to avoid deadlock.
+    """
+
+    def test_batch_sized_barrier_does_not_deadlock(self):
+        """A barrier sized to batch_size (< population) completes without deadlock."""
+        batch_size = 2
+        barriers = GenerationBarrier(num_workers=batch_size, timeout=3.0)
+
+        results = []
+        lock = threading.Lock()
+
+        def worker_fn(worker_id: int):
+            for name in BARRIER_NAMES:
+                barriers.wait(name, worker_id=worker_id)
+            with lock:
+                results.append(worker_id)
+
+        threads = [
+            threading.Thread(target=worker_fn, args=(i,))
+            for i in range(batch_size)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10.0)
+
+        assert len(results) == batch_size
+
+    def test_population_larger_than_batch_with_separate_barriers(self):
+        """Simulates hybrid: 6 workers, max_workers=2 → 3 batches of 2."""
+        population_size = 6
+        max_workers = 2
+        all_results = []
+        lock = threading.Lock()
+
+        # Simulate batched evaluation like population.evaluate_generation
+        workers = list(range(population_size))
+        batches = [
+            workers[i : i + max_workers]
+            for i in range(0, population_size, max_workers)
+        ]
+
+        for batch in batches:
+            batch_barriers = GenerationBarrier(
+                num_workers=len(batch), timeout=3.0
+            )
+
+            def worker_fn(wid: int, barriers=batch_barriers):
+                for name in BARRIER_NAMES:
+                    barriers.wait(name, worker_id=wid)
+                with lock:
+                    all_results.append(wid)
+
+            threads = [
+                threading.Thread(target=worker_fn, args=(wid,))
+                for wid in batch
+            ]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join(timeout=10.0)
+
+        assert sorted(all_results) == list(range(population_size))
+
+    def test_dead_worker_does_not_deadlock_batch(self):
+        """One worker dies mid-batch; drain_remaining unblocks the other."""
+        batch_size = 2
+        barriers = GenerationBarrier(num_workers=batch_size, timeout=3.0)
+
+        results = []
+        lock = threading.Lock()
+
+        def healthy_worker():
+            for name in BARRIER_NAMES:
+                barriers.wait(name, worker_id=0)
+            with lock:
+                results.append("healthy")
+
+        def dying_worker():
+            # Pass first 3 barriers then "die"
+            for name in BARRIER_NAMES[:3]:
+                barriers.wait(name, worker_id=1)
+            # Simulate failure: drain remaining barriers
+            barriers.drain_remaining(BARRIER_NAMES[3], worker_id=1)
+            with lock:
+                results.append("dead_but_drained")
+
+        threads = [
+            threading.Thread(target=healthy_worker),
+            threading.Thread(target=dying_worker),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10.0)
+
+        assert len(results) == 2
+        assert "healthy" in results
+        assert "dead_but_drained" in results
+        # Barrier should NOT be broken since drain_remaining cooperated
+        # (it acted as the participant arrival for later barriers)


### PR DESCRIPTION
- Fix hybrid mode deadlock: evaluate workers in explicit batches with per-batch barriers sized to actual concurrent threads (not population)
- Fix double-wait on 'disconnected' barrier: guard finally block with _barriers_drained flag to prevent second barrier cycle after drain
- Remove validation that forced num_parallel_workers <= population_size
- Add abort() method to GenerationBarrier for instant barrier breaking
- Add collection timeout in population.py to detect stuck workers
- Add 6 new tests for abort() and hybrid batching scenarios