### PR TITLE
feat(viz): Add knob importance visualizations

### DIFF
--- a/src/visualization/__main__.py
+++ b/src/visualization/__main__.py
@@ -3,6 +3,7 @@ Command-line entry point for the visualization framework.
 """
 
 import argparse
+import inspect
 from pathlib import Path
 import sys
 
@@ -70,6 +71,24 @@ def parse_args() -> argparse.Namespace:
         help="Formats to export (default: pdf png).",
     )
 
+    parser.add_argument(
+        "--importance-top-k",
+        type=int,
+        help="Number of knobs to show in the importance bar/beeswarm plots.",
+    )
+
+    parser.add_argument(
+        "--dependence-top-k",
+        type=int,
+        help="Number of knobs to show in dependence plots.",
+    )
+
+    parser.add_argument(
+        "--interaction-top-k",
+        type=int,
+        help="Number of knobs to include in the interaction heatmap.",
+    )
+
     return parser.parse_args()
 
 
@@ -119,11 +138,23 @@ def main() -> int:
         try:
             # We pass the unresolved data_dir to the generator.
             # It's up to each specific plot module to fetch the exact subdirectories it needs.
+            extra_args = {
+                "top_k_importance": args.importance_top_k,
+                "top_k_dependence": args.dependence_top_k,
+                "top_k_interactions": args.interaction_top_k,
+            }
+            sig = inspect.signature(spec.generator)
+            filtered_args = {
+                key: value
+                for key, value in extra_args.items()
+                if value is not None and key in sig.parameters
+            }
             spec.generator(
                 data_dir=args.data_dir,
                 output_dir=args.output_dir,
                 theme=theme,
                 formats=formats,
+                **filtered_args,
             )
             success_count += 1
         except Exception as e:

--- a/src/visualization/plots/knob_dependence.py
+++ b/src/visualization/plots/knob_dependence.py
@@ -13,7 +13,7 @@ from src.visualization.exceptions import DataLoadError
 from src.visualization.loaders import ImportanceData, load_importance_from_dir
 from src.visualization.theme import PBTuneTheme
 from src.visualization.types import ExportFormat, FigureSpec
-from src.visualization.utils import add_panel_labels, auto_grid
+from src.visualization.utils import auto_grid
 
 DEFAULT_IMPORTANCE_DIRS = (
     Path("oltp") / "pbt_runs" / "extensive" / "tuning_sessions",
@@ -109,12 +109,18 @@ def _manual_dependence(
     colorbar.ax.tick_params(labelsize=7)
 
 
+def _chunk_items(items: list[str], chunk_size: int) -> list[list[str]]:
+    """Split a list into fixed-size chunks."""
+    return [items[i : i + chunk_size] for i in range(0, len(items), chunk_size)]
+
+
 def generate_knob_dependence(
     *,
     data_dir: Path | str,
     output_dir: Path | str,
     theme: PBTuneTheme,
     formats: list[ExportFormat],
+    top_k_dependence: int | None = None,
 ) -> None:
     """Generate the knob dependence figure.
 
@@ -132,7 +138,8 @@ def generate_knob_dependence(
     if shap_values.size == 0 or importance.config_df.empty:
         raise DataLoadError("SHAP values unavailable for dependence plotting.")
 
-    top_k = min(4, len(importance.knob_names))
+    resolved_top_k = 4 if top_k_dependence is None else max(1, top_k_dependence)
+    top_k = min(resolved_top_k, len(importance.knob_names))
     top_knobs = importance.knob_names[:top_k]
 
     analysis_columns = [
@@ -145,81 +152,98 @@ def generate_knob_dependence(
     feature_names = list(analysis_columns)
     feature_values = analysis_df.to_numpy()
 
-    with theme.apply():
-        fig, axes = theme.subplots(
-            nrows=2, ncols=2, size_hint="double", aspect=0.7
-        )
-        axes = np.ravel(axes)
+    panels_per_fig = 4
+    knob_chunks = _chunk_items(top_knobs, panels_per_fig)
+    total_pages = len(knob_chunks)
+    label_max_len = 24 if total_pages > 1 else 28
 
-        for idx, (ax, knob) in enumerate(zip(axes, top_knobs)):
-            if knob not in column_index:
-                ax.text(
-                    0.5,
-                    0.5,
-                    f"Missing knob: {knob}",
-                    ha="center",
-                    va="center",
-                    transform=ax.transAxes,
+    for page_index, knob_chunk in enumerate(knob_chunks, start=1):
+        with theme.apply():
+            fig, axes = theme.subplots(
+                nrows=2,
+                ncols=2,
+                size_hint="double",
+                aspect=0.85 if total_pages > 1 else 0.7,
+            )
+            axes = np.ravel(axes)
+
+            for idx, (ax, knob) in enumerate(zip(axes, knob_chunk)):
+                if knob not in column_index:
+                    ax.text(
+                        0.5,
+                        0.5,
+                        f"Missing knob: {knob}",
+                        ha="center",
+                        va="center",
+                        transform=ax.transAxes,
+                    )
+                    ax.set_axis_off()
+                    continue
+
+                feature_idx = column_index[knob]
+                interaction = _interaction_feature(importance, knob) or knob
+                color_idx = column_index.get(interaction, feature_idx)
+
+                _manual_dependence(
+                    ax,
+                    fig,
+                    feature_values[:, feature_idx],
+                    shap_values[:, feature_idx],
+                    feature_values[:, color_idx],
+                    interaction,
                 )
+
+                short_knob = _shorten_label(knob, max_len=label_max_len)
+                short_interaction = _shorten_label(
+                    interaction, max_len=label_max_len
+                )
+                title = f"{short_knob} (c:{short_interaction})"
+                wrapped_title = textwrap.fill(title, width=26)
+                ax.set_title(wrapped_title, pad=6, fontsize=8)
+                row = idx // 2
+                col = idx % 2
+                if row == 1:
+                    ax.set_xlabel("Value", fontsize=8)
+                else:
+                    ax.set_xlabel("")
+                if col == 0:
+                    ax.set_ylabel("SHAP", fontsize=8)
+                else:
+                    ax.set_ylabel("")
+                ax.tick_params(axis="both", labelsize=7)
+
+            for ax in axes[len(knob_chunk) :]:
                 ax.set_axis_off()
-                continue
 
-            feature_idx = column_index[knob]
-            interaction = _interaction_feature(importance, knob) or knob
-            color_idx = column_index.get(interaction, feature_idx)
+            for idx, ax in enumerate(axes[: len(knob_chunk)]):
+                ax.text(
+                    -0.08,
+                    1.05,
+                    f"({chr(ord('a') + idx)})",
+                    transform=ax.transAxes,
+                    fontsize=9,
+                    fontweight="bold",
+                    va="bottom",
+                    ha="right",
+                )
+            fig.subplots_adjust(top=0.9, hspace=0.4, wspace=0.25)
 
-            _manual_dependence(
-                ax,
-                fig,
-                feature_values[:, feature_idx],
-                shap_values[:, feature_idx],
-                feature_values[:, color_idx],
-                interaction,
-            )
+        fig_id = "knob_dependence"
+        if total_pages > 1:
+            fig_id = f"{fig_id}_p{page_index}"
 
-            short_knob = _shorten_label(knob)
-            short_interaction = _shorten_label(interaction)
-            title = f"{short_knob} (c:{short_interaction})"
-            wrapped_title = textwrap.fill(title, width=26)
-            ax.set_title(wrapped_title, pad=6, fontsize=8)
-            row = idx // 2
-            col = idx % 2
-            if row == 1:
-                ax.set_xlabel("Value", fontsize=8)
-            else:
-                ax.set_xlabel("")
-            if col == 0:
-                ax.set_ylabel("SHAP", fontsize=8)
-            else:
-                ax.set_ylabel("")
-            ax.tick_params(axis="both", labelsize=7)
-
-        for ax in axes[len(top_knobs) :]:
-            ax.set_axis_off()
-
-        for idx, ax in enumerate(axes[: len(top_knobs)]):
-            ax.text(
-                -0.08,
-                1.05,
-                f"({chr(ord('a') + idx)})",
-                transform=ax.transAxes,
-                fontsize=9,
-                fontweight="bold",
-                va="bottom",
-                ha="right",
-            )
-        fig.subplots_adjust(top=0.9, hspace=0.4, wspace=0.25)
-
-    export_figure(
-        fig,
-        output_dir=output_dir,
-        fig_id="knob_dependence",
-        formats=formats,
-        metadata={
-            "correlation": importance.correlation,
-            "data_dir": str(importance_dir),
-        },
-    )
+        export_figure(
+            fig,
+            output_dir=output_dir,
+            fig_id=fig_id,
+            formats=formats,
+            metadata={
+                "correlation": importance.correlation,
+                "data_dir": str(importance_dir),
+                "page": page_index,
+                "total_pages": total_pages,
+            },
+        )
 
 
 register_figure(

--- a/src/visualization/plots/knob_dependence.py
+++ b/src/visualization/plots/knob_dependence.py
@@ -1,0 +1,237 @@
+"""Knob dependence plots using SHAP values."""
+
+from pathlib import Path
+from typing import Optional
+import textwrap
+
+import numpy as np
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
+
+from src.visualization import export_figure, register_figure
+from src.visualization.exceptions import DataLoadError
+from src.visualization.loaders import ImportanceData, load_importance_from_dir
+from src.visualization.theme import PBTuneTheme
+from src.visualization.types import ExportFormat, FigureSpec
+from src.visualization.utils import add_panel_labels, auto_grid
+
+DEFAULT_IMPORTANCE_DIRS = (
+    Path("oltp") / "pbt_runs" / "extensive" / "tuning_sessions",
+    Path("olap") / "pbt_runs" / "extensive" / "tuning_sessions",
+)
+
+
+def _resolve_importance_dir(data_dir: Path) -> Path:
+    """Resolve the directory that contains PBT tuning sessions for importance."""
+    if data_dir.is_dir():
+        json_files = list(data_dir.glob("pbt_results_*.json"))
+        if json_files:
+            return data_dir
+
+    for candidate in DEFAULT_IMPORTANCE_DIRS:
+        candidate_path = data_dir / candidate
+        if candidate_path.is_dir():
+            json_files = list(candidate_path.glob("pbt_results_*.json"))
+            if json_files:
+                return candidate_path
+
+    raise DataLoadError(
+        "No tuning session data found. Expected pbt_results_*.json under "
+        f"{data_dir / DEFAULT_IMPORTANCE_DIRS[0]} (or the OLAP equivalent)."
+    )
+
+
+def _interaction_feature(importance: ImportanceData, knob_name: str) -> Optional[str]:
+    """Pick the strongest interacting knob for color encoding."""
+    labels = importance.pairwise_labels
+    if knob_name not in labels:
+        return None
+
+    matrix = np.asarray(importance.pairwise_matrix)
+    if matrix.size == 0:
+        return None
+
+    idx = labels.index(knob_name)
+    symmetric = np.maximum(matrix, matrix.T)
+    row = symmetric[idx].copy()
+    row[idx] = 0.0
+
+    if np.allclose(row, 0.0):
+        return None
+
+    return labels[int(np.argmax(row))]
+
+
+def _shorten_label(name: str, max_len: int = 28) -> str:
+    """Abbreviate long knob names for compact figure labels."""
+    replacements = [
+        ("autovacuum_", "av_"),
+        ("checkpoint_", "ckpt_"),
+        ("vacuum_", "vac_"),
+        ("_scale_factor", "_scale"),
+        ("_completion_target", "_target"),
+        ("_freeze_min_age", "_freeze_age"),
+        ("_min_age", "_min_age"),
+        ("_cost_page_hit", "_cph"),
+    ]
+    shortened = name
+    for old, new in replacements:
+        shortened = shortened.replace(old, new)
+
+    if len(shortened) > max_len:
+        shortened = shortened[: max_len - 3] + "..."
+
+    return shortened
+
+
+def _manual_dependence(
+    ax: Axes,
+    fig: Figure,
+    x_vals: np.ndarray,
+    y_vals: np.ndarray,
+    color_vals: np.ndarray,
+    color_label: str,
+) -> None:
+    """Fallback dependence plot using matplotlib scatter points."""
+    scatter = ax.scatter(
+        x_vals,
+        y_vals,
+        c=color_vals,
+        cmap="viridis",
+        s=12,
+        alpha=0.7,
+        edgecolors="none",
+    )
+    ax.axhline(0.0, color="#6B7280", linestyle="--", linewidth=0.8)
+    auto_grid(ax, axis="both")
+
+    colorbar = fig.colorbar(scatter, ax=ax, pad=0.01, fraction=0.04)
+    colorbar.ax.tick_params(labelsize=7)
+
+
+def generate_knob_dependence(
+    *,
+    data_dir: Path | str,
+    output_dir: Path | str,
+    theme: PBTuneTheme,
+    formats: list[ExportFormat],
+) -> None:
+    """Generate the knob dependence figure.
+
+    Args:
+        data_dir: Base directory containing results.
+        output_dir: Destination for exported figures.
+        theme: Visualization theme for sizing and styling.
+        formats: Export formats.
+    """
+    base_dir = Path(data_dir)
+    importance_dir = _resolve_importance_dir(base_dir)
+    importance = load_importance_from_dir(importance_dir)
+
+    shap_values = np.asarray(importance.shap_values)
+    if shap_values.size == 0 or importance.config_df.empty:
+        raise DataLoadError("SHAP values unavailable for dependence plotting.")
+
+    top_k = min(4, len(importance.knob_names))
+    top_knobs = importance.knob_names[:top_k]
+
+    analysis_columns = [
+        name
+        for name in importance.config_df.columns
+        if importance.config_df[name].nunique() > 1
+    ]
+    analysis_df = importance.config_df[analysis_columns]
+    column_index = {name: idx for idx, name in enumerate(analysis_columns)}
+    feature_names = list(analysis_columns)
+    feature_values = analysis_df.to_numpy()
+
+    with theme.apply():
+        fig, axes = theme.subplots(
+            nrows=2, ncols=2, size_hint="double", aspect=0.7
+        )
+        axes = np.ravel(axes)
+
+        for idx, (ax, knob) in enumerate(zip(axes, top_knobs)):
+            if knob not in column_index:
+                ax.text(
+                    0.5,
+                    0.5,
+                    f"Missing knob: {knob}",
+                    ha="center",
+                    va="center",
+                    transform=ax.transAxes,
+                )
+                ax.set_axis_off()
+                continue
+
+            feature_idx = column_index[knob]
+            interaction = _interaction_feature(importance, knob) or knob
+            color_idx = column_index.get(interaction, feature_idx)
+
+            _manual_dependence(
+                ax,
+                fig,
+                feature_values[:, feature_idx],
+                shap_values[:, feature_idx],
+                feature_values[:, color_idx],
+                interaction,
+            )
+
+            short_knob = _shorten_label(knob)
+            short_interaction = _shorten_label(interaction)
+            title = f"{short_knob} (c:{short_interaction})"
+            wrapped_title = textwrap.fill(title, width=26)
+            ax.set_title(wrapped_title, pad=6, fontsize=8)
+            row = idx // 2
+            col = idx % 2
+            if row == 1:
+                ax.set_xlabel("Value", fontsize=8)
+            else:
+                ax.set_xlabel("")
+            if col == 0:
+                ax.set_ylabel("SHAP", fontsize=8)
+            else:
+                ax.set_ylabel("")
+            ax.tick_params(axis="both", labelsize=7)
+
+        for ax in axes[len(top_knobs) :]:
+            ax.set_axis_off()
+
+        for idx, ax in enumerate(axes[: len(top_knobs)]):
+            ax.text(
+                -0.08,
+                1.05,
+                f"({chr(ord('a') + idx)})",
+                transform=ax.transAxes,
+                fontsize=9,
+                fontweight="bold",
+                va="bottom",
+                ha="right",
+            )
+        fig.subplots_adjust(top=0.9, hspace=0.4, wspace=0.25)
+
+    export_figure(
+        fig,
+        output_dir=output_dir,
+        fig_id="knob_dependence",
+        formats=formats,
+        metadata={
+            "correlation": importance.correlation,
+            "data_dir": str(importance_dir),
+        },
+    )
+
+
+register_figure(
+    FigureSpec(
+        fig_id="knob_dependence",
+        paper_label="fig:dependence",
+        title="Knob dependence plots",
+        section="analysis",
+        category="importance",
+        size_hint="double",
+        generator=generate_knob_dependence,
+        data_requirements=["session_json"],
+        description="SHAP dependence plots for the top 4 knobs.",
+    )
+)

--- a/src/visualization/plots/knob_importance.py
+++ b/src/visualization/plots/knob_importance.py
@@ -6,6 +6,7 @@ from typing import Iterable
 import numpy as np
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure
+from matplotlib.colors import Normalize
 
 from src.utils.logger import get_logger
 from src.visualization import METRIC_COLORS, export_figure, register_figure
@@ -13,7 +14,7 @@ from src.visualization.exceptions import DataLoadError
 from src.visualization.loaders import ImportanceData, load_importance_from_dir
 from src.visualization.theme import PBTuneTheme
 from src.visualization.types import ExportFormat, FigureSpec
-from src.visualization.utils import add_panel_labels, auto_grid, despine
+from src.visualization.utils import auto_grid, despine
 
 LOGGER = get_logger("KnobImportancePlot")
 
@@ -43,6 +44,16 @@ def _shorten_label(name: str, max_len: int = 28) -> str:
         shortened = shortened[: max_len - 3] + "..."
 
     return shortened
+
+
+def _label_font_size(knob_count: int, base: float = 9.0) -> float:
+    """Scale label font size as the number of knobs grows.
+
+    Uses a simple linear decay: size = base - 0.6 * max(0, k - 10),
+    clamped to a minimum of 6 pt.
+    """
+    decay = 0.6 * max(0, knob_count - 10)
+    return max(6.0, base - decay)
 
 
 def _resolve_importance_dir(data_dir: Path) -> Path:
@@ -136,20 +147,23 @@ def _manual_beeswarm(
     shap_values: np.ndarray,
     feature_values: np.ndarray,
     feature_names: list[str],
+    label_gap: float,
 ) -> None:
     """Fallback beeswarm rendering using matplotlib scatter points."""
     rng = np.random.default_rng(0)
-    y_positions = np.arange(len(feature_names))
+    y_positions = np.arange(len(feature_names)) * label_gap
     last_scatter = None
+    color_norm = Normalize(vmin=0.0, vmax=1.0)
 
     # Approximate beeswarm by jittering points along the categorical axis.
     for idx, _ in enumerate(feature_names):
-        jitter = rng.normal(0, 0.12, size=shap_values.shape[0])
+        jitter = rng.normal(0, 0.12 * label_gap, size=shap_values.shape[0])
         last_scatter = ax.scatter(
             shap_values[:, idx],
             y_positions[idx] + jitter,
             c=feature_values[:, idx],
             cmap="viridis",
+            norm=color_norm,
             s=10,
             alpha=0.7,
             edgecolors="none",
@@ -157,12 +171,27 @@ def _manual_beeswarm(
 
     ax.set_yticks(y_positions)
     ax.set_yticklabels(feature_names)
+    ax.set_ylim(
+        -0.5 * label_gap, y_positions[-1] + 0.5 * label_gap
+    )
     ax.axvline(0.0, color="#6B7280", linestyle="--", linewidth=0.8)
     auto_grid(ax, axis="x")
 
     if last_scatter is not None:
         colorbar = fig.colorbar(last_scatter, ax=ax, pad=0.02)
-        colorbar.set_label("Feature value")
+        colorbar.set_label("Feature value (normalized)")
+        colorbar.set_ticks([0.0, 1.0])
+        colorbar.set_ticklabels(["Low", "High"])
+
+
+def _normalize_feature_values(values: np.ndarray) -> np.ndarray:
+    """Normalize each feature column to [0, 1] for consistent color mapping."""
+    min_vals = np.nanmin(values, axis=0)
+    max_vals = np.nanmax(values, axis=0)
+    ranges = max_vals - min_vals
+    safe_ranges = np.where(ranges == 0, 1.0, ranges)
+    normalized = (values - min_vals) / safe_ranges
+    return np.clip(normalized, 0.0, 1.0)
 
 
 def generate_knob_importance(
@@ -171,6 +200,7 @@ def generate_knob_importance(
     output_dir: Path | str,
     theme: PBTuneTheme,
     formats: list[ExportFormat],
+    top_k_importance: int | None = None,
 ) -> None:
     """Generate the knob importance figure.
 
@@ -184,23 +214,32 @@ def generate_knob_importance(
     importance_dir = _resolve_importance_dir(base_dir)
     importance = load_importance_from_dir(importance_dir)
 
-    top_k = min(10, len(importance.knob_names))
+    resolved_top_k = 10 if top_k_importance is None else max(1, top_k_importance)
+    top_k = min(resolved_top_k, len(importance.knob_names))
     top_knobs = importance.knob_names[:top_k]
     short_knobs = [_shorten_label(k) for k in top_knobs]
+    label_size = _label_font_size(top_k)
+    label_gap = 1.0 + 0.02 * max(0, min(20, top_k - 10))
 
     with theme.apply():
         fig, axes = theme.subplots(nrows=2, ncols=1, size_hint="single", aspect=1.2)
         axes = np.ravel(axes)
         bar_ax, swarm_ax = axes[0], axes[1]
 
+        bar_positions = np.arange(top_k) * label_gap
         bar_ax.barh(
-            short_knobs,
+            bar_positions,
             importance.fanova_scores[:top_k],
             color=METRIC_COLORS["score"],
         )
         bar_ax.invert_yaxis()
+        bar_ax.set_yticks(bar_positions)
+        bar_ax.set_yticklabels(short_knobs)
+        bar_ax.tick_params(axis="y", labelsize=label_size)
         bar_ax.set_xlabel("Marginal importance")
-        bar_ax.set_title("fANOVA marginal importances (top 10)", fontsize=9, pad=6)
+        bar_ax.set_title(
+            f"fANOVA marginal importances (top {top_k})", fontsize=9, pad=6
+        )
         auto_grid(bar_ax, axis="x")
         despine(bar_ax)
 
@@ -219,15 +258,25 @@ def generate_knob_importance(
                 importance, top_knobs
             )
             short_valid = [_shorten_label(k) for k in valid_knobs]
-            used_shap = _try_shap_beeswarm(
-                swarm_ax, shap_subset, feature_values, short_valid
-            )
+            normalized_features = _normalize_feature_values(feature_values)
+            used_shap = False
+            if label_gap == 1.0:
+                used_shap = _try_shap_beeswarm(
+                    swarm_ax, shap_subset, normalized_features, short_valid
+                )
             if not used_shap:
                 _manual_beeswarm(
-                    swarm_ax, fig, shap_subset, feature_values, short_valid
+                    swarm_ax,
+                    fig,
+                    shap_subset,
+                    normalized_features,
+                    short_valid,
+                    label_gap,
                 )
 
-        swarm_ax.set_title("SHAP beeswarm (top 10)", fontsize=9, pad=6)
+            swarm_ax.tick_params(axis="y", labelsize=label_size)
+
+        swarm_ax.set_title(f"SHAP beeswarm (top {top_k})", fontsize=9, pad=6)
         swarm_ax.set_xlabel("SHAP value (impact on score)")
         swarm_ax.set_ylabel("Knob")
 

--- a/src/visualization/plots/knob_importance.py
+++ b/src/visualization/plots/knob_importance.py
@@ -1,0 +1,272 @@
+"""Knob importance figure (fANOVA bars + SHAP beeswarm)."""
+
+from pathlib import Path
+from typing import Iterable
+
+import numpy as np
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
+
+from src.utils.logger import get_logger
+from src.visualization import METRIC_COLORS, export_figure, register_figure
+from src.visualization.exceptions import DataLoadError
+from src.visualization.loaders import ImportanceData, load_importance_from_dir
+from src.visualization.theme import PBTuneTheme
+from src.visualization.types import ExportFormat, FigureSpec
+from src.visualization.utils import add_panel_labels, auto_grid, despine
+
+LOGGER = get_logger("KnobImportancePlot")
+
+DEFAULT_IMPORTANCE_DIRS = (
+    Path("oltp") / "pbt_runs" / "extensive" / "tuning_sessions",
+    Path("olap") / "pbt_runs" / "extensive" / "tuning_sessions",
+)
+
+
+def _shorten_label(name: str, max_len: int = 28) -> str:
+    """Abbreviate long knob names for compact figure labels."""
+    replacements = [
+        ("autovacuum_", "av_"),
+        ("checkpoint_", "ckpt_"),
+        ("vacuum_", "vac_"),
+        ("_scale_factor", "_scale"),
+        ("_completion_target", "_target"),
+        ("_freeze_min_age", "_freeze_age"),
+        ("_cost_page_hit", "_cph"),
+        ("_multixact", "_mx"),
+    ]
+    shortened = name
+    for old, new in replacements:
+        shortened = shortened.replace(old, new)
+
+    if len(shortened) > max_len:
+        shortened = shortened[: max_len - 3] + "..."
+
+    return shortened
+
+
+def _resolve_importance_dir(data_dir: Path) -> Path:
+    """Resolve the directory that contains PBT tuning sessions for importance."""
+    if data_dir.is_dir():
+        json_files = list(data_dir.glob("pbt_results_*.json"))
+        if json_files:
+            return data_dir
+
+    for candidate in DEFAULT_IMPORTANCE_DIRS:
+        candidate_path = data_dir / candidate
+        if candidate_path.is_dir():
+            json_files = list(candidate_path.glob("pbt_results_*.json"))
+            if json_files:
+                return candidate_path
+
+    raise DataLoadError(
+        "No tuning session data found. Expected pbt_results_*.json under "
+        f"{data_dir / DEFAULT_IMPORTANCE_DIRS[0]} (or the OLAP equivalent)."
+    )
+
+
+def _match_knobs(
+    importance: ImportanceData, knob_names: Iterable[str]
+) -> tuple[list[str], np.ndarray, np.ndarray]:
+    """Align SHAP values and config data with the requested knob names.
+
+    Args:
+        importance: Loaded importance data.
+        knob_names: Desired knob names in display order.
+
+    Returns:
+        Tuple of (valid_knobs, shap_subset, feature_values).
+    """
+    analysis_columns = [
+        name
+        for name in importance.config_df.columns
+        if importance.config_df[name].nunique() > 1
+    ]
+    analysis_df = importance.config_df[analysis_columns]
+    column_index = {name: idx for idx, name in enumerate(analysis_columns)}
+    valid_knobs = [name for name in knob_names if name in column_index]
+
+    if not valid_knobs:
+        raise DataLoadError("None of the requested knobs exist in config data.")
+
+    indices = [column_index[name] for name in valid_knobs]
+    shap_values = np.asarray(importance.shap_values)
+    shap_subset = shap_values[:, indices]
+    feature_values = analysis_df[valid_knobs].to_numpy()
+    return valid_knobs, shap_subset, feature_values
+
+
+def _try_shap_beeswarm(
+    ax: Axes,
+    shap_values: np.ndarray,
+    feature_values: np.ndarray,
+    feature_names: list[str],
+) -> bool:
+    """Try to render a SHAP beeswarm plot using shap if available."""
+    try:
+        import shap
+    except ImportError:
+        return False
+
+    try:
+        import inspect
+
+        if "ax" not in inspect.signature(shap.plots.beeswarm).parameters:
+            return False
+        explanation = shap.Explanation(
+            values=shap_values,
+            data=feature_values,
+            feature_names=feature_names,
+        )
+        shap.plots.beeswarm(
+            explanation,
+            ax=ax,
+            show=False,
+            max_display=len(feature_names),
+        )
+        return True
+    except Exception as exc:
+        LOGGER.debug("shap beeswarm failed, falling back to manual plot: %s", exc)
+        return False
+
+
+def _manual_beeswarm(
+    ax: Axes,
+    fig: Figure,
+    shap_values: np.ndarray,
+    feature_values: np.ndarray,
+    feature_names: list[str],
+) -> None:
+    """Fallback beeswarm rendering using matplotlib scatter points."""
+    rng = np.random.default_rng(0)
+    y_positions = np.arange(len(feature_names))
+    last_scatter = None
+
+    # Approximate beeswarm by jittering points along the categorical axis.
+    for idx, _ in enumerate(feature_names):
+        jitter = rng.normal(0, 0.12, size=shap_values.shape[0])
+        last_scatter = ax.scatter(
+            shap_values[:, idx],
+            y_positions[idx] + jitter,
+            c=feature_values[:, idx],
+            cmap="viridis",
+            s=10,
+            alpha=0.7,
+            edgecolors="none",
+        )
+
+    ax.set_yticks(y_positions)
+    ax.set_yticklabels(feature_names)
+    ax.axvline(0.0, color="#6B7280", linestyle="--", linewidth=0.8)
+    auto_grid(ax, axis="x")
+
+    if last_scatter is not None:
+        colorbar = fig.colorbar(last_scatter, ax=ax, pad=0.02)
+        colorbar.set_label("Feature value")
+
+
+def generate_knob_importance(
+    *,
+    data_dir: Path | str,
+    output_dir: Path | str,
+    theme: PBTuneTheme,
+    formats: list[ExportFormat],
+) -> None:
+    """Generate the knob importance figure.
+
+    Args:
+        data_dir: Base directory containing results.
+        output_dir: Destination for exported figures.
+        theme: Visualization theme for sizing and styling.
+        formats: Export formats.
+    """
+    base_dir = Path(data_dir)
+    importance_dir = _resolve_importance_dir(base_dir)
+    importance = load_importance_from_dir(importance_dir)
+
+    top_k = min(10, len(importance.knob_names))
+    top_knobs = importance.knob_names[:top_k]
+    short_knobs = [_shorten_label(k) for k in top_knobs]
+
+    with theme.apply():
+        fig, axes = theme.subplots(nrows=2, ncols=1, size_hint="single", aspect=1.2)
+        axes = np.ravel(axes)
+        bar_ax, swarm_ax = axes[0], axes[1]
+
+        bar_ax.barh(
+            short_knobs,
+            importance.fanova_scores[:top_k],
+            color=METRIC_COLORS["score"],
+        )
+        bar_ax.invert_yaxis()
+        bar_ax.set_xlabel("Marginal importance")
+        bar_ax.set_title("fANOVA marginal importances (top 10)", fontsize=9, pad=6)
+        auto_grid(bar_ax, axis="x")
+        despine(bar_ax)
+
+        shap_values = np.asarray(importance.shap_values)
+        if shap_values.size == 0 or importance.config_df.empty:
+            swarm_ax.text(
+                0.5,
+                0.5,
+                "SHAP values unavailable",
+                ha="center",
+                va="center",
+                transform=swarm_ax.transAxes,
+            )
+        else:
+            valid_knobs, shap_subset, feature_values = _match_knobs(
+                importance, top_knobs
+            )
+            short_valid = [_shorten_label(k) for k in valid_knobs]
+            used_shap = _try_shap_beeswarm(
+                swarm_ax, shap_subset, feature_values, short_valid
+            )
+            if not used_shap:
+                _manual_beeswarm(
+                    swarm_ax, fig, shap_subset, feature_values, short_valid
+                )
+
+        swarm_ax.set_title("SHAP beeswarm (top 10)", fontsize=9, pad=6)
+        swarm_ax.set_xlabel("SHAP value (impact on score)")
+        swarm_ax.set_ylabel("Knob")
+
+        for idx, ax in enumerate([bar_ax, swarm_ax]):
+            ax.text(
+                -0.08,
+                1.02,
+                f"({chr(ord('a') + idx)})",
+                transform=ax.transAxes,
+                fontsize=9,
+                fontweight="bold",
+                va="bottom",
+                ha="right",
+            )
+
+        fig.subplots_adjust(left=0.23, top=0.92, hspace=0.5)
+
+    export_figure(
+        fig,
+        output_dir=output_dir,
+        fig_id="knob_importance",
+        formats=formats,
+        metadata={
+            "correlation": importance.correlation,
+            "data_dir": str(importance_dir),
+        },
+    )
+
+
+register_figure(
+    FigureSpec(
+        fig_id="knob_importance",
+        paper_label="fig:importance",
+        title="Knob importance overview",
+        section="analysis",
+        category="importance",
+        size_hint="single",
+        generator=generate_knob_importance,
+        data_requirements=["session_json"],
+        description="fANOVA bars with SHAP beeswarm (top 10 knobs).",
+    )
+)

--- a/src/visualization/plots/knob_interaction_heatmap.py
+++ b/src/visualization/plots/knob_interaction_heatmap.py
@@ -61,7 +61,9 @@ def _resolve_importance_dir(data_dir: Path) -> Path:
 
 
 def _render_heatmap(
-    importance: ImportanceData, theme: PBTuneTheme
+    importance: ImportanceData,
+    theme: PBTuneTheme,
+    top_k_interactions: int | None = None,
 ) -> tuple[Figure, Axes]:
     """Render a heatmap using seaborn if available, otherwise imshow.
 
@@ -73,6 +75,19 @@ def _render_heatmap(
 
         matrix = np.asarray(importance.pairwise_matrix)
         labels = importance.pairwise_labels
+
+        if top_k_interactions is not None:
+            resolved_top_k = max(1, top_k_interactions)
+            top_labels = [
+                name
+                for name in importance.knob_names
+                if name in labels
+            ][:resolved_top_k]
+            index_map = {name: idx for idx, name in enumerate(labels)}
+            indices = [index_map[name] for name in top_labels if name in index_map]
+            if indices:
+                matrix = matrix[np.ix_(indices, indices)]
+                labels = top_labels
         short_labels = [_shorten_label(label) for label in labels]
 
         if matrix.size == 0 or len(labels) == 0:
@@ -108,7 +123,11 @@ def _render_heatmap(
             ax.set_yticks(range(len(short_labels)))
             ax.set_yticklabels(short_labels)
 
-        ax.set_title("fANOVA pairwise interaction importance")
+        if top_k_interactions is None:
+            title = "fANOVA pairwise interaction importance"
+        else:
+            title = f"fANOVA pairwise interaction importance (top {len(labels)})"
+        ax.set_title(title)
         ax.set_xlabel("")
         ax.set_ylabel("Knob")
         ax.tick_params(axis="y", labelsize=7)
@@ -123,6 +142,7 @@ def generate_knob_interaction_heatmap(
     output_dir: Path | str,
     theme: PBTuneTheme,
     formats: list[ExportFormat],
+    top_k_interactions: int | None = None,
 ) -> None:
     """Generate the knob interaction heatmap figure.
 
@@ -136,7 +156,7 @@ def generate_knob_interaction_heatmap(
     importance_dir = _resolve_importance_dir(base_dir)
     importance = load_importance_from_dir(importance_dir)
 
-    fig, _ = _render_heatmap(importance, theme)
+    fig, _ = _render_heatmap(importance, theme, top_k_interactions=top_k_interactions)
 
     export_figure(
         fig,

--- a/src/visualization/plots/knob_interaction_heatmap.py
+++ b/src/visualization/plots/knob_interaction_heatmap.py
@@ -1,0 +1,165 @@
+"""Knob interaction heatmap from pairwise fANOVA scores."""
+
+from pathlib import Path
+
+import numpy as np
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
+from src.visualization import export_figure, register_figure
+from src.visualization.exceptions import DataLoadError
+from src.visualization.loaders import ImportanceData, load_importance_from_dir
+from src.visualization.theme import PBTuneTheme
+from src.visualization.types import ExportFormat, FigureSpec
+from src.visualization.utils import despine
+
+DEFAULT_IMPORTANCE_DIRS = (
+    Path("oltp") / "pbt_runs" / "extensive" / "tuning_sessions",
+    Path("olap") / "pbt_runs" / "extensive" / "tuning_sessions",
+)
+
+
+def _shorten_label(name: str, max_len: int = 24) -> str:
+    """Abbreviate long knob names for compact heatmap labels."""
+    replacements = [
+        ("autovacuum_", "av_"),
+        ("checkpoint_", "ckpt_"),
+        ("vacuum_", "vac_"),
+        ("_scale_factor", "_scale"),
+        ("_completion_target", "_target"),
+        ("_freeze_min_age", "_freeze_age"),
+        ("_cost_page_hit", "_cph"),
+        ("_multixact", "_mx"),
+    ]
+    shortened = name
+    for old, new in replacements:
+        shortened = shortened.replace(old, new)
+
+    if len(shortened) > max_len:
+        shortened = shortened[: max_len - 3] + "..."
+
+    return shortened
+
+
+def _resolve_importance_dir(data_dir: Path) -> Path:
+    """Resolve the directory that contains PBT tuning sessions for importance."""
+    if data_dir.is_dir():
+        json_files = list(data_dir.glob("pbt_results_*.json"))
+        if json_files:
+            return data_dir
+
+    for candidate in DEFAULT_IMPORTANCE_DIRS:
+        candidate_path = data_dir / candidate
+        if candidate_path.is_dir():
+            json_files = list(candidate_path.glob("pbt_results_*.json"))
+            if json_files:
+                return candidate_path
+
+    raise DataLoadError(
+        "No tuning session data found. Expected pbt_results_*.json under "
+        f"{data_dir / DEFAULT_IMPORTANCE_DIRS[0]} (or the OLAP equivalent)."
+    )
+
+
+def _render_heatmap(
+    importance: ImportanceData, theme: PBTuneTheme
+) -> tuple[Figure, Axes]:
+    """Render a heatmap using seaborn if available, otherwise imshow.
+
+    Returns:
+        Tuple of (fig, ax) for export.
+    """
+    with theme.apply():
+        fig, ax = theme.figure(size_hint="single", aspect=0.9)
+
+        matrix = np.asarray(importance.pairwise_matrix)
+        labels = importance.pairwise_labels
+        short_labels = [_shorten_label(label) for label in labels]
+
+        if matrix.size == 0 or len(labels) == 0:
+            ax.text(
+                0.5,
+                0.5,
+                "Pairwise interaction data unavailable",
+                ha="center",
+                va="center",
+                transform=ax.transAxes,
+            )
+            ax.set_axis_off()
+            return fig, ax
+
+        try:
+            import seaborn as sns
+
+            annot = matrix.shape[0] <= 12
+            sns.heatmap(
+                matrix,
+                ax=ax,
+                cmap="mako",
+                xticklabels=False,
+                yticklabels=short_labels,
+                annot=annot,
+                fmt=".2f",
+                cbar_kws={"label": "Interaction importance"},
+            )
+        except ImportError:
+            im = ax.imshow(matrix, cmap="viridis")
+            fig.colorbar(im, ax=ax, label="Interaction importance")
+            ax.set_xticks([])
+            ax.set_yticks(range(len(short_labels)))
+            ax.set_yticklabels(short_labels)
+
+        ax.set_title("fANOVA pairwise interaction importance")
+        ax.set_xlabel("")
+        ax.set_ylabel("Knob")
+        ax.tick_params(axis="y", labelsize=7)
+        despine(ax)
+
+        return fig, ax
+
+
+def generate_knob_interaction_heatmap(
+    *,
+    data_dir: Path | str,
+    output_dir: Path | str,
+    theme: PBTuneTheme,
+    formats: list[ExportFormat],
+) -> None:
+    """Generate the knob interaction heatmap figure.
+
+    Args:
+        data_dir: Base directory containing results.
+        output_dir: Destination for exported figures.
+        theme: Visualization theme for sizing and styling.
+        formats: Export formats.
+    """
+    base_dir = Path(data_dir)
+    importance_dir = _resolve_importance_dir(base_dir)
+    importance = load_importance_from_dir(importance_dir)
+
+    fig, _ = _render_heatmap(importance, theme)
+
+    export_figure(
+        fig,
+        output_dir=output_dir,
+        fig_id="knob_interaction_heatmap",
+        formats=formats,
+        metadata={
+            "correlation": importance.correlation,
+            "data_dir": str(importance_dir),
+        },
+    )
+
+
+register_figure(
+    FigureSpec(
+        fig_id="knob_interaction_heatmap",
+        paper_label="fig:interaction",
+        title="Knob interaction heatmap",
+        section="analysis",
+        category="importance",
+        size_hint="single",
+        generator=generate_knob_interaction_heatmap,
+        data_requirements=["session_json"],
+        description="Pairwise fANOVA interaction heatmap.",
+    )
+)


### PR DESCRIPTION
Add importance, interaction heatmap, and dependence plot modules with label cleanup and layout tuning for paper-ready output.
<img width="1384" height="829" alt="knob_interaction_heatmap" src="https://github.com/user-attachments/assets/4b01e81e-3de1-4298-bbaf-90777242aa5b" />
<img width="1390" height="1198" alt="knob_importance" src="https://github.com/user-attachments/assets/46b5be28-2d0d-4e4d-a91c-a2ef20efac37" />
<img width="1916" height="1415" alt="knob_dependence" src="https://github.com/user-attachments/assets/1eb22ad0-3d41-4917-8ad5-eb6a0bc2a619" />
