### PR TITLE
fix(barriers): remove barrier timeout — wait indefinitely

### DIFF
--- a/src/tuner/config/tuner_config.py
+++ b/src/tuner/config/tuner_config.py
@@ -118,12 +118,6 @@ class PBTConfig:
         advances until all workers have completed the current step.
         This ensures fair resource sharing during measurement.
         Default: True
-
-    barrier_timeout_seconds : float
-        Maximum seconds each barrier will wait for all workers to arrive
-        before raising BrokenBarrierError and degrading gracefully.
-        Should accommodate Docker worst-case restart latency (~70 s).
-        Default: 120.0
     """
 
     population_size: int = 4
@@ -146,7 +140,6 @@ class PBTConfig:
     metric_reference_version: Optional[str] = None
     scoring_calibration_evals: int = 5
     synchronize_workers: bool = True
-    barrier_timeout_seconds: float = 120.0
 
     def __post_init__(self):
         """Validate configuration after initialization"""
@@ -191,9 +184,6 @@ class PBTConfig:
         if self.scoring_calibration_evals < 1:
             raise ValueError("scoring_calibration_evals must be at least 1")
 
-        if self.barrier_timeout_seconds <= 0:
-            raise ValueError("barrier_timeout_seconds must be positive")
-
     @property
     def num_workers_per_quantile(self) -> int:
         """
@@ -230,7 +220,6 @@ class PBTConfig:
             "metric_reference_version": self.metric_reference_version,
             "scoring_calibration_evals": self.scoring_calibration_evals,
             "synchronize_workers": self.synchronize_workers,
-            "barrier_timeout_seconds": self.barrier_timeout_seconds,
         }
 
     def __repr__(self) -> str:
@@ -253,8 +242,7 @@ class PBTConfig:
             f"  scoring_policy_version={self.scoring_policy_version},\n"
             f"  metric_reference_version={self.metric_reference_version},\n"
             f"  scoring_calibration_evals={self.scoring_calibration_evals},\n"
-            f"  synchronize_workers={self.synchronize_workers},\n"
-            f"  barrier_timeout_seconds={self.barrier_timeout_seconds}\n"
+            f"  synchronize_workers={self.synchronize_workers}\n"
             f")"
         )
 

--- a/src/tuner/core/barriers.py
+++ b/src/tuner/core/barriers.py
@@ -34,7 +34,7 @@ Each barrier corresponds to a discrete sub-step inside
 
 Usage
 -----
->>> barriers = GenerationBarrier(num_workers=4, timeout=120.0)
+>>> barriers = GenerationBarrier(num_workers=4)
 >>> # Inside each worker thread:
 >>> barriers.wait("connected")  # blocks until all 4 threads arrive
 >>> barriers.wait("config_applied")
@@ -42,15 +42,19 @@ Usage
 Graceful Degradation
 --------------------
 If **any** worker thread crashes, its barrier slots are never filled, which
-would deadlock the remaining threads. Two safeguards prevent this:
+would deadlock the remaining threads. Three safeguards prevent this:
 
-1. ``timeout`` — every ``barrier.wait()`` call has a deadline. On timeout,
-   ``BrokenBarrierError`` is raised, the internal ``_broken`` flag is set,
-   and **all subsequent** ``wait()`` calls become instant no-ops.
-
-2. ``drain_remaining(start_from)`` — when a worker catches an exception, it
+1. ``drain_remaining(start_from)`` — when a worker catches an exception, it
    calls this method to release all barriers it hasn't reached yet, so the
    other threads can proceed.
+
+2. ``abort()`` — called from the population layer when a worker is confirmed
+   dead/stuck. Instantly breaks all barriers (``BrokenBarrierError`` on
+   all waiters), and marks subsequent ``wait()`` calls as no-ops.
+
+3. No per-barrier timeout — barriers wait indefinitely because legitimate
+   queries (e.g. 5-min OLAP analytics) can take arbitrarily long.  The
+   dead-worker cases are handled by (1) and (2) above, not timeouts.
 """
 
 from __future__ import annotations
@@ -93,32 +97,35 @@ class GenerationBarrier:
     ----------
     num_workers : int
         Number of worker threads that must arrive at each barrier.
-    timeout : float
-        Maximum seconds to wait at any single barrier before raising
-        ``BrokenBarrierError``.  Default 120 s accommodates Docker
-        restart worst-case (~70 s) with headroom.
     enabled : bool
         When ``False``, all ``wait()`` calls are instant no-ops.
         Used for sequential evaluation or ``--no-sync`` mode.
+
+    Notes
+    -----
+    Barriers wait **indefinitely** (no timeout).  If a worker dies, its
+    exception handler calls ``drain_remaining()`` to unblock peers.  If
+    a worker is truly stuck (thread hung), the population layer calls
+    ``abort()`` to break all barriers instantly.  A per-barrier timeout
+    would cause false positives on legitimately slow queries (e.g. 5-min
+    OLAP analytics).
     """
 
     def __init__(
         self,
         num_workers: int,
-        timeout: float = 120.0,
         enabled: bool = True,
     ) -> None:
         self._num_workers = num_workers
-        self._timeout = timeout
         self._enabled = enabled
         self._broken = False
 
-        # Build one threading.Barrier per sub-step.
+        # Build one threading.Barrier per sub-step (no timeout).
         self._barriers: Dict[str, threading.Barrier] = {}
         if self._enabled:
             for name in BARRIER_NAMES:
                 self._barriers[name] = threading.Barrier(
-                    parties=num_workers, timeout=timeout
+                    parties=num_workers
                 )
 
         # Index lookup for drain_remaining().
@@ -280,7 +287,7 @@ class GenerationBarrier:
         if self._enabled:
             for name in BARRIER_NAMES:
                 self._barriers[name] = threading.Barrier(
-                    parties=self._num_workers, timeout=self._timeout
+                    parties=self._num_workers
                 )
 
     def next_barrier_name(self, current: str) -> Optional[str]:
@@ -295,6 +302,5 @@ class GenerationBarrier:
             "enabled" if self.enabled else ("broken" if self._broken else "disabled")
         )
         return (
-            f"GenerationBarrier(workers={self._num_workers}, "
-            f"timeout={self._timeout}s, status={status})"
+            f"GenerationBarrier(workers={self._num_workers}, status={status})"
         )

--- a/src/tuner/core/population.py
+++ b/src/tuner/core/population.py
@@ -367,7 +367,6 @@ class Population:
         parallel: bool = True,
         max_workers: Optional[int] = None,
         synchronize_workers: bool = False,
-        barrier_timeout: float = 120.0,
     ) -> None:
         """
         Evaluate all workers in the current generation.
@@ -393,8 +392,6 @@ class Population:
         synchronize_workers : bool, default=False
             When True and parallel, insert threading.Barrier sync points
             between every sub-step so workers advance in lockstep.
-        barrier_timeout : float, default=120.0
-            Timeout in seconds for each barrier wait.
 
         Example
         -------
@@ -420,7 +417,7 @@ class Population:
                 COLORS.reset,
             )
             disabled_barriers = GenerationBarrier(
-                num_workers=1, timeout=barrier_timeout, enabled=False
+                num_workers=1, enabled=False
             )
 
             for worker in self.workers:
@@ -465,7 +462,6 @@ class Population:
                 # Create batch-local barriers sized to this batch.
                 batch_barriers = GenerationBarrier(
                     num_workers=len(batch),
-                    timeout=barrier_timeout,
                     enabled=use_barriers,
                 )
                 if use_barriers and len(batches) > 1:
@@ -487,45 +483,36 @@ class Population:
                         for worker in batch
                     }
 
-                    # Use a generous timeout to detect stuck workers
-                    # (barrier_timeout * num_barriers + headroom).
-                    collection_timeout = (barrier_timeout * len(batch)) + 60.0
-                    completed_futures = set()
-
-                    try:
-                        for future in as_completed(
-                            future_to_worker, timeout=collection_timeout
-                        ):
-                            completed_futures.add(future)
-                            worker = future_to_worker[future]
-                            try:
-                                metrics, score = future.result()
-                                worker.update_metrics(metrics, score)
-                            except Exception as e:
-                                worker.logger.error("Error evaluating: %s", e)
-                                batch_barriers.abort()  # Abort barriers so remaining threads unblock
-                                raise
-                    except TimeoutError:
-                        # as_completed raised TimeoutError — some futures
-                        # never completed within the generous deadline.
-                        pass
-
-                    # Check for stuck workers that never completed
-                    stuck_futures = set(future_to_worker.keys()) - completed_futures
-                    if stuck_futures:
-                        batch_barriers.abort()
-                        for future in stuck_futures:
-                            stuck_worker = future_to_worker[future]
+                    # Collect results as they complete.
+                    # No timeout — barriers wait indefinitely for peers.
+                    # Dead workers call drain_remaining() from their
+                    # exception handlers; truly stuck workers are handled
+                    # by abort() if needed.
+                    for future in as_completed(future_to_worker):
+                        worker = future_to_worker[future]
+                        try:
+                            metrics, score = future.result()
+                            worker.update_metrics(metrics, score)
                             worker_logger = get_logger(
                                 "PopulationWorker",
-                                worker_id=stuck_worker.worker_id,
+                                worker_id=worker.worker_id,
+                            )
+                            worker_logger.debug(
+                                "score=%.4f, step_count=%s",
+                                score,
+                                worker.step_count,
+                            )
+                        except Exception as e:
+                            worker_logger = get_logger(
+                                "PopulationWorker",
+                                worker_id=worker.worker_id,
                             )
                             worker_logger.error(
-                                "Worker stuck — did not complete within %.0fs; "
-                                "aborting barriers and continuing",
-                                collection_timeout,
+                                "Error evaluating: %s", e
                             )
-                            future.cancel()
+                            # Abort barriers so remaining threads unblock
+                            batch_barriers.abort()
+                            raise
 
         LOGGER.info(
             "%s➤ Evaluation of %d workers is completed.%s",
@@ -937,7 +924,6 @@ class Population:
         require_ready: bool = True,
         max_workers: Optional[int] = None,
         synchronize_workers: bool = False,
-        barrier_timeout: float = 120.0,
     ) -> GenerationResult:
         """
         Execute one complete PBT generation.
@@ -963,8 +949,6 @@ class Population:
         synchronize_workers : bool, default=False
             When True and parallel, insert lockstep barriers between every
             sub-step of worker evaluation for experimental fairness.
-        barrier_timeout : float, default=120.0
-            Timeout per barrier in seconds.
 
         Returns
         -------
@@ -1040,7 +1024,6 @@ class Population:
             parallel=parallel,
             max_workers=max_workers,
             synchronize_workers=synchronize_workers,
-            barrier_timeout=barrier_timeout,
         )
 
         rescued = self.rescue_dead_workers()

--- a/src/tuner/main.py
+++ b/src/tuner/main.py
@@ -820,7 +820,6 @@ class PBTTuner:
             require_ready=True,
             max_workers=self.pbt_config.num_parallel_workers,
             synchronize_workers=self.pbt_config.synchronize_workers,
-            barrier_timeout=self.pbt_config.barrier_timeout_seconds,
         )
         gen_elapsed_time = time.time() - gen_start_time
 

--- a/tests/unit/core/test_barriers.py
+++ b/tests/unit/core/test_barriers.py
@@ -24,7 +24,7 @@ class TestGenerationBarrierBasic:
     def test_all_workers_pass_all_barriers(self):
         """All N threads pass through all 17 barriers without deadlock."""
         num_workers = 3
-        barriers = GenerationBarrier(num_workers=num_workers, timeout=5.0)
+        barriers = GenerationBarrier(num_workers=num_workers)
 
         # Track order: each thread records its passage timestamps
         arrival_times: dict = {name: [] for name in BARRIER_NAMES}
@@ -54,7 +54,7 @@ class TestGenerationBarrierBasic:
     def test_barriers_enforce_ordering(self):
         """Workers at barrier N+1 cannot proceed until all pass barrier N."""
         num_workers = 4
-        barriers = GenerationBarrier(num_workers=num_workers, timeout=5.0)
+        barriers = GenerationBarrier(num_workers=num_workers)
 
         # Worker 0 will be delayed at B1 (connected) while others arrive quickly
         passed_barrier_1: List[int] = []
@@ -95,7 +95,7 @@ class TestGenerationBarrierDisabled:
 
     def test_disabled_barriers_dont_block(self):
         """When enabled=False, wait() returns immediately even with 1 thread."""
-        barriers = GenerationBarrier(num_workers=4, timeout=5.0, enabled=False)
+        barriers = GenerationBarrier(num_workers=4, enabled=False)
 
         # Should not block — only one thread, but barriers are disabled
         for name in BARRIER_NAMES:
@@ -105,7 +105,7 @@ class TestGenerationBarrierDisabled:
 
     def test_disabled_drain_remaining_noop(self):
         """drain_remaining is a no-op when disabled."""
-        barriers = GenerationBarrier(num_workers=4, timeout=5.0, enabled=False)
+        barriers = GenerationBarrier(num_workers=4, enabled=False)
         # Should not raise
         barriers.drain_remaining("connected", worker_id=0)
 
@@ -113,22 +113,29 @@ class TestGenerationBarrierDisabled:
 class TestGenerationBarrierBrokenRecovery:
     """Test graceful degradation when a barrier breaks."""
 
-    def test_timeout_sets_broken_flag(self):
-        """When a barrier times out, all subsequent waits are no-ops."""
-        # 2 workers, but only 1 will arrive → timeout
-        barriers = GenerationBarrier(num_workers=2, timeout=0.5)
+    def test_abort_sets_broken_flag(self):
+        """When abort() is called, all subsequent waits are no-ops."""
+        # 2 workers, but only 1 will arrive — abort unblocks it.
+        barriers = GenerationBarrier(num_workers=2)
 
-        results = {"timed_out": False, "subsequent_noop": False}
+        results = {"subsequent_noop": False}
 
         def lone_worker():
             barriers.wait("connected", worker_id=0)
-            # After timeout/broken, next barrier should be a no-op
+            # After abort/broken, next barrier should be a no-op
             barriers.wait("config_applied", worker_id=0)
             results["subsequent_noop"] = True
 
+        def aborter():
+            time.sleep(0.1)
+            barriers.abort()
+
         t = threading.Thread(target=lone_worker)
+        t_abort = threading.Thread(target=aborter)
         t.start()
-        t.join(timeout=3.0)
+        t_abort.start()
+        t.join(timeout=5.0)
+        t_abort.join(timeout=5.0)
 
         assert barriers.broken
         assert results["subsequent_noop"]
@@ -136,19 +143,23 @@ class TestGenerationBarrierBrokenRecovery:
     def test_drain_remaining_unblocks_peers(self):
         """When one worker drains, other workers waiting are unblocked."""
         num_workers = 2
-        barriers = GenerationBarrier(num_workers=num_workers, timeout=2.0)
+        barriers = GenerationBarrier(num_workers=num_workers)
 
         worker_0_passed = threading.Event()
         worker_1_passed = threading.Event()
 
         def worker_0():
-            """Normal worker that waits at 'connected'."""
-            barriers.wait("connected", worker_id=0)
+            """Normal worker that passes through ALL barriers."""
+            for name in BARRIER_NAMES:
+                barriers.wait(name, worker_id=0)
             worker_0_passed.set()
 
         def worker_1():
-            """Crashed worker: drains all barriers starting from 'connected'."""
-            # Simulate crash: drain instead of waiting
+            """Crashed worker: drains all barriers starting from 'connected'.
+
+            This simulates a worker that failed before reaching any barrier
+            and needs to release all of them so worker_0 can proceed.
+            """
             barriers.drain_remaining("connected", worker_id=1)
             worker_1_passed.set()
 
@@ -157,8 +168,8 @@ class TestGenerationBarrierBrokenRecovery:
         t0.start()
         t1.start()
 
-        t0.join(timeout=5.0)
-        t1.join(timeout=5.0)
+        t0.join(timeout=10.0)
+        t1.join(timeout=10.0)
 
         # Both workers should have passed (worker_1 via drain)
         assert worker_0_passed.is_set()
@@ -171,7 +182,7 @@ class TestGenerationBarrierReset:
     def test_reset_allows_reuse(self):
         """After reset, barriers can be used again for a new generation."""
         num_workers = 2
-        barriers = GenerationBarrier(num_workers=num_workers, timeout=2.0)
+        barriers = GenerationBarrier(num_workers=num_workers)
 
         def run_one_barrier():
             """Have all workers pass through the first barrier."""
@@ -209,28 +220,28 @@ class TestGenerationBarrierEdgeCases:
 
     def test_invalid_barrier_name_raises(self):
         """Passing an unknown barrier name raises ValueError."""
-        barriers = GenerationBarrier(num_workers=1, timeout=1.0)
+        barriers = GenerationBarrier(num_workers=1)
         with pytest.raises(ValueError, match="Unknown barrier name"):
             barriers.wait("nonexistent_barrier", worker_id=0)
 
     def test_next_barrier_name(self):
         """next_barrier_name returns correct successor."""
-        barriers = GenerationBarrier(num_workers=1, timeout=1.0, enabled=False)
+        barriers = GenerationBarrier(num_workers=1, enabled=False)
         assert barriers.next_barrier_name("connected") == "config_applied"
         assert barriers.next_barrier_name("disconnected") is None
         assert barriers.next_barrier_name("unknown") is None
 
     def test_repr(self):
         """repr shows meaningful status."""
-        b1 = GenerationBarrier(num_workers=3, timeout=60.0, enabled=True)
+        b1 = GenerationBarrier(num_workers=3, enabled=True)
         assert "enabled" in repr(b1)
 
-        b2 = GenerationBarrier(num_workers=3, timeout=60.0, enabled=False)
+        b2 = GenerationBarrier(num_workers=3, enabled=False)
         assert "disabled" in repr(b2)
 
     def test_single_worker_passes_instantly(self):
         """With num_workers=1, barriers pass immediately (no waiting)."""
-        barriers = GenerationBarrier(num_workers=1, timeout=1.0)
+        barriers = GenerationBarrier(num_workers=1)
 
         start = time.monotonic()
         for name in BARRIER_NAMES:
@@ -243,7 +254,7 @@ class TestGenerationBarrierEdgeCases:
     def test_abort_unblocks_waiting_threads(self):
         """abort() instantly breaks all barriers, unblocking waiters."""
         num_workers = 3
-        barriers = GenerationBarrier(num_workers=num_workers, timeout=30.0)
+        barriers = GenerationBarrier(num_workers=num_workers)
 
         unblocked = threading.Event()
 
@@ -271,7 +282,7 @@ class TestGenerationBarrierEdgeCases:
 
     def test_abort_on_already_broken_is_noop(self):
         """Calling abort() on a broken barrier set is harmless."""
-        barriers = GenerationBarrier(num_workers=2, timeout=1.0)
+        barriers = GenerationBarrier(num_workers=2)
         barriers.abort()
         assert barriers.broken
         barriers.abort()  # Should not raise
@@ -279,7 +290,7 @@ class TestGenerationBarrierEdgeCases:
 
     def test_abort_on_disabled_is_noop(self):
         """Calling abort() on a disabled barrier set is harmless."""
-        barriers = GenerationBarrier(num_workers=2, timeout=1.0, enabled=False)
+        barriers = GenerationBarrier(num_workers=2, enabled=False)
         barriers.abort()
         assert not barriers.broken  # Stays not-broken since disabled
 
@@ -295,7 +306,7 @@ class TestHybridModeBatching:
     def test_batch_sized_barrier_does_not_deadlock(self):
         """A barrier sized to batch_size (< population) completes without deadlock."""
         batch_size = 2
-        barriers = GenerationBarrier(num_workers=batch_size, timeout=3.0)
+        barriers = GenerationBarrier(num_workers=batch_size)
 
         results = []
         lock = threading.Lock()
@@ -330,7 +341,9 @@ class TestHybridModeBatching:
         ]
 
         for batch in batches:
-            batch_barriers = GenerationBarrier(num_workers=len(batch), timeout=3.0)
+            batch_barriers = GenerationBarrier(
+                num_workers=len(batch)
+            )
 
             def worker_fn(wid: int, barriers=batch_barriers):
                 for name in BARRIER_NAMES:
@@ -349,7 +362,7 @@ class TestHybridModeBatching:
     def test_dead_worker_does_not_deadlock_batch(self):
         """One worker dies mid-batch; drain_remaining unblocks the other."""
         batch_size = 2
-        barriers = GenerationBarrier(num_workers=batch_size, timeout=3.0)
+        barriers = GenerationBarrier(num_workers=batch_size)
 
         results = []
         lock = threading.Lock()


### PR DESCRIPTION
Queries can legitimately take 5+ minutes (OLAP workloads). Dead workers are already handled by drain_remaining() from exception handlers and abort() from population.py, making the timeout both redundant and harmful (false positives).

- Remove barrier_timeout_seconds from TunerConfig
- Remove timeout param from GenerationBarrier constructor
- Simplify as_completed() loop (no collection_timeout)
- Update tests to reflect no-timeout behavior