### PR TITLE
feat(tuner): Add manual worker resource allocation and fix precedence

### DIFF
--- a/.claude/skills/postgresql-knob-tuning/SKILL.md
+++ b/.claude/skills/postgresql-knob-tuning/SKILL.md
@@ -37,7 +37,7 @@ Examples:
 - `work_mem = 0.02` → 2% of detected RAM
 - `max_parallel_workers = 0.5` → 50% of detected CPU cores
 
-Fractions are stored in population state and only resolved to absolute values at runtime for the current hardware. This enables transfer learning and warm-start portability.
+Fractions are stored in population state and only resolved to absolute values at runtime against the `WorkerResources` for the given worker. These resources are either auto-detected from host limits (divided by number of parallel workers) or manually allocated (e.g., via `--worker-ram` and `--worker-cpus`). This enables transfer learning and warm-start portability.
 
 ### Cross-Knob Aggregate Validation
 After sampling, perturbation, or exploit copy, validate:

--- a/src/scripts/bo_baseline/config.py
+++ b/src/scripts/bo_baseline/config.py
@@ -69,6 +69,8 @@ class BOConfig:
     batched_bo: bool = False
     pbt_worker_resources: Optional[Dict[str, Any]] = None
     resource_division: int = 1
+    worker_ram: Optional[str] = None
+    worker_cpus: Optional[int] = None
 
     # Scoring policy
     # Available options:
@@ -312,6 +314,8 @@ class BOConfig:
             if hasattr(args, "snapshot_restore_interval")
             and args.snapshot_restore_interval is not None
             else base_config.snapshot_restore_interval,
+            worker_ram=args.worker_ram if hasattr(args, "worker_ram") else None,
+            worker_cpus=args.worker_cpus if hasattr(args, "worker_cpus") else None,
         )
 
         if args.pbt_session:

--- a/src/scripts/bo_baseline/runner.py
+++ b/src/scripts/bo_baseline/runner.py
@@ -25,6 +25,7 @@ from src.utils.metrics import WorkloadType, create_metric_config
 from src.utils.hardware_info import (
     get_system_info,
     detect_worker_resources,
+    resolve_manual_worker_resources,
     WorkerResources,
 )
 from src.utils.logger import setup_logging, get_logger, log_section_header
@@ -73,7 +74,7 @@ class BOBaselineRunner:
         # Collect system info
         self.system_info = get_system_info(data_path=self.data_root)
 
-        # Resource equalization: use PBT-derived resources if available, else divide host resources
+        # Resource equalization: PBT-derived > manual CLI override > auto detection
         if config.pbt_worker_resources:
             self.worker_resources = WorkerResources(
                 ram_bytes=int(config.pbt_worker_resources.get("ram_bytes", 0)),
@@ -82,6 +83,18 @@ class BOBaselineRunner:
             )
             self.logger.info(
                 "Using PBT-derived per-worker resources: "
+                f"{self.worker_resources.cpu_cores} cores, "
+                f"{self.worker_resources.ram_bytes / (1024**3):.1f} GB RAM"
+            )
+        elif config.worker_ram is not None or config.worker_cpus is not None:
+            self.worker_resources = resolve_manual_worker_resources(
+                worker_ram=config.worker_ram,
+                worker_cpus=config.worker_cpus,
+                num_workers=config.resource_division,
+                data_path=self.data_root,
+            )
+            self.logger.info(
+                "Using manual per-worker resources: "
                 f"{self.worker_resources.cpu_cores} cores, "
                 f"{self.worker_resources.ram_bytes / (1024**3):.1f} GB RAM"
             )
@@ -820,6 +833,26 @@ def main():
         type=int,
         default=None,
         help="Divides host capacity by this number to determine instance resources. If a PBT session is provided, this automatically takes the PBT session's parallel worker count.",
+    )
+    parser.add_argument(
+        "--worker-ram",
+        type=str,
+        default=None,
+        help=(
+            "RAM to allocate per worker (e.g., '3G', '512M', '1073741824'). "
+            "When set, bypasses auto-detection. Total across all workers must "
+            "not exceed host physical RAM."
+        ),
+    )
+    parser.add_argument(
+        "--worker-cpus",
+        type=int,
+        default=None,
+        help=(
+            "CPU cores to allocate per worker. "
+            "When set, bypasses auto-detection. Total across all workers must "
+            "not exceed host physical CPU cores."
+        ),
     )
     parser.add_argument(
         "--scoring-policy",

--- a/src/tuner/config/knob_space.py
+++ b/src/tuner/config/knob_space.py
@@ -321,13 +321,19 @@ class KnobSpace:
 
         filtered_count = len(self.knobs) - len(runtime_knobs)
         if filtered_count > 0:
-            LOGGER.debug(
-                "➤ Created ONLINE knob view: %s%d%s runtime knobs %s(filtered %d knob(s))%s",
+            LOGGER.info(
+                "➤ Created ONLINE knob view by filtering %d `restart-required` knob(s):"
+                " %s%d%s runtime knobs remain",
+                filtered_count,
                 COLORS.bold,
                 len(runtime_knobs),
                 COLORS.reset,
-                COLORS.italic,
-                filtered_count,
+            )
+        else:
+            LOGGER.info(
+                "➤ ONLINE knob view active: all %s%d%s knobs are runtime-safe (0 filtered)",
+                COLORS.bold,
+                len(runtime_knobs),
                 COLORS.reset,
             )
 

--- a/src/tuner/main.py
+++ b/src/tuner/main.py
@@ -101,6 +101,7 @@ from src.utils.hardware_info import (
     get_system_info,
     log_system_info,
     detect_worker_resources,
+    resolve_manual_worker_resources,
 )
 from src.utils.types import TuningMode
 
@@ -306,9 +307,6 @@ class PBTTuner:
 
         self.full_knob_space = self.knob_space
         if self.pbt_config.benchmark_config.tuning_mode == TuningMode.ONLINE:
-            LOGGER.info(
-                "Creating ONLINE knob view by filtering out `restart-required` knobs..."
-            )
             self.knob_space = self.knob_space.create_online_view()
 
         LOGGER.info(
@@ -317,10 +315,22 @@ class PBTTuner:
             self.pbt_config.num_parallel_workers,
             COLORS.reset,
         )
-        self.worker_resources = detect_worker_resources(
-            self.pbt_config.num_parallel_workers,
-            data_path=self.data_root,
-        )
+        
+        worker_ram_str = kwargs.get("worker_ram")
+        worker_cpus = kwargs.get("worker_cpus")
+
+        if worker_ram_str is not None or worker_cpus is not None:
+            self.worker_resources = resolve_manual_worker_resources(
+                worker_ram=worker_ram_str,
+                worker_cpus=worker_cpus,
+                num_workers=self.pbt_config.num_parallel_workers,
+                data_path=self.data_root,
+            )
+        else:
+            self.worker_resources = detect_worker_resources(
+                self.pbt_config.num_parallel_workers,
+                data_path=self.data_root,
+            )
 
         LOGGER.info(
             "Resolving hardware-relative knob ranges based on detected worker resources..."
@@ -1507,6 +1517,27 @@ on your hardware, configuration, and workload/benchmark.
     )
 
     config_group.add_argument(
+        "--worker-ram",
+        type=str,
+        default=None,
+        help=(
+            "RAM to allocate per worker (e.g., '3G', '512M', '1073741824'). "
+            "When set, bypasses auto-detection. Total across all workers must "
+            "not exceed host physical RAM."
+        ),
+    )
+    config_group.add_argument(
+        "--worker-cpus",
+        type=int,
+        default=None,
+        help=(
+            "CPU cores to allocate per worker. "
+            "When set, bypasses auto-detection. Total across all workers must "
+            "not exceed host physical CPU cores."
+        ),
+    )
+
+    config_group.add_argument(
         "--tuning-mode",
         type=str,
         default=None,
@@ -1905,6 +1936,8 @@ def main():
             disable_early_stopping=args.disable_early_stopping,
             ablation_variable=args.ablation_variable,
             ablation_value=args.ablation_value,
+            worker_ram=args.worker_ram,
+            worker_cpus=args.worker_cpus,
         )
 
         tuner.run()

--- a/src/utils/hardware_info.py
+++ b/src/utils/hardware_info.py
@@ -15,6 +15,7 @@ import os
 import platform
 import shutil
 import subprocess
+import re
 from pathlib import Path
 from typing import Any, Dict, Optional
 import math
@@ -276,6 +277,113 @@ def detect_worker_resources(
     return WorkerResources(
         ram_bytes=worker_ram, cpu_cores=worker_cpu, disk_type=disk_type
     )
+
+
+def parse_ram_value(value: str) -> int:
+    """Parse a human-readable RAM string into bytes."""
+    value = str(value).strip().upper()
+    match = re.match(r"^(\d+)\s*([KMGTPE]?)[B]?$", value)
+    if not match:
+        raise ValueError(f"Invalid RAM value format: {value}")
+    
+    number = int(match.group(1))
+    suffix = match.group(2)
+    
+    multipliers = {
+        "": 1,
+        "K": 1024,
+        "M": 1024**2,
+        "G": 1024**3,
+        "T": 1024**4,
+        "P": 1024**5,
+        "E": 1024**6,
+    }
+    return number * multipliers[suffix]
+
+
+def resolve_manual_worker_resources(
+    worker_ram: Optional[str] = None,
+    worker_cpus: Optional[int] = None,
+    num_workers: int = 1,
+    data_path: Optional[Path] = None,
+) -> WorkerResources:
+    """
+    Resolve manual worker resources and validate against host limits.
+    
+    Allows up to 95% of host capacity. Warns if > 80% is used.
+    Falls back entirely to auto-detection if > 95% is requested.
+    """
+    if data_path is not None:
+        disk_type = detect_disk_type_for_path(data_path)
+    else:
+        disk_type = detect_disk_type()
+
+    mem = psutil.virtual_memory()
+    total_ram = mem.total
+
+    try:
+        total_cpus = len(psutil.Process().cpu_affinity())
+    except (AttributeError, NotImplementedError):
+        total_cpus = psutil.cpu_count(logical=True) or 1
+
+    # Fallback auto-detection values
+    usable_ram = int(total_ram * 0.8)
+    usable_cpu = total_cpus * 0.8
+    auto_ram = max(100 * 1024 * 1024, int(usable_ram / num_workers))
+    auto_cpu = max(1, math.floor(usable_cpu / num_workers))
+
+    resolved_ram = auto_ram
+    if worker_ram is not None:
+        resolved_ram = parse_ram_value(worker_ram)
+
+    resolved_cpu = auto_cpu
+    if worker_cpus is not None:
+        resolved_cpu = int(worker_cpus)
+
+    total_req_ram = resolved_ram * num_workers
+    total_req_cpu = resolved_cpu * num_workers
+
+    # Validation logic (95% cap)
+    ram_exceeded = total_req_ram > (total_ram * 0.95)
+    cpu_exceeded = total_req_cpu > (total_cpus * 0.95)
+
+    if ram_exceeded or cpu_exceeded:
+        LOGGER.warning(
+            "Manual resource allocation (%d workers \u00d7 %s bytes RAM, %d CPUs) "
+            "exceeds 95%% of host physical capacity (RAM: %s bytes, CPU: %d). "
+            "Falling back to auto-detected resources.",
+            num_workers,
+            resolved_ram,
+            resolved_cpu,
+            total_ram,
+            total_cpus,
+        )
+        LOGGER.debug(
+            "➤ Worker resources allocated (fallback): RAM=%s bytes, CPU=%s cores, Disk=%s",
+            auto_ram,
+            auto_cpu,
+            disk_type,
+        )
+        return WorkerResources(ram_bytes=auto_ram, cpu_cores=auto_cpu, disk_type=disk_type)
+
+    # Warning logic (> 80% and <= 95%)
+    ram_warn = total_req_ram > (total_ram * 0.80)
+    cpu_warn = total_req_cpu > (total_cpus * 0.80)
+
+    if ram_warn or cpu_warn:
+        LOGGER.warning(
+            "Manual resource allocation uses more than 80%% of host capacity. "
+            "This may bottleneck the host machine and tuning processes. "
+            "Proceeding with requested allocation."
+        )
+        
+    LOGGER.info(
+        "Using manual worker resources: RAM=%s bytes, CPU=%s cores, Disk=%s",
+        resolved_ram,
+        resolved_cpu,
+        disk_type,
+    )
+    return WorkerResources(ram_bytes=resolved_ram, cpu_cores=resolved_cpu, disk_type=disk_type)
 
 
 def _detect_disk_type_linux(device_path: Optional[str] = None) -> str:

--- a/tests/unit/utils/test_hardware_info.py
+++ b/tests/unit/utils/test_hardware_info.py
@@ -167,3 +167,148 @@ def test_system_info_dict_keys(_mock_pg_version):
     assert isinstance(sys_info, dict)
     for key in expected_keys:
         assert key in sys_info
+
+
+import pytest
+from src.utils.hardware_info import parse_ram_value, resolve_manual_worker_resources
+
+
+def test_parse_ram_value():
+    assert parse_ram_value("3G") == 3221225472
+    assert parse_ram_value("512M") == 536870912
+    assert parse_ram_value("1024K") == 1048576
+    assert parse_ram_value("3221225472") == 3221225472
+    assert parse_ram_value("5GB") == 5368709120
+    assert parse_ram_value("10 MB") == 10485760
+    assert parse_ram_value("5") == 5
+    with pytest.raises(ValueError):
+        parse_ram_value("invalid")
+
+
+@patch("src.utils.hardware_info.detect_disk_type", return_value="SSD")
+@patch("src.utils.hardware_info.psutil.virtual_memory")
+@patch("src.utils.hardware_info.psutil.cpu_count")
+@patch("src.utils.hardware_info.psutil.Process")
+def test_resolve_manual_worker_resources_valid(
+    mock_process,
+    mock_cpu_count,
+    mock_virtual_memory,
+    _mock_disk_type,
+):
+    class MockMem:
+        total = 16 * 1024**3
+    mock_virtual_memory.return_value = MockMem()
+
+    class MockProcess:
+        def cpu_affinity(self):
+            return list(range(8))
+    mock_process.return_value = MockProcess()
+    mock_cpu_count.return_value = 8
+
+    wr = resolve_manual_worker_resources(worker_ram="2G", worker_cpus=1, num_workers=4)
+    assert wr.ram_bytes == 2 * 1024**3
+    assert wr.cpu_cores == 1
+    assert wr.disk_type == "SSD"
+
+
+@patch("src.utils.hardware_info.detect_disk_type", return_value="SSD")
+@patch("src.utils.hardware_info.psutil.virtual_memory")
+@patch("src.utils.hardware_info.psutil.cpu_count")
+@patch("src.utils.hardware_info.psutil.Process")
+def test_resolve_manual_worker_resources_exceeds_ram(
+    mock_process,
+    mock_cpu_count,
+    mock_virtual_memory,
+    _mock_disk_type,
+):
+    class MockMem:
+        total = 16 * 1024**3
+    mock_virtual_memory.return_value = MockMem()
+
+    class MockProcess:
+        def cpu_affinity(self):
+            return list(range(8))
+    mock_process.return_value = MockProcess()
+    mock_cpu_count.return_value = 8
+
+    # 5G * 4 = 20G > 16G -> Fallback
+    wr = resolve_manual_worker_resources(worker_ram="5G", worker_cpus=2, num_workers=4)
+    expected_auto_ram = int((16 * 1024**3 * 0.8) / 4)
+    assert wr.ram_bytes == expected_auto_ram
+
+
+@patch("src.utils.hardware_info.detect_disk_type", return_value="SSD")
+@patch("src.utils.hardware_info.psutil.virtual_memory")
+@patch("src.utils.hardware_info.psutil.cpu_count")
+@patch("src.utils.hardware_info.psutil.Process")
+def test_resolve_manual_worker_resources_exceeds_cpu(
+    mock_process,
+    mock_cpu_count,
+    mock_virtual_memory,
+    _mock_disk_type,
+):
+    class MockMem:
+        total = 16 * 1024**3
+    mock_virtual_memory.return_value = MockMem()
+
+    class MockProcess:
+        def cpu_affinity(self):
+            return list(range(8))
+    mock_process.return_value = MockProcess()
+    mock_cpu_count.return_value = 8
+
+    # 3 CPUs * 4 = 12 CPUs > 8 CPUs -> Fallback
+    wr = resolve_manual_worker_resources(worker_ram="2G", worker_cpus=3, num_workers=4)
+    expected_auto_cpu = max(1, int((8 * 0.8) / 4))
+    assert wr.cpu_cores == expected_auto_cpu
+
+
+@patch("src.utils.hardware_info.detect_disk_type", return_value="SSD")
+@patch("src.utils.hardware_info.psutil.virtual_memory")
+@patch("src.utils.hardware_info.psutil.cpu_count")
+@patch("src.utils.hardware_info.psutil.Process")
+def test_resolve_manual_worker_resources_partial_override(
+    mock_process,
+    mock_cpu_count,
+    mock_virtual_memory,
+    _mock_disk_type,
+):
+    class MockMem:
+        total = 16 * 1024**3
+    mock_virtual_memory.return_value = MockMem()
+
+    class MockProcess:
+        def cpu_affinity(self):
+            return list(range(8))
+    mock_process.return_value = MockProcess()
+    mock_cpu_count.return_value = 8
+
+    wr = resolve_manual_worker_resources(worker_ram="2G", worker_cpus=None, num_workers=4)
+    expected_auto_cpu = max(1, int((8 * 0.8) / 4))
+    assert wr.ram_bytes == 2 * 1024**3
+    assert wr.cpu_cores == expected_auto_cpu
+
+
+@patch("src.utils.hardware_info.detect_disk_type_for_path", return_value="HDD")
+@patch("src.utils.hardware_info.psutil.virtual_memory")
+@patch("src.utils.hardware_info.psutil.cpu_count")
+@patch("src.utils.hardware_info.psutil.Process")
+def test_resolve_manual_worker_resources_disk_type_always_inferred(
+    mock_process,
+    mock_cpu_count,
+    mock_virtual_memory,
+    _mock_disk_type,
+):
+    class MockMem:
+        total = 16 * 1024**3
+    mock_virtual_memory.return_value = MockMem()
+
+    class MockProcess:
+        def cpu_affinity(self):
+            return list(range(8))
+    mock_process.return_value = MockProcess()
+    mock_cpu_count.return_value = 8
+
+    from pathlib import Path
+    wr = resolve_manual_worker_resources(worker_ram="2G", worker_cpus=1, num_workers=4, data_path=Path("/tmp/data"))
+    assert wr.disk_type == "HDD"


### PR DESCRIPTION
## Description

This PR introduces the ability to manually override worker hardware resource allocations (RAM and CPUs) via CLI arguments for both the main PBT Tuner and the BO Baseline Runner, rather than strictly relying on auto-detection.

It includes several safety and boundary checks:
- Enforces an absolute safety cap of **95%** of host machine physical capacity. Allocations exceeding this will drop a warning and dynamically fall back to the auto-detected split limits to prevent host thrashing.
- Emits a warning if user-requested resources sit between **80% and 95%** of the host capacity (to signal potential overhead risks while proceeding with execution).
- Corrects a configuration precedence bug in the BO Baseline runner to explicitly honor `PBT Session -> CLI Argument -> Auto-detection` fallback routing.
- Upgrades `parse_ram_value` logic to robustly parse various human-readable RAM expressions (e.g. `5G`, `5GB`, `10 MB`).

## Changes Made

- **`src/utils/hardware_info.py`**: Added `parse_ram_value` and `resolve_manual_worker_resources`. Upgraded the byte-parsing regex to support `B` suffixes and whitespace.
- **`src/tuner/main.py`**: Intercepted `--worker-ram` and `--worker-cpus` to pass to the `PBTTuner` instantiation parameters.
- **`src/scripts/bo_baseline/config.py` & `runner.py`**: Brought baseline configuration up to speed with PBT resource arguments, while patching the precedence resolution hierarchy.
- **`src/tuner/config/knob_space.py`**: Cleaned up dynamic knob space generation logs and view initialization filters.
- **`tests/unit/utils/test_hardware_info.py`**: Implemented robust boundary unit tests spanning 80%, 95% threshold fallbacks, and multi-format RAM string assertions.
- **Documentation**: Synchronized `README.md` (Quick Start examples) and `SKILL.md` fraction representation rules with the new configurations.

## Testing & Verification

- [x] Validated via `pytest` over isolated environment boundary cases.
- [x] Validated precedence mapping logic internally within PBT instantiation runs and explicit BO runner loads.
- [x] Pre-flight bug scan and manual self-review passed cleanly without any side effects.