### PR TITLE
Timing-instrumentation follow-ups: docker auto.conf fix, BO sequential overhead, OFFLINE default, cloud-matrix expansion

### DIFF
--- a/.agents/workflows/run-pbt-experiment.md
+++ b/.agents/workflows/run-pbt-experiment.md
@@ -5,9 +5,11 @@ description: How to launch a PBT tuning experiment end-to-end
 # Run PBT Experiment
 
 ## Prerequisites
-1. PostgreSQL is installed and accessible via `pg_ctl` / `initdb`
-2. Python environment activated with all dependencies
-3. Sysbench installed (for OLTP) or TPC-H `dbgen` built (for OLAP)
+1. PostgreSQL is installed and accessible via `pg_ctl` / `initdb` (bare-metal),
+   or Docker is available (default backend)
+2. Python environment activated with all dependencies (`./scripts/bootstrap.sh`)
+3. Sysbench installed (for OLTP `--benchmark sysbench`) or TPC-H `dbgen` built
+   (for OLAP `--benchmark tpch`)
 4. `.env` file configured with database credentials
 
 ## Steps
@@ -26,63 +28,79 @@ python -c "import src.tuner; print('OK')"
 
 | Parameter | Options | Default |
 |-----------|---------|---------|
-| `--workload` | `oltp`, `olap`, `mixed` | `oltp` |
-| `--tier` | `minimal`, `core`, `standard`, `extensive` | `core` |
-| `--population-size` | 4-16 | 8 |
-| `--generations` | 5-50 | 20 |
-| `--seed` | any integer | 42 |
+| `--workload` / `--benchmark` | `oltp`/`olap`/`mixed` or `sysbench`/`tpch` | `oltp` |
+| `--tier` | `minimal`, `core`, `standard`, `extensive` | `minimal` |
+| `--population` | 4-16 | (config preset) |
+| `--generations` | 5-50 | (config preset) |
+| `--random-seed` | any integer | unset |
+| `--config` | `rapid`, `standard`, `thorough`, `research`, `extreme` | `standard` |
+
+Note: `--workload`, `--workload-file`, and `--benchmark` are mutually exclusive.
+Use `--benchmark sysbench` (with `--sysbench-workload`) or `--benchmark tpch` for
+external benchmark binaries; use `--workload {oltp,olap,mixed}` for built-in JSON
+workloads.
 
 ### 3. Run Single Experiment
 ```bash
 python -m src.tuner.main \
-    --workload oltp \
+    --benchmark sysbench \
+    --sysbench-workload oltp_read_write \
     --tier core \
-    --population-size 8 \
+    --population 8 \
     --generations 20 \
-    --seed 42 \
-    --output results/sysbench/pbt_runs/core/seed_42/
+    --random-seed 42 \
+    --output-dir results/oltp/oltp_read_write/pbt_runs/core/seed_42/
 ```
 
 ### 4. Run Multi-Seed Campaign
-Run with each of the 5 standard seeds: `42, 123, 456, 789, 1024`
+The five-seed standard campaign uses seeds `42, 123, 456, 789, 1024`.
 
 ```bash
 for SEED in 42 123 456 789 1024; do
     python -m src.tuner.main \
-        --workload oltp \
+        --benchmark sysbench \
+        --sysbench-workload oltp_read_write \
         --tier core \
-        --population-size 8 \
+        --population 8 \
         --generations 20 \
-        --seed $SEED \
-        --output results/sysbench/pbt_runs/core/seed_${SEED}/
+        --random-seed $SEED \
+        --output-dir results/oltp/oltp_read_write/pbt_runs/core/seed_${SEED}/
 done
 ```
 
+The repository also ships `scripts/run_tier{1,2,3}.sh` and `scripts/run_all.sh`
+as ready-made experiment-matrix wrappers if you prefer not to script the loop
+yourself.
+
 ### 5. Run Baseline (Default PG Config)
+The tuner CLI does not have a `--baseline-only` flag. Default-vs-tuned baselines
+are produced post-hoc by `python -m src.evaluation` against an existing PBT
+session JSON. The evaluator runs both the default config and the tuned config
+under identical conditions.
+
 ```bash
-python -m src.tuner.main \
-    --workload oltp \
-    --tier minimal \
-    --baseline-only \
-    --repetitions 5 \
-    --output results/sysbench/baselines/
+python -m src.evaluation \
+    --session results/oltp/oltp_read_write/pbt_runs/core/seed_42/pbt_results_YYYYMMDD_HHMM.json \
+    --repetitions 5
 ```
 
 ### 6. Warm-Start (Transfer Learning)
 ```bash
 python -m src.tuner.main \
-    --workload oltp \
+    --benchmark sysbench \
+    --sysbench-workload oltp_read_write \
     --tier standard \
-    --warm-start results/best_configs/best_config_XXXX.json \
-    --population-size 8 \
+    --warm-start results/oltp/oltp_read_write/pbt_runs/core/best_configs/best_config_YYYYMMDD_HHMM.json \
+    --population 8 \
     --generations 15 \
-    --seed 42 \
-    --output results/sysbench/pbt_runs/standard/warm_start/
+    --random-seed 42 \
+    --output-dir results/oltp/oltp_read_write/pbt_runs/standard/warm_start/
 ```
 
 ## After the Run
 
-1. Results saved to `--output` directory as `results_{timestamp}.json`
-2. Best config saved to `results/best_configs/`
-3. Check `generation_history` in results JSON for convergence
-4. Use `results-and-visualization` skill for plotting
+1. Results saved under `--output-dir` as `pbt_results_{timestamp}.json`
+2. Best config saved to `results/{olap|oltp/{workload}}/pbt_runs/{tier}/best_configs/`
+3. Check `generation_history` in the results JSON for convergence
+4. Use the `results-and-visualization` skill (and `python -m src.visualization`)
+   for plotting

--- a/.claude/skills/benchmark-orchestration/SKILL.md
+++ b/.claude/skills/benchmark-orchestration/SKILL.md
@@ -2,13 +2,11 @@
 name: benchmark-orchestration
 description: >
   Sysbench OLTP and TPC-H OLAP benchmark execution patterns, multi-instance PostgreSQL
-  management, snapshot management, the full WorkloadEvaluator pipeline, and performance
+  management, snapshot management, the full WorkloadOrchestrator pipeline, and performance
   measurement workflows. Use this skill when working on benchmark executors, evaluation
   pipeline, instance management, snapshot restoration, configuration application, restart
-  management, system metrics collection, or any code in src/benchmarks/,
-  src/tuner/evaluator/, src/tuner/utils/instance_manager.py,
-  src/tuner/utils/snapshot_manager.py, src/tuner/utils/restart_manager.py,
-  src/tuner/utils/applicator.py, or src/tuner/utils/postgres_instance.py.
+  policy, system metrics collection, or any code in src/benchmarks/, src/tuner/benchmark/,
+  src/utils/applicator.py, or src/utils/environments/.
 ---
 
 # Benchmark Orchestration Patterns
@@ -22,7 +20,7 @@ evaluate_worker(worker)
     ├── apply_configuration(worker.knob_config)
     │   ├── Separate knobs by context (postmaster vs sighup)
     │   ├── Write ALL knobs to postgresql.conf
-    │   ├── If postmaster knobs changed → _perform_restart()
+    │   ├── If postmaster knobs changed → restart via environment backend
     │   ├── Else if sighup knobs changed → pg_ctl reload
     │   └── _verify_configuration() via SELECT current_setting()
     ├── _ensure_benchmark_ready()
@@ -36,14 +34,18 @@ evaluate_worker(worker)
     └── Return (PerformanceMetrics, score)
 ```
 
-All of this is orchestrated by `WorkloadEvaluator` in `src/tuner/evaluator/evaluator.py`.
+All of this is orchestrated by `WorkloadOrchestrator` in `src/tuner/benchmark/orchestrator.py`.
+Per-worker timing is recorded via a `TimingRecorder` local to `evaluate_worker` and attached
+as `worker.last_eval_timing`.
 
 ## Sysbench OLTP
 
 - **CLI pattern:** `prepare → run (--warmup=N) → cleanup`
 - **Implementation:** Calls native `sysbench` binary via `subprocess.run()`
 - **Output parsing:** Regex extraction for TPS, p95 latency, error rate
-- **Location:** `src/benchmarks/sysbench/executor.py`
+- **Output partitioning:** Results split by workload mode under
+  `results/oltp/{sysbench_workload}/...`
+- **Location:** `src/benchmarks/sysbench/`
 
 ## TPC-H OLAP
 
@@ -52,7 +54,7 @@ All of this is orchestrated by `WorkloadEvaluator` in `src/tuner/evaluator/evalu
 - **Design choice:** No Throughput Test (consistent with OtterTune, CDBTune papers)
 - **Data generation:** `dbgen` → COPY into PostgreSQL tables
 - **Statement timeout:** Scales dynamically with `scale_factor` to prevent hangs
-- **Location:** `src/benchmarks/tpch/executor.py`
+- **Location:** `src/benchmarks/tpch/`
 
 ## Multi-Instance PostgreSQL Management
 
@@ -62,10 +64,12 @@ Each PBT worker gets a dedicated PostgreSQL instance to enable true parallel eva
 |-----------|--------|
 | **Port scheme** | `base_port + worker_id` (default base: 5440) |
 | **Data dirs** | `{pg_data_base}/worker_{worker_id}/` |
+| **Backends** | `DockerEnvironment` (with CPU subset isolation, ADR-004) or `BareMetalEnvironment` |
 | **Creation** | `initdb → configure postgresql.conf → pg_ctl start` |
 | **Auto-detect** | Finds `pg_ctl`/`initdb` via PATH or common install dirs |
 | **Reuse** | Reuses existing data dirs if already initialized |
-| **Location** | `src/tuner/utils/instance_manager.py` |
+| **Resource slicing** | Manual override via `--worker-ram` / `--worker-cpus` |
+| **Location** | `src/utils/environments/` |
 
 ## Snapshot Management
 
@@ -77,20 +81,30 @@ Prevents data drift between generations (sysbench DML modifies tables):
 | **shutil** (fallback) | `shutil.copytree()` | When rsync unavailable |
 
 - **Interval-based restore:** Configurable via `snapshot_restore_interval`
-- **Location:** `src/tuner/utils/snapshot_manager.py`
+- **Backend-managed:** Snapshots live alongside the worker data directory managed by the
+  `DatabaseEnvironment` backend.
 
 ## Configuration Application
 
-The `KnobApplicator` (`src/tuner/utils/applicator.py`) handles:
+The `KnobApplicator` (`src/utils/applicator.py`) handles:
 
 1. **Context-aware application:** Separates postmaster vs sighup knobs
 2. **Restart minimization:** Only restarts when postmaster values actually differ
 3. **Verification:** Confirms each knob via `SELECT current_setting()`
 4. **Fraction resolution:** Converts hardware fractions to absolute values
 
-The `RestartManager` (`src/tuner/utils/restart_manager.py`) tracks:
-- Which postmaster knobs changed since last restart
-- Whether a restart is actually needed (value diff check)
+## Restart Policy
+
+`src/tuner/benchmark/restart_policy.py` exposes the restart policy with three tuning modes:
+
+| `TuningMode` | Behavior |
+|--------------|----------|
+| `ONLINE` | Minimize restarts; favor reload-only changes |
+| `OFFLINE` | Restart freely between evaluations (default) |
+| `ADAPTIVE` | Decide per-cycle based on which knobs actually changed |
+
+Selected via `--tuning-mode {online,offline,adaptive}` on the tuner CLI. The legacy
+`RestartCostModel` was archived to `prototypes/restart_cost_model/`.
 
 ## System Metrics Collection
 
@@ -114,4 +128,4 @@ Dead worker penalty: Any worker with `failure_type is not None` gets score 0.0,
 preventing failed configs from contaminating normalization ranges.
 
 ## Reference Files
-- Read `references/execution-patterns.md` for sysbench CLI patterns, TPC-H query flow, and WorkloadEvaluator step-by-step
+- Read `references/execution-patterns.md` for sysbench CLI patterns, TPC-H query flow, and WorkloadOrchestrator step-by-step

--- a/.claude/skills/benchmark-orchestration/references/execution-patterns.md
+++ b/.claude/skills/benchmark-orchestration/references/execution-patterns.md
@@ -76,9 +76,9 @@ SET statement_timeout = '{timeout_ms}'
 
 ---
 
-## WorkloadEvaluator Pipeline
+## WorkloadOrchestrator Pipeline
 
-The `WorkloadEvaluator` class (`src/tuner/evaluator/evaluator.py`) orchestrates
+The `WorkloadOrchestrator` class (`src/tuner/benchmark/orchestrator.py`) orchestrates
 the full evaluation of a single worker:
 
 ```

--- a/.claude/skills/codebase-architecture/SKILL.md
+++ b/.claude/skills/codebase-architecture/SKILL.md
@@ -13,10 +13,9 @@ description: >
 
 ## Project Identity
 
-- **Name**: Population-Based Training for PostgreSQL Configuration Tuning
+- **Name**: Population-Based Training for PostgreSQL Configuration Tuning (PBTune)
 - **Language**: Python 3.11+
 - **Target DB**: PostgreSQL 14+
-- **Source**: ~21,000 lines across `src/`
 - **License**: Academic Research (Non-Commercial)
 
 ## High-Level Data Flow
@@ -27,9 +26,9 @@ CLI args (main.py)
     → KnobSpace (tiered CSV → KnobDefinitions)
     → Population (N Workers, LHS-initialized)
     → FOR each generation:
-        → Parallel evaluation via ThreadPoolExecutor
+        → Parallel evaluation via ThreadPoolExecutor (lockstep barriers B1..B17)
             → KnobApplicator (ALTER SYSTEM + restart/reload)
-            → WorkloadEvaluator (sysbench / TPC-H / template SQL)
+            → WorkloadOrchestrator (sysbench / TPC-H / template SQL)
             → PerformanceMetrics collected
             → CompositeScorer (normalize → weight → gate → score)
         → Evolution (truncation selection → exploit → explore → perturb)
@@ -47,9 +46,10 @@ CLI args (main.py)
 | `core/population.py` | PBT loop: init → evaluate → evolve → converge |
 | `core/worker.py` | Worker state (config, score, history, readiness) |
 | `core/evolution.py` | Truncation selection, perturbation, convergence detection |
-| `evaluator/evaluator.py` | Benchmark dispatch, metric collection, scoring integration |
-| `evaluator/workload.py` | JSON/YAML workload template execution |
-| `evaluator/restart_policy.py` | CDBTune-inspired batched restart logic |
+| `core/barriers.py` | B1..B17 lockstep generation barriers |
+| `benchmark/orchestrator.py` | `WorkloadOrchestrator` — benchmark dispatch, metric collection, scoring integration |
+| `benchmark/workload.py` | JSON/YAML workload template execution |
+| `benchmark/restart_policy.py` | Restart policy with `TuningMode` {ONLINE, OFFLINE, ADAPTIVE} |
 | `config/knob_space.py` | Search space definition, LHS sampling, perturbation |
 | `config/knob_loader.py` | Tiered knob CSV loading (minimal/core/standard/extensive) |
 | `config/tuner_config.py` | CLI-derived configuration dataclass |
@@ -64,6 +64,7 @@ CLI args (main.py)
 | `workload_features.py` | Feature extraction (sysbench, TPC-H, template SQL) |
 | `contracts.py` | `WorkloadFeatures`, `MetricSnapshot`, `ScoreBreakdown`, `NormalizationState` |
 | `constants.py` | Metric IDs, directionality, default policy constants |
+| `outlier_filtering.py` | Outlier-resistant pre-filtering for normalization |
 
 ### `src/utils/` — Shared Utilities
 | File | Responsibility |
@@ -73,19 +74,27 @@ CLI args (main.py)
 | `applicator.py` | `KnobApplicator` — applies configs via ALTER SYSTEM |
 | `hardware_info.py` | System resource detection (CPU, RAM, disk) |
 | `metric_instrumentation.py` | Extended metric collection (buffer stats, scan efficiency) |
+| `timing.py` | `TimingRecorder`, `TimingRecord` (frozen dataclass) — v1.1 timing primitives |
+| `session_clock.py` | `session_timestamp()` — wall-clock for filenames/log lines |
+| `types.py` | Shared dataclasses and type aliases |
 | `environments/base.py` | `DatabaseEnvironment` ABC |
 | `environments/bare_metal.py` | Bare-metal PostgreSQL backend |
-| `environments/docker.py` | Docker container-based backend |
+| `environments/docker.py` | Docker container-based backend (supports CPU subset isolation, ADR-004) |
 | `environments/factory.py` | Environment factory (auto-selects backend) |
-| `logger/` | Colored logging, banners, formatters, adapters (7 files) |
+| `logger/` | Colored logging, banners, formatters, adapters |
+
+> Durations come from `time.monotonic()` (never `time.time()`). Three recorder layers:
+> (1) `tuner.bootstrap_timing` on `PBTTuner`, (2) `population.generation_timing` on
+> `Population`, and (3) a per-worker recorder local in `WorkloadOrchestrator.evaluate_worker`
+> (attached as `worker.last_eval_timing`).
 
 ### `src/evaluation/` — Post-Hoc Comparison Suite (entry: `python -m src.evaluation`)
 | File | Responsibility |
 |------|---------------|
 | `__main__.py` | CLI entry point |
-| `runner.py` | `ComparisonRunner` — orchestrates default-vs-tuned evaluations |
+| `runner.py` | `ComparisonRunner` — orchestrates default-vs-tuned (and optional BO) evaluations |
 | `statistics.py` | Wilcoxon, bootstrap CI, Holm-corrected α, Cohen's d |
-| `loader.py` | Session JSON parser with scoring metadata compatibility |
+| `loader.py` | Session JSON parser with scoring + timing-schema compatibility |
 | `types.py` | `ComparisonConfig`, `RunResult`, `ComparisonReport` |
 | `exceptions.py` | Domain-specific exception hierarchy |
 
@@ -94,14 +103,28 @@ CLI args (main.py)
 |------|---------------|
 | `data_loader.py` | Load/normalize PBT session results for analysis |
 | `importance.py` | fANOVA + TreeSHAP knob importance analysis |
+| `hardware_validator.py` | Cross-hardware importance stability checks |
+| `tier_generator.py` | Data-driven tier generation (Jenks Natural Breaks) |
+| `timing_breakdown.py` | Aggregates v1.1 timing records to LaTeX/CSV |
+
+### `src/visualization/` — Publication Figures (entry: `python -m src.visualization`)
+| File | Responsibility |
+|------|---------------|
+| `__main__.py` | CLI entry point |
+| `plots/` | Convergence, trajectory, breakdown, BO-vs-PBT figures |
+| `loaders/` | Session/comparison JSON loaders |
+| `registry.py` | Figure registry |
+| `theme.py`, `colors.py` | Publication theme + colorblind palette |
+| `export.py` | PDF/PNG export helpers |
+| `types.py`, `utils.py`, `exceptions.py` | Shared dataclasses, helpers, errors |
 
 ### Other Packages
 | Package | Responsibility |
 |---------|---------------|
-| `src/database/` | PostgreSQL connection management |
-| `src/knobs/` | Knob metadata retrieval from PG catalogs |
-| `src/benchmarks/` | Benchmark executor interfaces (sysbench, TPC-H) |
-| `src/scripts/` | Setup, cleanup, knob analysis utilities |
+| `src/database/` | PostgreSQL connection + management (`connection.py`, `data_loader.py`, `management.py`) |
+| `src/knobs/` | Knob metadata, retrieval, preprocessing, policy (`knob_metadata.py`, `retrieval.py`, `preprocess_knobs.py`, `policy.py`) |
+| `src/benchmarks/` | Benchmark executor interfaces (`executor.py`, `sysbench/`, `tpch/`) |
+| `src/scripts/` | Setup, cleanup, knob analysis, BO baseline (`bo_baseline/` subpackage), `pbt_vs_bo_comarison.py` (filename typo is intentional) |
 | `src/config/` | Global database configuration |
 
 ## Key Data Types
@@ -114,37 +137,56 @@ CLI args (main.py)
 | `TunerConfig` | `src/tuner/config/tuner_config.py` | Session configuration |
 | `ScoringPolicySpec` | `src/utils/scoring/policies.py` | Policy definition |
 | `ComparisonConfig` | `src/evaluation/types.py` | Evaluation session config |
+| `TimingRecorder`, `TimingRecord` | `src/utils/timing.py` | Timing instrumentation primitives |
 
 ## Build & Validation
 
 ```bash
+make install-dev
 make lint           # ruff check src tests
-make typecheck      # mypy src/evaluation src/utils src/scripts
+make typecheck      # mypy src/evaluation src/utils src/scripts (includes src/utils/logger)
 make test           # pytest -q tests/unit
 make check-all      # lint + typecheck + test
+make fix-and-check  # auto-fix then re-run check-all
+```
+
+## CLI Entry Points (the five user-facing commands)
+
+```bash
+python -m src.tuner.main                # PBT tuning
+python -m src.evaluation                # Post-hoc default-vs-tuned comparison
+python -m src.scripts.bo_baseline       # SMAC3 BO baseline
+python -m src.scripts.pbt_vs_bo_comarison  # Cross-method comparison (filename typo is intentional)
+python -m src.visualization             # Publication figure generation
+```
+
+Setup/utility scripts:
+```bash
+bash scripts/bootstrap.sh
+python -m src.scripts.setup_database
+python -m src.scripts.cleanup_instances
+python -m src.scripts.analyze_knobs
+python -m src.scripts.analyze_knob_importance
 ```
 
 ## Result Directories
 
 ```
 results/
-├── oltp/{sysbench_workload}/
-│   ├── pbt_runs/{tier}/tuning_sessions/
+├── oltp/{oltp_read_only,oltp_read_write,oltp_write_only}/
+│   ├── pbt_runs/{tier}/{tuning_sessions, best_configs, ...}/
+│   ├── bo_runs/{tier}/
 │   ├── comparisons/{tier}/
 │   └── baselines/
 ├── olap/
 │   └── (same structure for TPC-H)
-└── best_configs/
+└── analysis/{workload}/
 ```
 
 ## Documentation Index
 
-| Document | Focus |
-|----------|-------|
-| `docs/FEATURE_DRIVEN_SCORING.md` | Scoring-v2 architecture |
-| `docs/PBT_CORE_COMPONENTS.md` | Worker, Evolution, Population |
-| `docs/PERFORMANCE_EVALUATION.md` | Evaluator, metrics, scoring |
-| `docs/BENCHMARKING.md` | Dual-evaluation strategy |
-| `docs/EVALUATION_RUNBOOK.md` | Reproducibility commands |
-| `docs/CONFIGURATION_MANAGEMENT.md` | KnobSpace, sampling, perturbation |
-| `docs/AUTOTUNING_KNOB_POLICY.md` | Comprehensive knob policy reference |
+- `docs/architecture/` — explanation (Diataxis): PBT core, feature-driven scoring, ADRs
+- `docs/reference/` — lookup tables, session JSON schema (`session-json-schema.md`)
+- `docs/guides/` — how-tos (evaluation runbook, knob policy, etc.)
+- `docs/getting-started/` — tutorials
+- `docs/research/` — positioning, baselines, related work

--- a/.claude/skills/dev-workflow/SKILL.md
+++ b/.claude/skills/dev-workflow/SKILL.md
@@ -39,15 +39,18 @@ Type checking covers: `src/evaluation`, `src/utils`, `src/scripts`
 
 ```
 tests/unit/
-├── analysis/     # data_loader, importance
-├── benchmarks/   # sysbench, tpch executor tests
-├── config/       # hardware normalization
-├── core/         # population, evaluator, CLI, warm start, saturation
-├── evaluation/   # comparative evaluation, public API
-├── knobs/        # metadata loader, policy loader
-├── scoring/      # normalizer, weight model, workload features
-├── scripts/      # cleanup instances
-└── utils/        # environments, hardware info, instrumentation
+├── analysis/      # data_loader, importance, timing_breakdown
+├── api/           # public API surface
+├── benchmarks/    # sysbench, tpch executor tests
+├── config/        # hardware normalization
+├── core/          # barriers, orchestrator fault injection, CLI, warm start, saturation
+├── evaluation/    # comparative evaluation, public API
+├── knobs/         # metadata loader, policy loader
+├── scoring/       # normalizer, weight model, workload features
+├── scripts/       # cleanup instances, BO baseline
+├── tuner/         # session save/finalization, timing block
+├── utils/         # environments, hardware info, instrumentation, timing
+└── visualization/ # plot rendering
 ```
 
 All tests use `pytest`. Common fixtures are in `tests/conftest.py` and
@@ -69,6 +72,7 @@ All tests use `pytest`. Common fixtures are in `tests/conftest.py` and
 
 ## Dependencies
 
-- Runtime: `requirements.txt` (psycopg2, numpy, pandas, scipy, docker, fanova, shap)
+- Runtime: `requirements.txt` (psycopg2-binary, SQLAlchemy, numpy, pandas, scipy, scikit-learn, psutil, PyYAML, fanova, shap)
+- Optional: smac3, ConfigSpace (BO baseline)
 - Dev: `requirements-dev.txt` (pytest, ruff, mypy)
-- Install: `pip install -r requirements.txt -r requirements-dev.txt`
+- Install: `pip install -r requirements.txt -r requirements-dev.txt` (or `make install-dev`)

--- a/.claude/skills/evaluation-suite/SKILL.md
+++ b/.claude/skills/evaluation-suite/SKILL.md
@@ -80,6 +80,10 @@ scoring_policy_version = "1.0"
 metric_reference_version = "v1"
 ```
 
+For new runs, the active default is `feature_driven_v2`; `fixed_v1` is retained
+for compatibility with legacy sessions. The loader is also tolerant of the v1.1
+session/timing JSON schema (see `docs/reference/session-json-schema.md`).
+
 The evaluation CLI supports policy override for re-evaluation:
 ```bash
 python -m src.evaluation \
@@ -91,12 +95,26 @@ python -m src.evaluation \
 
 ```bash
 python -m src.evaluation \
-    --session <path>           # Required: path to tuning session JSON
-    --repetitions <N>          # Default: 5
-    --no-docker                # Use bare-metal instead of Docker
-    --scoring-policy <id>      # Override: fixed_v1 or feature_driven_v2
-    --output <path>            # Custom output path for comparison report
+    --session <path>              # Required: path to tuning session JSON
+    --bo-session <path>           # Optional: 3-way Default vs BO vs PBT comparison
+    --benchmark {sysbench,tpch}   # Auto-detected when omitted
+    --repetitions <N>             # Default: 5
+    --no-docker                   # Use bare-metal instead of Docker
+    --scoring-policy <id>         # Override: fixed_v1 or feature_driven_v2
+    --scoring-policy-version <v>  # Override policy version
+    --metric-reference-version <v># Override metric reference version
+    --output-dir <path>           # Custom output directory for comparison report
+    --colocate-output             # Place report next to the session file
+    --seed <N>                    # RNG seed for reproducibility
+    --data-dir <path>             # Override data dir
+    --docker-image <image>        # Override evaluation Docker image
+    --verbose {DEBUG,INFO,WARNING,ERROR}   # or -v for DEBUG
 ```
+
+Benchmark parameters (auto-detected from session, override only when needed):
+`--tpch-scale-factor`, `--tpch-warmup-passes`, `--sysbench-duration`,
+`--sysbench-tables`, `--sysbench-table-size`, `--sysbench-workload`,
+`--sysbench-warmup-seconds`.
 
 ## Output: ComparisonReport
 
@@ -128,7 +146,7 @@ JSON report saved to `results/{workload}/comparisons/{tier}/`:
 | Type definitions | `src/evaluation/types.py` |
 | Exceptions | `src/evaluation/exceptions.py` |
 | Docker image | `docker/eval.Dockerfile` |
-| Runbook | `docs/EVALUATION_RUNBOOK.md` |
+| Runbook | `docs/guides/evaluation-runbook.md` |
 
 ## Common Pitfalls
 

--- a/.claude/skills/pbt-algorithm-patterns/SKILL.md
+++ b/.claude/skills/pbt-algorithm-patterns/SKILL.md
@@ -51,23 +51,25 @@ Worker lifecycle:
 ```
 
 ### Scoring Formula
+
+The canonical scoring contract is:
+
 ```
-For latency (lower is better):
-    normalized = (max - clamped_value) / (max - min)   → ∈ [0, 1]
-
-For throughput (higher is better):
-    normalized = (clamped_value - min) / (max - min)   → ∈ [0, 1]
-
-For memory/error (already ∈ [0,1], lower is better):
-    normalized = 1 - clamped_value
-
-Final = Σ(weight_i × normalized_i) × 100
+S = 100 × G × Σ(w_i × u_i)
 ```
 
-All weights sum to 1.0. Presets:
-- **OLTP:** latency=0.50, throughput=0.40, memory=0.05, error=0.05
-- **OLAP:** latency=0.55, throughput=0.30, memory=0.10, error=0.05
-- **MIXED:** latency=0.40, throughput=0.35, memory=0.15, error=0.10
+Where:
+- **G** ∈ [0, 1] — reliability gate (0 on fatal failure or high error rate)
+- **w_i** — metric weight from the active scoring policy (Σw_i = 1)
+- **u_i** ∈ [0, 1] — normalized utility from the quantile normalizer
+- **S** ∈ [0, 100] — final bounded score
+
+Active scoring policies (see `src/utils/scoring/policies.py`):
+- `feature_driven_v2` — default for new runs (dynamic weights from workload features)
+- `fixed_v1` — compatibility-only static weights
+
+See the `scoring-pipeline` skill for full details on `CompositeScorer`,
+`QuantileUtilityNormalizer`, and feature-driven weights.
 
 ### Adaptive Normalization
 - Activates at generation ≥ 2 (need observed data)
@@ -105,8 +107,9 @@ with a diversity-preserving resampling strategy:
 | Orchestrator | `src/tuner/main.py` | `PBTTuner` |
 | Population | `src/tuner/core/population.py` | `Population`, `PopulationConfig`, `GenerationResult` |
 | Evolution | `src/tuner/core/evolution.py` | `truncation_selection()`, `execute_exploit_explore()`, `get_best_worker()`, `check_convergence()` |
+| Generation barriers | `src/tuner/core/barriers.py` | B1..B17 lockstep barriers |
 | Worker | `src/tuner/core/worker.py` | `Worker` |
-| Scoring | `src/utils/metrics.py` | `MetricConfig`, `PerformanceMetrics`, `WorkloadType` |
+| Scoring | `src/utils/scoring/scorer.py`, `src/utils/metrics.py` | `CompositeScorer`, `PerformanceMetrics`, `WorkloadType` |
 
 ## Design Decisions (Deviations from Original PBT Paper)
 

--- a/.claude/skills/pbt-algorithm-patterns/references/pbt-lifecycle.md
+++ b/.claude/skills/pbt-algorithm-patterns/references/pbt-lifecycle.md
@@ -10,7 +10,7 @@
 │  3. FOR generation = 1..max_generations:                        │
 │     └── run_generation(generation)                              │
 │         ├── population.evaluate_generation(evaluate_fn)         │
-│         │   └── ThreadPoolExecutor(max_workers=pop_size)        │
+│         │   └── ThreadPoolExecutor(max_workers=parallel_workers)        │
 │         │       └── evaluate_worker(worker) × N                 │
 │         │           ├── apply_configuration(worker.knob_config) │
 │         │           ├── _ensure_benchmark_ready()               │

--- a/.claude/skills/pbt-algorithm-patterns/references/scoring-formula.md
+++ b/.claude/skills/pbt-algorithm-patterns/references/scoring-formula.md
@@ -1,5 +1,11 @@
 # Scoring Formula — Detailed Reference
 
+> This file documents the legacy `fixed_v1` scoring math implemented in
+> `MetricConfig.compute_score()`. The current default for new runs is
+> `feature_driven_v2` — see the `scoring-pipeline` skill (canonical contract:
+> `S = 100 × G × Σ(w_i × u_i)`). `fixed_v1` is retained for compatibility with
+> legacy sessions.
+
 ## Core Computation (`MetricConfig.compute_score()`)
 
 Located in `src/utils/metrics.py`.

--- a/.claude/skills/postgresql-knob-tuning/SKILL.md
+++ b/.claude/skills/postgresql-knob-tuning/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: postgresql-knob-tuning
-description: PostgreSQL configuration parameter (knob) tuning patterns, including parameter contexts (postmaster/sighup/user), knob space management, hardware-aware fractional normalization, safe bounds enforcement, and the knob tier system. Use this skill whenever working on knob configuration, parameter application, knob metadata, hardware-aware normalization, transfer learning via warm-start, or any code in src/tuner/config/, src/tuner/utils/applicator.py, or src/knobs/.
+description: PostgreSQL configuration parameter (knob) tuning patterns, including parameter contexts (postmaster/sighup/user), knob space management, hardware-aware fractional normalization, safe bounds enforcement, and the knob tier system. Use this skill whenever working on knob configuration, parameter application, knob metadata, hardware-aware normalization, transfer learning via warm-start, or any code in src/tuner/config/, src/utils/applicator.py, or src/knobs/.
 ---
 
 # PostgreSQL Knob Tuning Patterns
@@ -71,7 +71,7 @@ To regenerate tier CSVs after metadata changes: `python -m src.knobs`
 
 ## Warm-Start (Transfer Learning Level 1)
 ```bash
-python -m src.tuner.main --warm-start results/best_configs/best_config_YYYYMMDD_HHMM.json
+python -m src.tuner.main --warm-start results/olap/pbt_runs/{tier}/best_configs/best_config_YYYYMMDD_HHMM.json
 ```
 - Loads `best_config.json` from previous run
 - Seeds 1-2 workers with loaded config (fractional representation)
@@ -84,11 +84,11 @@ python -m src.tuner.main --warm-start results/best_configs/best_config_YYYYMMDD_
 |-----------|------|
 | Knob space + LHS | `src/tuner/config/knob_space.py` |
 | Knob CSV loading | `src/tuner/config/knob_loader.py` |
-| Knob application | `src/tuner/utils/applicator.py` |
+| Knob application | `src/utils/applicator.py` |
 | Knob metadata | `src/knobs/knob_metadata.py` |
 | Knob preprocessing | `src/knobs/preprocess_knobs.py` |
 | pg_settings retrieval | `src/knobs/retrieval.py` |
-| Hardware detection | `src/tuner/utils/hardware_info.py` |
+| Hardware detection | `src/utils/hardware_info.py` |
 
 ## Reference Files
 - Read `references/parameter-contexts.md` for detailed PostgreSQL parameter handling

--- a/.claude/skills/postgresql-knob-tuning/references/hardware-normalization.md
+++ b/.claude/skills/postgresql-knob-tuning/references/hardware-normalization.md
@@ -58,7 +58,7 @@ def repair_config_dependencies(config):
 
 ## HardwareInfo Detection
 
-`src/tuner/utils/hardware_info.py` captures:
+`src/utils/hardware_info.py` captures:
 - Total RAM (bytes)
 - CPU core count (physical)
 - Disk type (SSD/HDD)

--- a/.claude/skills/postgresql-knob-tuning/references/parameter-contexts.md
+++ b/.claude/skills/postgresql-knob-tuning/references/parameter-contexts.md
@@ -36,14 +36,17 @@ KnobApplicator.apply_configuration(config, postmaster_dict, sighup_dict):
 
 ## Restart Minimization Strategy
 
-The `RestartManager` class (`src/tuner/utils/restart_manager.py`) handles:
+The restart policy module (`src/tuner/benchmark/restart_policy.py`) handles:
 - Tracking which postmaster knobs have changed since last restart
 - Batching restarts to minimize service interruptions
 - Detecting when restart is actually needed (only if postmaster values differ)
+- Selectable behavior via `TuningMode` {ONLINE, OFFLINE, ADAPTIVE}
+  (exposed on the tuner CLI as `--tuning-mode`)
+
+The legacy `RestartCostModel` was archived to `prototypes/restart_cost_model/`.
 
 ## Multi-Instance Port Scheme
 
 Each PBT worker gets its own PostgreSQL instance:
-- Base port: 5440 (configurable via `--base-port`)
-- Worker i gets port: `5440 + worker_id`
+- Base port: 5440 (worker i gets port `5440 + worker_id`)
 - Data directory: `{pg_data_base}/worker_{worker_id}/`

--- a/.claude/skills/scientific-experiment-runner/SKILL.md
+++ b/.claude/skills/scientific-experiment-runner/SKILL.md
@@ -19,9 +19,9 @@ Run full PBT pipeline with **5 random seeds**: `[42, 123, 456, 789, 1024]`
 # Each seed gets a separate run
 python -m src.tuner.main \
     --workload oltp --tier core \
-    --population-size 8 --generations 20 \
-    --seed 42 \
-    --output results/sysbench/pbt_runs/core/seed_42/
+    --population 8 --generations 20 \
+    --random-seed 42 \
+    --output-dir results/oltp/oltp_read_write/pbt_runs/core/seed_42/
 ```
 
 Report: mean ± std of best score across seeds, plus convergence curves.
@@ -32,16 +32,18 @@ config on TPC-H is *transfer learning*, not validation.
 
 ## Baseline Evaluation
 
-Run benchmark against **default PostgreSQL config** with **5 repetitions**:
+Run benchmark against **default PostgreSQL config** with **5 repetitions**
+via the post-hoc evaluation suite (`src/evaluation`):
 
 ```bash
-python -m src.tuner.main \
-    --workload oltp --tier minimal \
-    --baseline-only --repetitions 5 \
-    --output results/sysbench/baselines/
+python -m src.evaluation \
+    --session results/oltp/oltp_read_write/pbt_runs/core/tuning_sessions/pbt_results_YYYYMMDD_HHMM.json \
+    --repetitions 5
 ```
 
-Compute mean ± std for all metrics. This is the reference point for improvement%.
+The comparison runner evaluates both the default config and the tuned config
+under identical Docker isolation. Compute mean ± std for all metrics. This is
+the reference point for improvement%.
 
 ## Improvement Calculation
 ```
@@ -70,22 +72,19 @@ Compare on three axes:
 ## Results Directory Structure
 ```
 results/
-├── sysbench/
-│   ├── baselines/                    # Default PG config benchmarks
-│   │   └── baseline_{timestamp}.json
+├── oltp/{oltp_read_only,oltp_read_write,oltp_write_only}/
+│   ├── baselines/                         # Default PG config benchmarks
 │   ├── pbt_runs/
-│   │   ├── minimal/                  # By knob tier
-│   │   │   └── seed_{seed}/
-│   │   │       └── results_{timestamp}.json
-│   │   ├── core/
-│   │   ├── standard/
-│   │   └── extensive/
-│   └── bo_comparison/
-│       └── smac3_{timestamp}.json
-├── tpch/
-│   └── (same structure)
-└── best_configs/
-    └── best_config_{timestamp}.json  # For warm-start
+│   │   ├── {minimal,core,standard,extensive}/   # By knob tier
+│   │   │   ├── tuning_sessions/
+│   │   │   │   └── pbt_results_{timestamp}.json
+│   │   │   └── best_configs/
+│   │   │       └── best_config_{timestamp}.json # For warm-start
+│   ├── bo_runs/{tier}/
+│   └── comparisons/{tier}/
+├── olap/
+│   └── (same structure for TPC-H)
+└── analysis/{workload}/
 ```
 
 ## Results JSON Schema
@@ -111,7 +110,16 @@ Every results file MUST include:
 }
 ```
 
-Hardware provenance is captured via `src/tuner/utils/hardware_info.py`.
+Hardware provenance is captured via `src/utils/hardware_info.py`.
+
+## BO Baseline & Cross-Method Comparison
+
+This project ships an SMAC3-based BO baseline and a cross-method comparison script:
+
+```bash
+python -m src.scripts.bo_baseline        # Runs the SMAC3 baseline
+python -m src.scripts.pbt_vs_bo_comarison  # Cross-method comparison (filename typo intentional)
+```
 
 ## Citing Published Baselines
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -39,7 +39,7 @@ Paste full error traceback here
 
 ## Logs
 
-Attach `results/pbt_tuning.html` or relevant log excerpts.
+Attach the relevant `pbt_tuning_*.html` from `results/{olap,oltp/<workload>}/pbt_runs/<tier>/` or relevant log excerpts.
 
 ## Additional Context
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -36,7 +36,7 @@ What alternative approaches have you considered?
 
 If you have implementation ideas, describe them here:
 
-- Affected components: [e.g., Population, Evaluator, Evolution]
+- Affected components: [e.g., Population, WorkloadOrchestrator, Evolution]
 - API changes: ...
 - Configuration changes: ...
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ python -m src.tuner.main --benchmark sysbench --sysbench-tables 4
 python -m src.tuner.main --benchmark tpch --scale-factor 1.0
 
 # Warm-Starting (Transfer Learning across hardware boundaries)
-python -m src.tuner.main --warm-start results/best_configs/best_config_YYYYMMDD_HHMM.json
+python -m src.tuner.main --warm-start results/olap/pbt_runs/extensive/best_configs/best_config_YYYYMMDD_HHMM.json
 ```
 
 ### Evaluation Commands
@@ -89,62 +89,88 @@ The system follows a layered architecture:
 1. **Population Manager** (`src/tuner/core/population.py`): Orchestrates PBT algorithm
 2. **Worker** (`src/tuner/core/worker.py`): Individual configuration + performance state
 3. **Evolution** (`src/tuner/core/evolution.py`): Exploit-explore algorithms
-4. **Evaluator** (`src/tuner/evaluator/evaluator.py`): Workload execution and metric collection
-5. **Environment Factory** (`src/utils/environments/factory.py`): Docker/Bare-metal environment orchestration
-6. **Knob Space** (`src/tuner/config/knob_space.py`): Search space definition and sampling
+4. **Generation Barriers** (`src/tuner/core/barriers.py`): Lockstep B1–B17 synchronisation
+5. **Workload Orchestrator** (`src/tuner/benchmark/orchestrator.py`): Per-worker apply → run → measure pipeline (formerly "Evaluator")
+6. **Restart Policy** (`src/tuner/benchmark/restart_policy.py`): TuningMode-driven restart decisions
+7. **Environment Factory** (`src/utils/environments/factory.py`): Docker / bare-metal lifecycle
+8. **Knob Space** (`src/tuner/config/knob_space.py`): Search space definition and LHS sampling
+9. **Composite Scorer** (`src/utils/scoring/`): Feature-driven score = G × Σ(wᵢ × uᵢ)
+10. **Timing Recorder** (`src/utils/timing.py`, `src/utils/session_clock.py`): Monotonic-clock instrumentation (schema v1.1)
 
 ### Key Design Patterns
 
 - **Parallel Evaluation**: Each worker runs on a dedicated PostgreSQL instance (ports 5440+)
 - **Dual-Benchmarking**: Supports both internal JSON workloads and external C-binaries (sysbench/tpch)
 - **Snapshot Management**: Intelligent baseline snapshots for fast restarts
-- **Feature-Driven Scoring**: Workload-feature-conditioned weighting with compatibility policy and robust normalization
+- **Feature-Driven Scoring**: Workload-feature-conditioned weighting with reliability gate and quantile-anchored normalization
+- **Lockstep Generation Barriers**: B1–B17 synchronisation so every worker's measurement window experiences identical contention
+- **Hardware-Aware Encoding**: Knobs serialise as fractions of detected resources for cross-host portability
+- **Timing Instrumentation**: Three-layer (`bootstrap_timing`, `generation_timing`, per-worker) recorders aggregate into the session JSON
 
 ### Directory Structure
 
 ```text
 src/tuner/
-├── core/                # PBT algorithm implementation
-├── config/              # Configuration management
-├── evaluator/           # Performance evaluation
-└── main.py              # Entry point
+├── core/                # population, worker, evolution, barriers
+├── config/              # knob_space, knob_loader, tuner_config
+├── benchmark/           # orchestrator (was "evaluator"), restart_policy, workload
+└── main.py              # CLI entry point
 
 src/utils/
-├── environments/        # Docker/Bare-metal database environment backends
-├── logger/              # Logging setup and formatters
-├── metrics.py           # Performance metrics and scoring
-├── rescoring.py         # Shared post-hoc global score recalibration utilities
-└── restart_manager.py
+├── environments/        # base, docker, bare_metal, factory
+├── scoring/             # scorer, normalization, weights, policies, workload_features, contracts, constants, outlier_filtering
+├── logger/              # Colored logging + HTML output + adapters
+├── applicator.py        # KnobApplicator — ALTER SYSTEM + verify() read-back
+├── metrics.py           # PerformanceMetrics dataclass
+├── metric_instrumentation.py
+├── hardware_info.py     # WorkerResources detection
+├── rescoring.py         # Post-hoc global score recalibration utilities
+├── timing.py            # TimingRecorder + TimingRecord (schema v1.1, monotonic clock)
+├── session_clock.py     # session_timestamp() — wall-clock for filenames/log lines
+└── types.py
 
 src/evaluation/          # Post-hoc evaluation tools (independent of PBT loop)
 ├── types.py             # Dataclasses: ComparisonConfig, RunResult, etc.
-├── loader.py            # load_tuning_session() — parse pbt_results JSON
+├── loader.py            # load_tuning_session() — schema-tolerant session JSON parser
 ├── statistics.py        # Wilcoxon + bootstrap CI + Holm-corrected secondary endpoints + Cohen's d
 ├── runner.py            # ComparisonRunner — main orchestrator
+├── exceptions.py        # Domain-specific exception hierarchy
 └── __main__.py          # CLI: python -m src.evaluation
 
-src/database/            # Database connection and management
-src/knobs/               # Knob metadata retrieval
-src/scripts/             # Utility scripts
+src/analysis/            # data_loader, importance, hardware_validator, tier_generator, timing_breakdown
+src/database/            # connection, data_loader, management
+src/knobs/               # knob_metadata, retrieval, preprocess_knobs, policy
+src/benchmarks/          # executor + sysbench/ + tpch/
+src/scripts/             # setup_database, cleanup_instances, analyze_knobs, analyze_knob_importance,
+                         # pbt_vs_bo_comarison (sic), bo_baseline/ subpackage
+src/visualization/       # plots, loaders, registry, theme, export, __main__
 docker/                  # Docker evaluation images
 ├── eval.Dockerfile      # PostgreSQL + sysbench + TPC-H dbgen
 ├── build_dbgen.sh       # TPC-H dbgen compilation
 └── run_power_test.sh    # TPC-H 22-query power test runner
-docs/                    # Documentation
+data/                    # Knob metadata, policy, tier CSVs
+├── knob_metadata.json
+├── knob_policy.json
+├── postgresql_all_knobs.csv
+├── expert_defined_knobs/  # minimal | core | standard | extensive CSVs
+└── data_driven_knobs/     # Workload-specific tiers from analysis pipeline
+docs/                    # Documentation (Diataxis: getting-started/guides/reference/architecture/research)
 results/                 # Optimization results
-├── olap/comparisons/    # evaluate_tuning output (JSON with statistics)
-└── oltp/comparisons/
-workloads/               # Workload definitions
-tests/                   # Test suite
+├── olap/{pbt_runs,bo_runs,comparisons,baselines}/{tier}/
+└── oltp/{oltp_read_only,oltp_read_write,oltp_write_only}/{pbt_runs,bo_runs,comparisons,baselines}/{tier}/
+workloads/               # Workload definitions (oltp.json, olap.json, mixed.json, custom)
+tests/                   # Test suite (unit/ — analysis, benchmarks, config, core, evaluation, knobs, scoring, scripts, utils)
 ```
 
 ## Common Development Tasks
 
 ### Adding New Knobs
 
-1. Update knob metadata in `src/knobs/knob_metadata.py`
-2. Add to appropriate tier in `src/tuner/config/knob_loader.py`
-3. Update perturbation logic in `src/tuner/core/evolution.py`
+1. Add the knob row to the appropriate tier CSV in `data/expert_defined_knobs/` (or generate via `data/data_driven_knobs/` for data-driven tiers)
+2. Ensure the knob is present in `data/knob_metadata.json` (run `python -m src.scripts.analyze_knobs --refresh-raw` if it isn't)
+3. If the knob has tuning constraints, update `data/knob_policy.json` and the policy logic in `src/knobs/policy.py`
+4. Knob retrieval is handled by `src/knobs/retrieval.py`; loading by `src/tuner/config/knob_loader.py`
+5. Update perturbation logic in `src/tuner/core/evolution.py` only if the knob needs special perturbation semantics
 
 ### Creating New Workloads
 
@@ -157,6 +183,8 @@ tests/                   # Test suite
 1. Core algorithm changes in `src/tuner/core/evolution.py`
 2. Population management in `src/tuner/core/population.py`
 3. Configuration in `src/tuner/config/tuner_config.py`
+4. Lockstep barriers (B1–B17) in `src/tuner/core/barriers.py`
+5. Per-worker evaluation flow in `src/tuner/benchmark/orchestrator.py`
 
 ### Testing Changes
 
@@ -179,10 +207,13 @@ python -m src.tuner.main --tier core --config standard --verbose DEBUG
 
 - `src/tuner/main.py` - Main orchestration and CLI
 - `src/tuner/core/population.py` - PBT algorithm implementation
-- `src/tuner/evaluator/evaluator.py` - Performance measurement
+- `src/tuner/benchmark/orchestrator.py` - WorkloadOrchestrator (apply → run → measure)
 - `src/tuner/config/knob_space.py` - Knob space management
 - `src/utils/environments/factory.py` - Environment backend selection and lifecycle
-- `docs/architecture/feature-driven-scoring.md` - Canonical reference for the scoring-v2 architecture and migration path
+- `src/utils/scoring/scorer.py` - CompositeScorer (S = G × Σ(wᵢ × uᵢ))
+- `src/utils/timing.py` - Timing instrumentation primitives (schema v1.1)
+- `docs/architecture/feature-driven-scoring.md` - Canonical reference for the scoring-v2 architecture
+- `docs/architecture/overview.md` - Top-level system map
 
 ## Research Context
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to PBT PostgreSQL Tuning
 
-> Last reviewed: 2026-03-13
+> Last reviewed: 2026-06-15
 
 See also: [Documentation Index](./docs/README.md)
 

--- a/README.md
+++ b/README.md
@@ -300,8 +300,9 @@ python -m src.tuner.main \
 
 **Output:**
 
-- JSON results: `results/pbt_results_TIMESTAMP.json`
-- HTML log (colored): `results/pbt_tuning.html`
+- JSON results: `results/oltp/oltp_read_write/pbt_runs/minimal/tuning_sessions/pbt_results_TIMESTAMP.json`
+- HTML log (colored): `results/oltp/oltp_read_write/pbt_runs/minimal/pbt_tuning_TIMESTAMP.html`
+- Best config: `results/oltp/oltp_read_write/pbt_runs/minimal/best_configs/best_config_TIMESTAMP.json`
 
 ### Example 2: Standard Tuning Session (15-20 minutes)
 
@@ -367,14 +368,17 @@ python -m src.tuner.main \
 Open the HTML log in your browser for color-coded output:
 
 ```bash
+# Path follows the workload-partitioned layout, e.g. for OLTP read-write minimal tier:
+LOG=results/oltp/oltp_read_write/pbt_runs/minimal/pbt_tuning_TIMESTAMP.html
+
 # Windows
-start results/pbt_tuning.html
+start "$LOG"
 
 # macOS
-open results/pbt_tuning.html
+open "$LOG"
 
 # Linux
-xdg-open results/pbt_tuning.html
+xdg-open "$LOG"
 ```
 
 ### CLI Reference
@@ -388,16 +392,17 @@ python -m src.tuner.main --help
 | Argument        | Options                                    | Default    | Description                            |
 | --------------- | ------------------------------------------ | ---------- | -------------------------------------- |
 | `--tier`        | `minimal`, `core`, `standard`, `extensive` | `minimal`  | Knob space tier (5, 13, 36, 80+ knobs) |
-| `--config`      | `rapid`, `standard`, `thorough`            | `standard` | PBT configuration profile              |
-| `--population`  | 4-16                                       | 8          | Number of parallel workers             |
-| `--generations` | 10-100                                     | 30         | Optimization iterations                |
+| `--config`      | `rapid`, `standard`, `thorough`, `research`, `extreme` | `standard` | PBT configuration profile  |
+| `--population`  | integer                                    | from profile | Worker count (overrides profile)     |
+| `--generations` | integer                                    | from profile | Optimization iterations              |
 | `--workload`    | `oltp`, `olap`, `mixed`                    | `oltp`     | Workload type                          |
 | `--duration`    | seconds                                    | 30         | Evaluation duration per worker         |
 | `--sysbench-workload` | `oltp_read_only`, `oltp_read_write`, `oltp_write_only` | `oltp_read_write` | Sysbench OLTP mode when `--benchmark sysbench` |
-| `--scoring-policy` | `fixed_v1`, `feature_driven_v2`          | `feature_driven_v2` | Scoring policy (default for new runs)  |
-| `--scoring-policy-version` | version string                    | `1.0`      | Scoring policy version                 |
-| `--scoring-calibration-evals` | integer                         | 50         | Number of evals for normalization calibration |
-| `--verbose`     | `QUIET`, `NORMAL`, `VERBOSE`, `DEBUG`      | `NORMAL`   | Logging level                          |
+| `--scoring-policy` | `fixed_v1`, `feature_driven_v2`          | falls back to PBT config | Scoring policy (`feature_driven_v2` for new runs) |
+| `--scoring-policy-version` | version string                    | `2.0`      | Scoring policy version                 |
+| `--scoring-calibration-evals` | integer                         | `5`        | Number of evals for normalization calibration |
+| `--tuning-mode` | `online`, `offline`, `adaptive`            | `offline`  | Restart policy (online = no restarts; offline = every gen; adaptive = every N gens) |
+| `--verbose`     | `DEBUG`, `INFO`, `WARNING`, `ERROR`, `TRACE` | `INFO`   | Console log level                      |
 
 ### Sysbench Benchmark Modes
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -2,7 +2,7 @@
 
 This repository includes files copied from third-party open-source projects. Their original licenses apply to those files and are reproduced or referenced below.
 
-> Last updated: 2026-03-13
+> Last updated: 2026-06-15
 ---
 
 ## 1. github/awesome-copilot
@@ -19,36 +19,21 @@ Files under `.github/` listed in the table below were copied unchanged from the 
 
 | File | Upstream path | Description |
 |------|--------------|-------------|
-| `debug.agent.md` | `agents/debug.agent.md` | Debug your application to find and fix a bug |
 | `implementation-plan.agent.md` | `agents/implementation-plan.agent.md` | Generate an implementation plan for new features or refactoring existing code |
 | `polyglot-test-generator.agent.md` | `agents/polyglot-test-generator.agent.md` | Orchestrates comprehensive test generation using Research-Plan-Implement pipeline |
 | `postgresql-dba.agent.md` | `agents/postgresql-dba.agent.md` | Work with PostgreSQL databases using the PostgreSQL extension |
 | `prd.agent.md` | `agents/prd.agent.md` | Generate a comprehensive Product Requirements Document (PRD) in Markdown |
-| `principal-software-engineer.agent.md` | `agents/principal-software-engineer.agent.md` | Provide principal-level software engineering guidance with focus on engineering excellence |
 | `research-technical-spike.agent.md` | `agents/research-technical-spike.agent.md` | Systematically research and validate technical spike documents through exhaustive investigation |
-| `scientific-paper-research.agent.md` | `agents/scientific-paper-research.agent.md` | Research agent that searches scientific papers and retrieves structured experimental data |
-| `se-technical-writer.agent.md` | `agents/se-technical-writer.agent.md` | Technical writing specialist for creating developer documentation, technical blogs, and tutorials |
 
 #### Instructions (`.github/instructions/`)
 
 | File | Upstream path | Description |
 |------|--------------|-------------|
-| `code-review-generic.instructions.md` | `instructions/code-review-generic.instructions.md` | Generic code review instructions that can be customized for any project using GitHub Copilot |
 | `context-engineering.instructions.md` | `instructions/context-engineering.instructions.md` | Guidelines for structuring code and projects to maximize GitHub Copilot effectiveness |
 | `markdown.instructions.md` | `instructions/markdown.instructions.md` | Documentation and content creation standards |
 | `memory-bank.instructions.md` | `instructions/memory-bank.instructions.md` | Context retention and memory bank workflow across sessions |
-| `performance-optimization.instructions.md` | `instructions/performance-optimization.instructions.md` | Performance optimization best practices for all languages, frameworks, and stacks |
-| `prompt.instructions.md` | `instructions/prompt.instructions.md` | Guidelines for creating high-quality prompt files for GitHub Copilot |
 | `shell.instructions.md` | `instructions/shell.instructions.md` | Shell scripting best practices and conventions for bash, sh, zsh, and other shells |
 | `spec-driven-workflow-v1.instructions.md` | `instructions/spec-driven-workflow-v1.instructions.md` | Specification-Driven Workflow v1 — structured approach to software development |
-| `task-implementation.instructions.md` | `instructions/task-implementation.instructions.md` | Instructions for implementing task plans with progressive tracking and change record |
-| `update-docs-on-code-change.instructions.md` | `instructions/update-docs-on-code-change.instructions.md` | Automatically update README.md and documentation files when application code changes |
-
-#### Prompts (`.github/prompts/`)
-
-| File | Upstream path | Description |
-|------|--------------|-------------|
-| `unit-test-generation.prompt.md` | `skills/polyglot-test-agent/unit-test-generation.prompt.md` | Best practices and guidelines for generating comprehensive, parameterized unit tests with 80% code coverage |
 
 ### MIT License (awesome-copilot)
 

--- a/docs/architecture/hardware-aware-normalization.md
+++ b/docs/architecture/hardware-aware-normalization.md
@@ -1,6 +1,6 @@
 # Hardware-Aware Normalization & Warm-Starting
 
-> Last reviewed: 2026-06-07
+> Last reviewed: 2026-06-15
 
 See also: [Documentation Index](../README.md), [Configuration Management](configuration-management.md), [Environment Backends](environment-backends.md), [Cross-Workload Transfer](../research/cross-workload-transfer.md)
 
@@ -59,7 +59,7 @@ If `Total > Budget` (80% of node's per-worker RAM limit constraint), the framewo
 You can resume PBT optimizations from any previous state mapping via the CLI:
 
 ```bash
-python -m src.tuner.main --warm-start ../results/best_config.json
+python -m src.tuner.main --warm-start results/oltp/oltp_read_write/pbt_runs/core/best_configs/best_config_YYYYMMDD_HHMM.json
 ```
 
 **What Happens:**

--- a/docs/architecture/pbt-core.md
+++ b/docs/architecture/pbt-core.md
@@ -1,6 +1,6 @@
 # PBT Core Components
 
-> Last reviewed: 2026-06-07
+> Last reviewed: 2026-06-15
 
 See also: [Documentation Index](../README.md), [Generation Barriers](generation-barriers.md), [Performance Evaluation](performance-evaluation.md), [Workload Orchestrator](workload-orchestrator.md)
 
@@ -100,7 +100,7 @@ class Worker:
     metrics: Optional[PerformanceMetrics] = None
     score_breakdown: Optional[ScoreBreakdown] = None
     step_count: int = 0
-    ready_interval: int = 3
+    ready_interval: int = 1
     parent_id: Optional[int] = None
     generation_created: int = 0
     # ... see source for full attribute set

--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -1,8 +1,31 @@
 # Environment Setup Guide
 
-> Last reviewed: 2026-03-13
+> Last reviewed: 2026-06-15
 
-See also: [Documentation Index](../README.md)
+See also: [Documentation Index](../README.md), [quickstart](quickstart.md)
+
+## Recommended: one-shot bootstrap
+
+The fastest path on Linux/macOS is the bootstrap script. It detects your package
+manager, installs system dependencies (build toolchain, PostgreSQL client
+headers, sysbench prerequisites), provisions a Python 3.11+ virtual environment
+under `.venv/`, and installs `requirements.txt`:
+
+```bash
+./scripts/bootstrap.sh             # Full install
+./scripts/bootstrap.sh --dev       # Also installs requirements-dev.txt
+./scripts/bootstrap.sh --clean     # Wipe .venv and start fresh
+./scripts/bootstrap.sh --skip-system  # Skip the system-package step
+```
+
+After it completes:
+
+```bash
+source .venv/bin/activate
+```
+
+The manual steps below are equivalent if you prefer to do them yourself or are
+on a platform the script doesn't cover.
 
 ## Database Configuration
 
@@ -32,10 +55,12 @@ DB_NAME=test_dataset
 
 #### Python packages
 
-Install the required Python packages:
+Install the required Python packages (Python 3.11+ required):
 
 ```bash
 pip install -r requirements.txt
+# For development (linting, typecheck, tests):
+pip install -r requirements-dev.txt
 ```
 
 **Key Dependencies**:
@@ -124,7 +149,8 @@ After setting up your environment, explore the system documentation:
 ### Core System Documentation
 - **[PostgreSQL Connection and Knobs](../architecture/postgresql-connection-and-knobs.md)**: Database connection management and knob retrieval system
 - **[PBT Core Components](../architecture/pbt-core.md)**: Worker, Evolution, and Population classes for population-based training
-- **[Performance Evaluation](../architecture/performance-evaluation.md)**: Evaluator, metrics collection, and scoring system
+- **[Performance Evaluation](../architecture/performance-evaluation.md)**: WorkloadOrchestrator, metrics collection, and scoring system
+- **[Workload Orchestrator](../architecture/workload-orchestrator.md)**: Workload execution and per-worker measurement pipeline
 - **[Configuration Management](../architecture/configuration-management.md)**: KnobSpace and KnobApplicator for safe configuration handling
 
 ### Quick Start

--- a/docs/guides/adding-knobs.md
+++ b/docs/guides/adding-knobs.md
@@ -1,6 +1,6 @@
 # Adding a New Tunable Knob
 
-> Last reviewed: 2026-06-07
+> Last reviewed: 2026-06-15
 
 See also: [configuration-management](../architecture/configuration-management.md), [postgresql-connection-and-knobs](../architecture/postgresql-connection-and-knobs.md), [autotuning-knob-policy](../reference/autotuning-knob-policy.md), [knob-importance-analysis](../architecture/knob-importance-analysis.md)
 
@@ -234,7 +234,7 @@ If empirical analysis ([knob-importance-analysis](../architecture/knob-importanc
 2. Re-run `python -m src.scripts.analyze_knobs`.
 3. Verify the diff is the expected single-knob promotion.
 
-The fANOVA + TreeSHAP pipeline can also produce **data-driven tier overlays** under `data/data_driven_knobs/{workload}/` — these are workload-specific and live alongside the expert-defined tiers without overwriting them. Use `--source data_driven --workload <label>` on the tuner CLI to load those instead.
+The fANOVA + TreeSHAP pipeline can also produce **data-driven tier overlays** under `data/data_driven_knobs/{workload}/` — these are workload-specific and live alongside the expert-defined tiers without overwriting them. Use `--knob-source data_driven --workload <label>` on the tuner CLI to load those instead.
 
 ## Common mistakes
 

--- a/docs/guides/evaluation-runbook.md
+++ b/docs/guides/evaluation-runbook.md
@@ -1,6 +1,6 @@
 # Evaluation Reproducibility Runbook
 
-> Last reviewed: 2026-04-17
+> Last reviewed: 2026-06-15
 
 See also: [Documentation Index](../README.md)
 
@@ -91,14 +91,18 @@ python -m src.evaluation \
   --tpch-warmup-passes 2
 ```
 
-### Option E: One-Command Repro Script
+### Option E: Three-Way Comparison (Default vs BO vs PBT)
+
+When a paired BO baseline run is available, run a multi-arm comparison so that
+default, BO-tuned, and PBT-tuned configurations are measured against the same
+workload under the same paired seeds:
 
 ```bash
-./scripts/run_repro_eval.sh --session results/olap/pbt_runs/extensive/tuning_sessions/pbt_results_YYYYMMDD_HHMM.json --repetitions 10
+python -m src.evaluation \
+  --session results/oltp/oltp_read_write/pbt_runs/core/tuning_sessions/pbt_results_YYYYMMDD_HHMM.json \
+  --bo-session results/oltp/oltp_read_write/bo_runs/core/tuning_sessions/bo_results_YYYYMMDD_HHMM.json \
+  --repetitions 10
 ```
-
-`run_repro_eval.sh` is a convenience-only passthrough. Argument validation,
-defaults, and CLI contract are defined only in `python -m src.evaluation`.
 
 When omitted, `--seed` defaults to `50000`.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,6 +1,6 @@
 # CLI Reference
 
-> Last reviewed: 2026-06-07
+> Last reviewed: 2026-06-15
 
 See also: [getting-started/quickstart](../getting-started/quickstart.md), [guides/evaluation-runbook](../guides/evaluation-runbook.md), [guides/bo-baseline](../guides/bo-baseline.md), [guides/pbt-vs-bo-comparison](../guides/pbt-vs-bo-comparison.md)
 
@@ -14,7 +14,7 @@ python -m src.scripts.pbt_vs_bo_comarison  # cross-method comparison
 python -m src.visualization              # publication figure generation
 ```
 
-For the canonical authority on any flag's exact semantics, run the entry point with `--help`. This page reflects the flag set as of 2026-06-07.
+For the canonical authority on any flag's exact semantics, run the entry point with `--help`. This page reflects the flag set as of 2026-06-15.
 
 ---
 
@@ -50,7 +50,9 @@ The primary entry point. See [getting-started/quickstart](../getting-started/qui
 | `--population <int>` | from profile | Override the profile's worker count. |
 | `--generations <int>` | from profile | Override the profile's generation count. |
 | `--parallel-workers <int>` | population size | Number of workers running concurrently. Limits resource division — see [hardware-aware-normalization §7](../architecture/hardware-aware-normalization.md#7-docker-cpu-subset-enforcement). |
-| `--tuning-mode {online\|offline\|adaptive}` | `online` | Restart policy. See [workload-orchestrator §Restart policy](../architecture/workload-orchestrator.md#restart-policy-and-tuning-modes). |
+| `--worker-ram <str>` | auto | RAM per worker (e.g. `3G`, `512M`, `1073741824`). Bypasses auto-detection; total across all workers must not exceed host RAM. |
+| `--worker-cpus <int>` | auto | CPU cores per worker. Bypasses auto-detection; total across all workers must not exceed host cores. |
+| `--tuning-mode {online\|offline\|adaptive}` | `offline` | Restart policy. `online` = runtime knobs only, no restarts; `offline` = all knobs, restart every generation; `adaptive` = all knobs, restart every N generations. See [workload-orchestrator §Restart policy](../architecture/workload-orchestrator.md#restart-policy-and-tuning-modes). |
 | `--perturbation-factor <float>` | `0.2` | Perturbation spread factor for knob exploration. Range is `[1-X, 1+X]`. |
 | `--disable-early-stopping` | off | Run the full `--generations` even after the early-stopping patience expires. |
 | `--no-sync` | off | Disable lockstep barriers. **Reduces measurement fairness** — use only for single-worker debugging. See [generation-barriers](../architecture/generation-barriers.md). |
@@ -59,10 +61,10 @@ The primary entry point. See [getting-started/quickstart](../getting-started/qui
 
 | Flag | Default | Purpose |
 | --- | --- | --- |
-| `--scoring-policy {fixed_v1\|feature_driven_v2}` | `feature_driven_v2` | Score formula. See [feature-driven-scoring](../architecture/feature-driven-scoring.md). |
-| `--scoring-policy-version <str>` | `2.0` | Pinned policy version recorded in session JSON. |
-| `--metric-reference-version <str>` | `v2` | Metric semantics version recorded in session JSON. |
-| `--scoring-calibration-evals <int>` | `50` | Evaluations before the quantile normaliser's first calibration. |
+| `--scoring-policy {fixed_v1\|feature_driven_v2}` | falls back to PBT config (`feature_driven_v2` for new runs) | Score formula. See [feature-driven-scoring](../architecture/feature-driven-scoring.md). |
+| `--scoring-policy-version <str>` | from policy | Pinned policy version recorded in session JSON. |
+| `--metric-reference-version <str>` | from policy | Metric semantics version recorded in session JSON. |
+| `--scoring-calibration-evals <int>` | `5` | Evaluations before the quantile normaliser's first calibration. |
 
 ### Workload
 
@@ -108,7 +110,7 @@ The primary entry point. See [getting-started/quickstart](../getting-started/qui
 | `--colocate-output` | off | Place HTML logs alongside session JSONs in the same directory. |
 | `--ablation-variable <str>` | none | Tag the session with an ablation variable name (recorded in JSON metadata). |
 | `--ablation-value <str>` | none | The value of the ablation variable (recorded in JSON metadata). |
-| `--verbose {QUIET\|NORMAL\|VERBOSE\|DEBUG}` | `NORMAL` | Logging verbosity. |
+| `--verbose {DEBUG\|INFO\|WARNING\|ERROR\|TRACE}` | `INFO` | Logging verbosity. |
 | `--no-color` | off | Disable ANSI colour in console output. |
 
 ---
@@ -119,8 +121,8 @@ Post-hoc evaluation suite. See [guides/evaluation-runbook](../guides/evaluation-
 
 | Flag | Default | Purpose |
 | --- | --- | --- |
-| `--session <path>` | required | PBT session JSON to evaluate. Repeatable for multi-arm comparisons. |
-| `--bo-session <path>` | none | BO session JSON for direct comparison against the PBT session. |
+| `--session <path>` | required | PBT (or BO) session JSON to evaluate. |
+| `--bo-session <path>` | none | BO session JSON for 3-way Default vs BO vs PBT comparison alongside `--session`. |
 | `--benchmark {sysbench\|tpch}` | from session | Override the benchmark recorded in the session. |
 | `--repetitions <int>` | `5` | Number of paired (default, tuned) runs. |
 | `--seed <int>` | `50000` | Base seed; repetition `i` uses `seed + i - 1` for both default and tuned. |
@@ -131,10 +133,11 @@ Post-hoc evaluation suite. See [guides/evaluation-runbook](../guides/evaluation-
 | `--scoring-policy-version`, `--metric-reference-version` | from session | Pinned policy/metric versions. |
 | `--no-docker` | off | Bare-metal evaluation (reduced isolation; tagged in output JSON). |
 | `--data-dir` | `./.instances` | Worker PostgreSQL data directory root. |
-| `--docker-image <image>` | auto | Override the auto-resolved PostgreSQL image. |
+| `--docker-image <image>` | `pbt-eval` | Docker image name/tag for evaluation containers. |
 | `--output-dir` | `results` | Comparison artefact root. |
 | `--colocate-output` | off | Place comparison HTML alongside the JSON. |
-| `--verbose` | `INFO` | Logging verbosity. |
+| `--verbose {DEBUG\|INFO\|WARNING\|ERROR}` | `INFO` | Logging verbosity. |
+| `-v` | off | Shortcut for `--verbose DEBUG`. |
 
 ---
 

--- a/docs/reference/session-json-schema.md
+++ b/docs/reference/session-json-schema.md
@@ -1,8 +1,8 @@
 # Session JSON Schema
 
-> Last reviewed: 2026-06-13
+> Last reviewed: 2026-06-15
 
-See also: [evaluation-suite](../architecture/evaluation-suite.md), [feature-driven-scoring](../architecture/feature-driven-scoring.md), [pbt-core](../architecture/pbt-core.md), [bo-baseline guide](../guides/bo-baseline.md), [timing instrumentation contributor guide](../contributor/timing-instrumentation.md)
+See also: [evaluation-suite](../architecture/evaluation-suite.md), [feature-driven-scoring](../architecture/feature-driven-scoring.md), [pbt-core](../architecture/pbt-core.md), [bo-baseline guide](../guides/bo-baseline.md), [timing instrumentation contributor guide](timing-instrumentation.md)
 
 Every tuning run, evaluation comparison, and analysis pass emits or consumes one of three JSON shapes:
 
@@ -50,7 +50,7 @@ Backwards compatibility: v1.0 readers that walk `worker_scores[*].timing.summary
 
 ### Component reference
 
-The components currently emitted by the orchestrator, population, and tuner bootstrap. The source-file pointer is where the bracket is opened; new components are added by following the [contributor guide](../contributor/timing-instrumentation.md).
+The components currently emitted by the orchestrator, population, and tuner bootstrap. The source-file pointer is where the bracket is opened; new components are added by following the [contributor guide](timing-instrumentation.md).
 
 | Component | Layer | Semantics | Source |
 | --- | --- | --- | --- |

--- a/docs/reference/timing-instrumentation.md
+++ b/docs/reference/timing-instrumentation.md
@@ -1,10 +1,10 @@
 # Timing Instrumentation — Contributor Guide
 
-> Last reviewed: 2026-06-13
+> Last reviewed: 2026-06-15
 > Schema version this guide describes: **v1.1**
-> See also: [session JSON schema (timing section)](../reference/session-json-schema.md#timing-instrumentation-v10), [timing instrumentation plan](../research/timing-instrumentation-plan.md)
+> See also: [session JSON schema (timing section)](session-json-schema.md#timing-instrumentation-v11), [timing instrumentation plan](../research/timing-instrumentation-plan.md)
 
-This guide explains how to add a new component bracket to the PBTune timing instrumentation and how to read the timing data the system emits. The schema is documented in the [session JSON schema](../reference/session-json-schema.md#timing-instrumentation-v10); this page is about the *code* side.
+This guide explains how to add a new component bracket to the PBTune timing instrumentation and how to read the timing data the system emits. The schema is documented in the [session JSON schema](session-json-schema.md#timing-instrumentation-v11); this page is about the *code* side.
 
 ## The primitives
 
@@ -31,7 +31,7 @@ The per-worker recorder is returned out of `evaluate_worker` as part of the 5-tu
 
 1. **Pick the recorder** based on scope (see table above). For a per-worker bracket inside the orchestrator, use the local `recorder` already created at the top of `evaluate_worker`.
 
-2. **Pick a component name.** Snake_case, stable, descriptive of the *operation*, not the call site (`apply_only`, not `applicator_step1`). Don't reuse names already in the [component reference](../reference/session-json-schema.md#component-reference) for unrelated work. Names are the dimension key in the cost-decomposition table; renaming one silently invalidates older sessions through the analysis script.
+2. **Pick a component name.** Snake_case, stable, descriptive of the *operation*, not the call site (`apply_only`, not `applicator_step1`). Don't reuse names already in the [component reference](session-json-schema.md#component-reference) for unrelated work. Names are the dimension key in the cost-decomposition table; renaming one silently invalidates older sessions through the analysis script.
 
 3. **Wrap the work** in a `span` context manager:
 
@@ -55,7 +55,7 @@ The per-worker recorder is returned out of `evaluate_worker` as part of the 5-tu
    recorder.add("sysbench_measurement", measured_seconds, observed=False)
    ```
 
-6. **Update the component reference** in [docs/reference/session-json-schema.md](../reference/session-json-schema.md#component-reference) with the new entry: name, layer, semantics, source file. The table is the contract between code and the analysis script.
+6. **Update the component reference** in [session-json-schema.md](session-json-schema.md#component-reference) with the new entry: name, layer, semantics, source file. The table is the contract between code and the analysis script.
 
 7. **Add a test.** At minimum, assert that a representative run produces a record with the new component name. The orchestrator-stub-based integration test pattern in `tests/unit/tuner/` is a good template.
 
@@ -85,9 +85,27 @@ Empty recorders aggregate to `{}`.
 
 The session-level `timing_summary` is computed by `PBTTuner._aggregate_session_timing()`, which walks `generation_history`, merges every per-worker and per-generation `timing.records` into a single recorder, and emits its `aggregate()`. This means `timing_summary` reflects *all* observations of each component across the session — typically `n = population_size × total_generations` for worker-level components.
 
+## Algorithm-overhead mapping (PBT vs BO)
+
+The cost decomposition has one component per algorithm that captures the *non-evaluation* work the optimizer does between evaluations. These play the same role and should be compared directly:
+
+| Algorithm | Component | Source | What it covers |
+| --- | --- | --- | --- |
+| PBT | `evolve` (per-generation) | `Population.train_generation` — `execute_exploit_explore` + `env.clone_instances` | Exploit/explore decisions, per-worker config perturbation, physical PGDATA cloning of elite→poor workers |
+| BO (parallel) | `bo_overhead_ask` + `bo_overhead_tell` | `BORunner._run_parallel_optimization` — explicit brackets around `facade.ask()` and `facade.tell()` | Surrogate model query (ask) + observation update (tell) for each iteration |
+| BO (sequential) | `bo_overhead_seconds` (per-iteration) | `objective.py` — gap between successive `objective()` invocations | Same as parallel but measured indirectly: `t_iterN+1_start - t_iterN_end` is the time `facade.optimize()` spent on ask + tell + bookkeeping |
+
+For a fair PBT-vs-BO cost comparison, sum:
+
+- PBT side: `timing_summary["evolve"]["total"]`
+- BO parallel: `timing_summary["bo_overhead_ask"]["total"] + timing_summary["bo_overhead_tell"]["total"]`, OR equivalently `tuning_session.bo_overhead_total_seconds`
+- BO sequential: `tuning_session.bo_overhead_total_seconds` (sum of per-iteration `bo_overhead_seconds`; the last iteration's overhead is 0.0 because it has no successor — this is a known boundary effect, ≤1 iteration's worth of overhead)
+
+The two sides are not strictly identical work — PBT pays for physical data cloning while BO pays for surrogate-model fitting — but they sit at the same level in the cost-decomposition table: *non-evaluation algorithmic overhead per iteration*.
+
 ## Reading the JSON
 
-The full schema lives in [docs/reference/session-json-schema.md](../reference/session-json-schema.md#timing-instrumentation-v11). The shortest path from JSON to a per-component summary across a session:
+The full schema lives in [session-json-schema.md](session-json-schema.md#timing-instrumentation-v11). The shortest path from JSON to a per-component summary across a session:
 
 ```python
 import json
@@ -104,7 +122,7 @@ For per-generation or per-worker drill-down, walk `data["generation_history"][i]
 When you add a new component:
 
 - **You do not need to bump `timing_schema_version`.** Component names are an open vocabulary inside the existing schema. The version bumps for *structural* changes (new fields, semantic redefinition of an existing component), not for new entries in the `summary` dict.
-- **You do need to update the component reference table** in [docs/reference/session-json-schema.md](../reference/session-json-schema.md#component-reference).
+- **You do need to update the component reference table** in [session-json-schema.md](session-json-schema.md#component-reference).
 - **You do need to handle older sessions in any consumer** that depends on the component being present — `data["timing_summary"].get("my_component")` returns `None` for sessions written before the bracket existed.
 
 If you find yourself wanting to change the semantics of an existing component name (e.g. `workload` is split into `warmup` + `measurement`), do **not** redefine the existing name. Add new components alongside and update consumers to prefer the new ones when both are present. This keeps older sessions interpretable.

--- a/prototypes/restart_cost_model/README.md
+++ b/prototypes/restart_cost_model/README.md
@@ -11,6 +11,6 @@ the scoring function and the restart mechanism, and the penalty was
 a heuristic approximation rather than an empirical measurement.
 
 The new architecture replaces this with an explicit `RestartPolicy`
-(`src/tuner/evaluator/restart_policy.py`) that makes restart decisions
+(`src/tuner/benchmark/restart_policy.py`) that makes restart decisions
 based on the `TuningMode` (ONLINE / OFFLINE / ADAPTIVE), leaving the
 scoring function clean and unbiased.

--- a/scripts/experiments/experiment_matrix.py
+++ b/scripts/experiments/experiment_matrix.py
@@ -1,9 +1,17 @@
 import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+
+# Pinned seed lists. Frozen here as a single source of truth so a future
+# patch to one experiment cannot silently violate the cross-experiment
+# seed invariant the paper rests on. Tuples (not lists) so they remain
+# immutable and hashable.
+SEEDS_K5: Tuple[int, ...] = (42, 123, 456, 789, 1024)
+SEEDS_K1: Tuple[int, ...] = (42,)
+
 
 @dataclass(frozen=True)
 class Experiment:
@@ -16,8 +24,8 @@ class Experiment:
     config_profile: str                 # always "thorough"
     knob_tier: str                      # "extensive" | "minimal" | "core" | "standard"
     knob_source: str                    # "expert" | "data_driven"
-    tuning_mode: str                    # "offline"
-    seeds: List[int]
+    tuning_mode: str                    # "offline" | "online"
+    seeds: Tuple[int, ...]
     eval_repetitions: int               # 10 or 5
     run_bo: bool                        # True for Tier 1/2, False for Tier 3
     population: Optional[int] = None
@@ -28,6 +36,13 @@ class Experiment:
     perturbation_factor: Optional[float] = None
     ablation_variable: Optional[str] = None
     ablation_value: Optional[str] = None
+    # Warm-start: when set, the runner resolves the best_config.json from
+    # the manifest entry for ``(warm_start_source, warm_start_source_seed,
+    # pbt)`` and passes it as ``--warm-start <path>``. The source
+    # experiment must have completed its PBT phase before this experiment
+    # runs.
+    warm_start_source: Optional[str] = None
+    warm_start_source_seed: Optional[int] = None
 
 
 def get_data_driven_tier_experiments(workload_type: str = "oltp_read_write") -> List[Experiment]:
@@ -55,7 +70,7 @@ def get_data_driven_tier_experiments(workload_type: str = "oltp_read_write") -> 
                 knob_tier="extensive" if knobs is None else tier_name,
                 knob_source="data_driven",
                 tuning_mode="offline",
-                seeds=[42],
+                seeds=SEEDS_K1,
                 eval_repetitions=5,
                 run_bo=False,
                 ablation_variable="knob_source",
@@ -66,134 +81,162 @@ def get_data_driven_tier_experiments(workload_type: str = "oltp_read_write") -> 
 
 
 def build_all_experiments() -> List[Experiment]:
-    seeds_k5 = [42, 123, 456, 789, 1024]
-    seeds_k1 = [42]
-    
     experiments = [
-        # Tier 1
+        # Tier 1 — primary, K=5 for Wilcoxon-grade significance
         Experiment(
             id="t1_sysbench_rw", tier=1, description="Primary: Sysbench OLTP RW",
             benchmark="sysbench", sysbench_workload="oltp_read_write", scale_factor=None,
             config_profile="thorough", knob_tier="extensive", knob_source="expert", tuning_mode="offline",
-            seeds=seeds_k5, eval_repetitions=10, run_bo=True
+            seeds=SEEDS_K5, eval_repetitions=10, run_bo=True
         ),
         Experiment(
             id="t1_tpch_sf1", tier=1, description="Primary: TPC-H SF1",
             benchmark="tpch", sysbench_workload=None, scale_factor=1.0,
             config_profile="thorough", knob_tier="extensive", knob_source="expert", tuning_mode="offline",
-            seeds=seeds_k5, eval_repetitions=10, run_bo=True
+            seeds=SEEDS_K5, eval_repetitions=10, run_bo=True
         ),
-        
-        # Tier 2
+
+        # Tier 2 — generalizability. OFFLINE rows extend Tier 1 across the
+        # workload mix; ONLINE rows validate the no-restart claim — only
+        # valid on read-only workloads, where snapshots are auto-disabled
+        # (see docs/research/timing-instrumentation-plan.md §A and Phase
+        # 4.3b/4.3d calibration).
         Experiment(
-            id="t2_sysbench_ro", tier=2, description="Generalizability: Sysbench OLTP RO",
+            id="t2_sysbench_ro", tier=2, description="Generalizability: Sysbench OLTP RO (OFFLINE)",
             benchmark="sysbench", sysbench_workload="oltp_read_only", scale_factor=None,
             config_profile="thorough", knob_tier="extensive", knob_source="expert", tuning_mode="offline",
-            seeds=seeds_k1, eval_repetitions=10, run_bo=True
+            seeds=SEEDS_K1, eval_repetitions=10, run_bo=True
         ),
         Experiment(
-            id="t2_sysbench_wo", tier=2, description="Generalizability: Sysbench OLTP WO",
+            id="t2_sysbench_wo", tier=2, description="Generalizability: Sysbench OLTP WO (OFFLINE)",
             benchmark="sysbench", sysbench_workload="oltp_write_only", scale_factor=None,
             config_profile="thorough", knob_tier="extensive", knob_source="expert", tuning_mode="offline",
-            seeds=seeds_k1, eval_repetitions=10, run_bo=True
+            seeds=SEEDS_K1, eval_repetitions=10, run_bo=True
         ),
         Experiment(
-            id="t2_tpch_sf10", tier=2, description="Generalizability: TPC-H SF10",
+            id="t2_tpch_sf10", tier=2, description="Generalizability: TPC-H SF10 (OFFLINE)",
             benchmark="tpch", sysbench_workload=None, scale_factor=10.0,
             config_profile="thorough", knob_tier="extensive", knob_source="expert", tuning_mode="offline",
-            seeds=seeds_k1, eval_repetitions=10, run_bo=True
+            seeds=SEEDS_K1, eval_repetitions=10, run_bo=True
         ),
-        
+        Experiment(
+            id="t2_online_sysbench_ro", tier=2, description="Generalizability: Sysbench OLTP RO (ONLINE no-restart)",
+            benchmark="sysbench", sysbench_workload="oltp_read_only", scale_factor=None,
+            config_profile="thorough", knob_tier="extensive", knob_source="expert", tuning_mode="online",
+            seeds=SEEDS_K1, eval_repetitions=10, run_bo=True
+        ),
+        Experiment(
+            id="t2_online_tpch_sf1", tier=2, description="Generalizability: TPC-H SF1 (ONLINE no-restart)",
+            benchmark="tpch", sysbench_workload=None, scale_factor=1.0,
+            config_profile="thorough", knob_tier="extensive", knob_source="expert", tuning_mode="online",
+            seeds=SEEDS_K1, eval_repetitions=10, run_bo=True
+        ),
+
         # Tier 3 (Ablations)
         Experiment(
             id="t3_pop_4", tier=3, description="Ablation: Population size 4",
             benchmark="sysbench", sysbench_workload="oltp_read_write", scale_factor=None,
             config_profile="thorough", knob_tier="extensive", knob_source="expert", tuning_mode="offline",
-            seeds=seeds_k1, eval_repetitions=5, run_bo=False,
+            seeds=SEEDS_K1, eval_repetitions=5, run_bo=False,
             population=4, ablation_variable="population_size", ablation_value="4"
         ),
         Experiment(
             id="t3_pop_12", tier=3, description="Ablation: Population size 12",
             benchmark="sysbench", sysbench_workload="oltp_read_write", scale_factor=None,
             config_profile="thorough", knob_tier="extensive", knob_source="expert", tuning_mode="offline",
-            seeds=seeds_k1, eval_repetitions=5, run_bo=False,
+            seeds=SEEDS_K1, eval_repetitions=5, run_bo=False,
             population=12, parallel_workers=6, ablation_variable="population_size", ablation_value="12"
         ),
         Experiment(
             id="t3_pop_16", tier=3, description="Ablation: Population size 16",
             benchmark="sysbench", sysbench_workload="oltp_read_write", scale_factor=None,
             config_profile="thorough", knob_tier="extensive", knob_source="expert", tuning_mode="offline",
-            seeds=seeds_k1, eval_repetitions=5, run_bo=False,
+            seeds=SEEDS_K1, eval_repetitions=5, run_bo=False,
             population=16, parallel_workers=8, ablation_variable="population_size", ablation_value="16"
         ),
         Experiment(
             id="t3_scoring_v1", tier=3, description="Ablation: Scoring fixed_v1",
             benchmark="sysbench", sysbench_workload="oltp_read_write", scale_factor=None,
             config_profile="thorough", knob_tier="extensive", knob_source="expert", tuning_mode="offline",
-            seeds=seeds_k1, eval_repetitions=5, run_bo=False,
+            seeds=SEEDS_K1, eval_repetitions=5, run_bo=False,
             scoring_policy="fixed_v1", ablation_variable="scoring_pipeline", ablation_value="fixed_v1"
         ),
         Experiment(
             id="t3_exploit_020", tier=3, description="Ablation: Exploit 0.20 (Pop 12)",
             benchmark="sysbench", sysbench_workload="oltp_read_write", scale_factor=None,
             config_profile="thorough", knob_tier="extensive", knob_source="expert", tuning_mode="offline",
-            seeds=seeds_k1, eval_repetitions=5, run_bo=False,
+            seeds=SEEDS_K1, eval_repetitions=5, run_bo=False,
             population=12, parallel_workers=6, exploit_quantile=0.20, ablation_variable="exploit_quantile", ablation_value="0.20"
         ),
         Experiment(
             id="t3_exploit_025", tier=3, description="Ablation: Exploit 0.25 (Pop 12)",
             benchmark="sysbench", sysbench_workload="oltp_read_write", scale_factor=None,
             config_profile="thorough", knob_tier="extensive", knob_source="expert", tuning_mode="offline",
-            seeds=seeds_k1, eval_repetitions=5, run_bo=False,
+            seeds=SEEDS_K1, eval_repetitions=5, run_bo=False,
             population=12, parallel_workers=6, exploit_quantile=0.25, ablation_variable="exploit_quantile", ablation_value="0.25"
         ),
         Experiment(
             id="t3_exploit_030", tier=3, description="Ablation: Exploit 0.30 (Pop 12)",
             benchmark="sysbench", sysbench_workload="oltp_read_write", scale_factor=None,
             config_profile="thorough", knob_tier="extensive", knob_source="expert", tuning_mode="offline",
-            seeds=seeds_k1, eval_repetitions=5, run_bo=False,
+            seeds=SEEDS_K1, eval_repetitions=5, run_bo=False,
             population=12, parallel_workers=6, exploit_quantile=0.30, ablation_variable="exploit_quantile", ablation_value="0.30"
         ),
         Experiment(
             id="t3_tier_minimal", tier=3, description="Ablation: Knob tier minimal",
             benchmark="sysbench", sysbench_workload="oltp_read_write", scale_factor=None,
             config_profile="thorough", knob_tier="minimal", knob_source="expert", tuning_mode="offline",
-            seeds=seeds_k1, eval_repetitions=5, run_bo=False,
+            seeds=SEEDS_K1, eval_repetitions=5, run_bo=False,
             ablation_variable="knob_tier", ablation_value="minimal"
         ),
         Experiment(
             id="t3_tier_core", tier=3, description="Ablation: Knob tier core",
             benchmark="sysbench", sysbench_workload="oltp_read_write", scale_factor=None,
             config_profile="thorough", knob_tier="core", knob_source="expert", tuning_mode="offline",
-            seeds=seeds_k1, eval_repetitions=5, run_bo=False,
+            seeds=SEEDS_K1, eval_repetitions=5, run_bo=False,
             ablation_variable="knob_tier", ablation_value="core"
         ),
         Experiment(
             id="t3_tier_standard", tier=3, description="Ablation: Knob tier standard",
             benchmark="sysbench", sysbench_workload="oltp_read_write", scale_factor=None,
             config_profile="thorough", knob_tier="standard", knob_source="expert", tuning_mode="offline",
-            seeds=seeds_k1, eval_repetitions=5, run_bo=False,
+            seeds=SEEDS_K1, eval_repetitions=5, run_bo=False,
             ablation_variable="knob_tier", ablation_value="standard"
         ),
         Experiment(
             id="t3_perturb_narrow", tier=3, description="Ablation: Perturbation narrow [0.9, 1.1]",
             benchmark="sysbench", sysbench_workload="oltp_read_write", scale_factor=None,
             config_profile="thorough", knob_tier="extensive", knob_source="expert", tuning_mode="offline",
-            seeds=seeds_k1, eval_repetitions=5, run_bo=False,
+            seeds=SEEDS_K1, eval_repetitions=5, run_bo=False,
             perturbation_factor=0.1, ablation_variable="perturbation_factor", ablation_value="0.1"
         ),
         Experiment(
             id="t3_perturb_wide", tier=3, description="Ablation: Perturbation wide [0.6, 1.4]",
             benchmark="sysbench", sysbench_workload="oltp_read_write", scale_factor=None,
             config_profile="thorough", knob_tier="extensive", knob_source="expert", tuning_mode="offline",
-            seeds=seeds_k1, eval_repetitions=5, run_bo=False,
+            seeds=SEEDS_K1, eval_repetitions=5, run_bo=False,
             perturbation_factor=0.4, ablation_variable="perturbation_factor", ablation_value="0.4"
         ),
+        # Warm-start ablation: bootstrap an ONLINE run on Sysbench RO from
+        # the best config produced by the OFFLINE t1_sysbench_rw run.
+        # Validates the OFFLINE-then-ONLINE deployment path (plan §A,
+        # Tier 3 row). The runner resolves the upstream best_config.json
+        # via the manifest entry for (warm_start_source,
+        # warm_start_source_seed, pbt).
+        Experiment(
+            id="t3_warm_start_offline_to_online", tier=3,
+            description="Ablation: OFFLINE→ONLINE warm-start (Sysbench RW source, RO target)",
+            benchmark="sysbench", sysbench_workload="oltp_read_only", scale_factor=None,
+            config_profile="thorough", knob_tier="extensive", knob_source="expert", tuning_mode="online",
+            seeds=SEEDS_K1, eval_repetitions=5, run_bo=False,
+            ablation_variable="warm_start", ablation_value="offline_to_online",
+            warm_start_source="t1_sysbench_rw", warm_start_source_seed=42,
+        ),
     ]
-    
+
     # Add dynamic data-driven tier experiments
     experiments.extend(get_data_driven_tier_experiments())
-    
+
     return experiments
 
 def get_experiments_by_tier(tier: int) -> List[Experiment]:

--- a/scripts/experiments/runner.py
+++ b/scripts/experiments/runner.py
@@ -151,7 +151,7 @@ class ExperimentRunner:
                         self._mark_status(bo_key, "failed", error="Missing PBT JSON")
                     else:
                         LOGGER.info(f"Phase 2/3: Running BO for {exp.id} (seed {seed})")
-                        cmd = self._build_bo_cmd(pbt_session_path, seed)
+                        cmd = self._build_bo_cmd(exp, pbt_session_path, seed)
                         self._mark_status(bo_key, "running", started_at=datetime.utcnow().isoformat() + "Z")
                         
                         start_time = time.time()
@@ -196,6 +196,67 @@ class ExperimentRunner:
             else:
                 LOGGER.info(f"Skipping EVAL (already done/failed)")
 
+    def _resolve_warm_start_path(self, exp: Experiment) -> Optional[Path]:
+        """Resolve the best_config.json path for a warm-start experiment.
+
+        The source experiment's PBT phase must have completed and recorded
+        a session_json in the manifest. The best_config.json lives as a
+        sibling of the session JSON: ``.../pbt_runs/<tier>/best_configs/
+        best_config_<timestamp>.json`` (vs ``.../pbt_runs/<tier>/
+        tuning_sessions/pbt_results_<timestamp>.json``).
+
+        Returns None if the source isn't ready (caller should fail fast).
+        """
+        if exp.warm_start_source is None or exp.warm_start_source_seed is None:
+            return None
+
+        source_key = self._get_run_key(
+            exp.warm_start_source, exp.warm_start_source_seed, "pbt"
+        )
+        source_run = self.manifest["runs"].get(source_key, {})
+        if source_run.get("status") != "done":
+            LOGGER.error(
+                "Warm-start source %s/seed_%d/pbt is not done (status=%s). "
+                "Run that experiment first, or remove --tier filtering so the "
+                "matrix runs in dependency order.",
+                exp.warm_start_source,
+                exp.warm_start_source_seed,
+                source_run.get("status", "missing"),
+            )
+            return None
+
+        session_json_str = source_run.get("session_json")
+        if not session_json_str:
+            LOGGER.error(
+                "Warm-start source %s recorded no session_json in manifest.",
+                source_key,
+            )
+            return None
+
+        session_path = PROJECT_ROOT / session_json_str
+        # Derive sibling best_config path. Filenames share the timestamp
+        # suffix; only the directory differs (tuning_sessions ↔ best_configs)
+        # and the prefix (pbt_results_ ↔ best_config_).
+        try:
+            best_config_path = (
+                session_path.parent.parent
+                / "best_configs"
+                / session_path.name.replace("pbt_results_", "best_config_", 1)
+            )
+        except Exception as e:
+            LOGGER.error("Failed to derive best_config path from %s: %s", session_path, e)
+            return None
+
+        if not best_config_path.exists():
+            LOGGER.error(
+                "Warm-start best_config not found at %s (session was %s)",
+                best_config_path,
+                session_path,
+            )
+            return None
+
+        return best_config_path
+
     def _build_pbt_cmd(self, exp: Experiment, seed: int) -> List[str]:
         cmd = [
             "python", "-m", "src.tuner.main",
@@ -205,13 +266,18 @@ class ExperimentRunner:
             "--benchmark", exp.benchmark,
             "--random-seed", str(seed),
             "--tuning-mode", exp.tuning_mode,
+            # Pin restore interval explicitly so the experiment is
+            # self-documenting and cannot drift if THOROUGH_CONFIG changes
+            # upstream. THOROUGH currently has interval=1; the explicit
+            # flag makes that contract part of the experiment record.
+            "--snapshot-restore-interval", "1",
             "--force-recreate-instances",
             "--cleanup-instances",
             "--worker-ram", self.worker_ram,
             "--worker-cpus", str(self.worker_cpus),
-            "--verbose", "INFO"
+            "--verbose", "DEBUG"
         ]
-        
+
         if exp.sysbench_workload:
             cmd.extend(["--sysbench-workload", exp.sysbench_workload])
         if exp.scale_factor is not None:
@@ -233,19 +299,48 @@ class ExperimentRunner:
                 "--ablation-variable", exp.ablation_variable,
                 "--ablation-value", str(exp.ablation_value)
             ])
-            
+
+        # Warm-start: resolve upstream best_config.json from the manifest.
+        # If the source isn't ready, the resolver returns None and logs
+        # an error; we fall through without a flag so PBT runs without
+        # warm-start (LHS init only). Caller should check
+        # _resolve_warm_start_path before invoking when correctness matters.
+        if exp.warm_start_source is not None:
+            warm_path = self._resolve_warm_start_path(exp)
+            if warm_path is not None:
+                cmd.extend(["--warm-start", str(warm_path)])
+            elif self.dry_run:
+                cmd.extend(["--warm-start", "DRY_RUN_WARM_START_PATH.json"])
+
         return cmd
 
-    def _build_bo_cmd(self, pbt_session: Optional[Path], seed: int) -> List[str]:
+    def _build_bo_cmd(self, exp: Experiment, pbt_session: Optional[Path], seed: int) -> List[str]:
+        # BO inherits population/budget from the PBT session via
+        # --pbt-session, but every experiment-defining flag is passed
+        # explicitly so a stale or partial session JSON cannot silently
+        # change the workload shape. Anything that would mismatch the
+        # PBT run breaks the fair-comparison invariant the paper rests on.
         cmd = [
             "python", "-m", "src.scripts.bo_baseline",
+            "--config", exp.config_profile,
+            "--tier", exp.knob_tier,
+            "--knob-source", exp.knob_source,
+            "--benchmark", exp.benchmark,
             "--seed", str(seed),
+            "--tuning-mode", exp.tuning_mode,
+            "--enable-snapshots",
+            "--snapshot-restore-interval", "1",
             "--force-recreate-instances",
             "--cleanup-instances",
             "--worker-ram", self.worker_ram,
             "--worker-cpus", str(self.worker_cpus),
-            "--verbose", "INFO"
+            "--verbose", "DEBUG"
         ]
+        if exp.sysbench_workload:
+            cmd.extend(["--sysbench-workload", exp.sysbench_workload])
+        if exp.scale_factor is not None:
+            cmd.extend(["--scale-factor", str(exp.scale_factor)])
+
         if pbt_session:
             cmd.extend(["--pbt-session", str(pbt_session)])
         elif self.dry_run:

--- a/src/scripts/bo_baseline/objective.py
+++ b/src/scripts/bo_baseline/objective.py
@@ -179,6 +179,11 @@ def create_objective(
         "previous_config": None,
         "iteration_count": 0,
         "ranges_frozen": False,
+        # Monotonic timestamp of the previous iteration's end. The gap
+        # between iter[N].end and iter[N+1].start is the BO overhead
+        # (facade.ask + facade.tell + SMAC bookkeeping) that produced
+        # the next configuration. We attribute that gap back to iter[N].
+        "last_iter_end_monotonic": None,
     }
 
     def objective(config: Configuration, seed: int = 0) -> float:
@@ -198,6 +203,24 @@ def create_objective(
             Cost value (100 - score), with penalties for failures
         """
         try:
+            # Measure the BO overhead that occurred between the previous
+            # iteration's end and this call: facade.ask + facade.tell +
+            # SMAC's surrogate update. Attribute it to the PREVIOUS
+            # iteration (whose return triggered the ask/tell that
+            # produced *this* configuration). The very first iteration
+            # has no predecessor — its incoming overhead is captured by
+            # the runner's pre-optimize bracket if any.
+            iter_start_monotonic = time.monotonic()
+            if (
+                state["last_iter_end_monotonic"] is not None
+                and iteration_log
+            ):
+                inter_call_gap = (
+                    iter_start_monotonic - state["last_iter_end_monotonic"]
+                )
+                if inter_call_gap > 0:
+                    iteration_log[-1]["bo_overhead_seconds"] = inter_call_gap
+
             # Handle snapshot restoration before evaluating the config
             if (
                 enable_snapshots
@@ -238,8 +261,12 @@ def create_objective(
                 "restarted": restarted,
                 "timestamp": time.time(),
                 "timing": eval_timing.to_dict(include_summary=False),
-                # Sequential mode does not bracket ask/tell — see runner.py for
-                # the parallel-mode path that breaks these out.
+                # In sequential mode this is updated retroactively when the
+                # NEXT objective() call begins — the inter-call gap captures
+                # facade.ask + facade.tell + SMAC bookkeeping. The final
+                # iteration of a session keeps the 0.0 default since it
+                # has no successor. Parallel mode populates this directly
+                # in runner.py from explicit ask/tell brackets.
                 "bo_overhead_seconds": 0.0,
             }
             iteration_log.append(iteration_entry)
@@ -270,10 +297,17 @@ def create_objective(
                 f"wall_time={wall_time:.2f}s, frozen={state['ranges_frozen']}"
             )
 
+            # Stamp this iteration's end so the NEXT objective() call can
+            # measure the BO overhead gap and attribute it to this entry.
+            state["last_iter_end_monotonic"] = time.monotonic()
+
             return cost
 
         except Exception as e:
             LOGGER.error(f"Error evaluating configuration: {e}", exc_info=True)
+            # Still stamp so the next overhead measurement isn't polluted
+            # by error-path time.
+            state["last_iter_end_monotonic"] = time.monotonic()
             return 100.0
 
     return objective

--- a/src/tuner/config/tuner_config.py
+++ b/src/tuner/config/tuner_config.py
@@ -254,7 +254,7 @@ RAPID_CONFIG = PBTConfig(
     ready_interval=1,
     num_parallel_workers=2,
     benchmark_config=clone_benchmark_config(RAPID_BENCHMARK_CONFIG),
-    snapshot_restore_interval=1,  # Calibration: every gen so snapshot_restore records fire
+    snapshot_restore_interval=10,  # Infrequent snapshotting for speed
     verbose=True,
 )
 

--- a/src/tuner/main.py
+++ b/src/tuner/main.py
@@ -1657,7 +1657,7 @@ on your hardware, configuration, and workload/benchmark.
         choices=["online", "offline", "adaptive"],
         help=(
             "Tuning mode controlling restart behavior "
-            "(default: online). "
+            "(default: offline). "
             "online = runtime knobs only, no restarts; "
             "offline = all knobs, restart every generation; "
             "adaptive = all knobs, restart every N generations"

--- a/src/utils/environments/docker.py
+++ b/src/utils/environments/docker.py
@@ -409,6 +409,13 @@ class DockerEnvironment(DatabaseEnvironment):
 
         Copies the snapshot's PGDATA directory into the worker's bind-mount
         directory using a container (to handle UID 999 ownership).
+
+        The freshly-written ``postgresql.auto.conf`` is preserved across the
+        wipe so the knob configuration applied by the orchestrator survives
+        a restore-as-restart. The snapshot itself was created with auto.conf
+        excluded (see ``create_snapshot``), so the post-copy state has only
+        the per-worker auto.conf the orchestrator just wrote — which is the
+        whole point of the apply_only -> restore-as-restart sequence.
         """
         snapshot_pgdata = self._snapshot_host_dir()
         if not snapshot_pgdata.exists():
@@ -419,7 +426,21 @@ class DockerEnvironment(DatabaseEnvironment):
             )
             return None
 
-        pgdata_dir = self._prepare_worker_pgdata_dir(worker_id, quiet=quiet)
+        # Do NOT wipe the destination from the host side: that would destroy
+        # the postgresql.auto.conf the orchestrator just wrote via apply_only.
+        # The wipe + preserve + copy + restore happens atomically inside the
+        # copy container (which runs as UID 999 and can manage postgres-owned
+        # files without chown errors).
+        pgdata_dir = self._worker_host_pgdata_dir(worker_id)
+        if not pgdata_dir.exists():
+            # Brand-new path (e.g. first restore on a fresh repo): create
+            # with permissive mode so the copy container can write into it.
+            pgdata_dir.mkdir(parents=True, exist_ok=True)
+            os.chmod(pgdata_dir, 0o777)
+        # If the dir already exists, don't mkdir or chmod — the host user
+        # may not own the contents (postgres UID 999 created them) and
+        # ``os.chmod`` would raise PermissionError. The copy container
+        # handles all in-directory mutation as 999:999.
 
         try:
             with self._with_timeout(self._restore_api_timeout):
@@ -427,7 +448,26 @@ class DockerEnvironment(DatabaseEnvironment):
                     self.image_name,
                     user="999:999",  # Copy as postgres user to avoid chown errors on exFAT/NTFS
                     entrypoint=["bash", "-lc"],
-                    command=["set -euo pipefail; cp -R /source/. /dest/"],
+                    command=[
+                        # 1. Preserve auto.conf if present (apply_only just
+                        #    wrote the worker's knobs there).
+                        # 2. Wipe everything in /dest (worker's stale PGDATA).
+                        # 3. Copy snapshot in (snapshot has no auto.conf).
+                        # 4. Restore preserved auto.conf if we saved one.
+                        # find -mindepth 1 -delete leaves /dest itself intact
+                        # but removes every child (regular files, dirs, dotfiles).
+                        "set -euo pipefail; "
+                        "PRESERVED=0; "
+                        "if [ -f /dest/postgresql.auto.conf ]; then "
+                        "  cp -p /dest/postgresql.auto.conf /tmp/auto.conf.preserve; "
+                        "  PRESERVED=1; "
+                        "fi; "
+                        "find /dest -mindepth 1 -delete; "
+                        "cp -R /source/. /dest/; "
+                        "if [ \"$PRESERVED\" = \"1\" ]; then "
+                        "  cp -p /tmp/auto.conf.preserve /dest/postgresql.auto.conf; "
+                        "fi"
+                    ],
                     volumes={
                         self._docker_bind_path(snapshot_pgdata): {
                             "bind": "/source",

--- a/src/utils/types.py
+++ b/src/utils/types.py
@@ -67,7 +67,7 @@ class BenchmarkConfig:
     sysbench_table_size: int = 100000
     sysbench_workload: str = DEFAULT_SYSBENCH_WORKLOAD
     scale_factor: float = 0.1
-    tuning_mode: TuningMode = TuningMode.ONLINE
+    tuning_mode: TuningMode = TuningMode.OFFLINE
     adaptive_restart_interval: int = 10
 
     def __post_init__(self) -> None:

--- a/tests/unit/utils/test_docker_environment.py
+++ b/tests/unit/utils/test_docker_environment.py
@@ -131,6 +131,70 @@ def test_restore_snapshot_returns_false_when_container_run_fails() -> None:
     assert env.restore_snapshot(worker_id=0, snapshot_id="pbt-snapshot-test") is False
 
 
+def test_seed_pgdata_dir_preserves_auto_conf_across_restore(tmp_path: Path) -> None:
+    """The copy container must preserve postgresql.auto.conf so the worker's
+    freshly-applied knobs (written by apply_only just before restore) survive
+    the wipe-and-reseed.
+
+    Regression test for the bug where `_prepare_worker_pgdata_dir` wiped the
+    PGDATA bind mount from the host, destroying the auto.conf that
+    `apply_only` had just written. The fix moves the wipe + auto.conf
+    preserve + copy into a single atomic shell command inside the copy
+    container.
+    """
+    env = _make_environment()
+    env.base_dir = tmp_path
+
+    # Make the snapshot dir exist so the early-return guard passes.
+    snapshot_dir = env._snapshot_host_dir()
+    snapshot_dir.mkdir(parents=True, exist_ok=True)
+
+    # Capture what command the copy container actually receives.
+    captured: dict = {}
+
+    def _run_capture(*args, **kwargs):
+        captured.update(kwargs)
+        m = MagicMock()
+        m.wait.return_value = {"StatusCode": 0}
+        return m
+
+    env.client.containers.run.side_effect = _run_capture
+
+    result = env._seed_pgdata_dir_from_snapshot(worker_id=0, quiet=True)
+    assert result is not None
+
+    cmd = captured.get("command")
+    assert cmd is not None, "containers.run must be called with a command"
+    cmd_str = cmd[0] if isinstance(cmd, list) else cmd
+
+    # Three invariants that prevent the auto.conf-wipe regression:
+    # 1. The pre-copy preservation hop must exist (cp before delete).
+    assert "/dest/postgresql.auto.conf" in cmd_str, (
+        "Command must reference /dest/postgresql.auto.conf for preservation"
+    )
+    assert "auto.conf.preserve" in cmd_str, (
+        "Command must save auto.conf to a tmp location before wiping /dest"
+    )
+    # 2. The wipe + copy + restore sequence must be ordered correctly:
+    #    preserve -> delete -> copy -> restore. We assert ordering by string
+    #    position in the single shell command.
+    save_pos = cmd_str.find("auto.conf.preserve")
+    delete_pos = cmd_str.find("find /dest")
+    copy_pos = cmd_str.find("cp -R /source")
+    restore_pos = cmd_str.rfind("auto.conf.preserve")
+    assert 0 <= save_pos < delete_pos < copy_pos < restore_pos, (
+        f"Sequence must be preserve→delete→copy→restore; got positions "
+        f"save={save_pos} delete={delete_pos} copy={copy_pos} restore={restore_pos}"
+    )
+    # 3. The destructive host-side wipe must NOT be used: that's what caused
+    #    the bug. _prepare_worker_pgdata_dir calls _force_remove_host_dir,
+    #    which would destroy auto.conf before the container ever runs.
+    #    Patching here would silently regress us — assert via call count.
+    assert not any(
+        "force_remove" in str(call) for call in env.client.containers.run.mock_calls
+    ), "Host-side _force_remove_host_dir must not be invoked during restore"
+
+
 @pytest.mark.skip(reason="Legacy volume tests")
 def test_restore_snapshot_uses_restore_specific_ready_timeout() -> None:
     """Snapshot restore should use a longer, restore-specific readiness timeout."""

--- a/workloads/README.md
+++ b/workloads/README.md
@@ -1,6 +1,6 @@
 # Custom Workload Files
 
-> Last reviewed: 2026-03-13
+> Last reviewed: 2026-06-15
 
 See also: [Documentation Index](../docs/README.md)
 
@@ -120,7 +120,7 @@ python -m src.tuner.main --tier minimal --workload-file workloads/my_workload.ya
 
 ```python
 from src.tuner.main import PBTTuner
-from src.tuner.evaluator.metrics import WorkloadType
+from src.utils.metrics import WorkloadType
 
 tuner = PBTTuner(
     knob_tier="core",
@@ -252,4 +252,4 @@ pip install pyyaml
 - Check for typos in SQL statements
 - Verify database connection
 
-> Check `src/tuner/evaluator/evaluator.py` for implementation details and [`../docs/BENCHMARKING.md`](../docs/BENCHMARKING.md) for the full architecture overview.
+> Check `src/tuner/benchmark/orchestrator.py` for implementation details and [`../docs/reference/benchmarking.md`](../docs/reference/benchmarking.md) for the full architecture overview.


### PR DESCRIPTION
## Summary

Follow-ups to the timing-instrumentation work that landed in #93 (`feat/timing-instrumentation`). This branch fixes a latent correctness bug, adds the missing piece of BO timing parity, flips the default tuning mode to OFFLINE, and expands the cloud experiments matrix to honor the paper's ONLINE-on-RO and warm-start ablation claims.

Six conventional commits, scoped tightly so each one is independently reviewable.

## Commits

### 1. `fix(env): Preserve postgresql.auto.conf across docker snapshot restore` — **the important one**

The Docker backend's `restore_snapshot` path wiped the worker's PGDATA directory before copying the snapshot in. Phase 2B.7 had excluded `postgresql.auto.conf` from the snapshot itself so the orchestrator's freshly-applied knobs (written by `apply_only` just before the restore-as-restart) would survive the round-trip — but the wipe-then-copy pattern destroyed that freshly-written auto.conf before the copy ever ran. PG restarted from the snapshot with no auto.conf, falling back to defaults. The mismatch was visible in verification logs as 49–56 of 179 knobs "verified" (the count of sampled knobs that happened to coincide with PG defaults — pure noise).

The bare-metal backend was already correct: `rsync --delete --exclude postgresql.auto.conf` preserves the destination's auto.conf naturally.

Fix moves the wipe + auto.conf preservation + copy into a single atomic shell command inside the existing copy container (which runs as UID 999:999 and can manage postgres-owned files). Regression test added.

**Validation:** `--tier extensive` (179 knobs) × 4 workers × 5 gens, OFFLINE+RW, `snapshot_restore_interval=1` produced zero "Configuration mismatch" warnings across all 3,580 per-knob verifications.

### 2. `feat(bo): Measure sequential-mode ask/tell overhead via inter-call gap`

BO sequential mode previously emitted `bo_overhead_seconds=0.0` because SMAC's `facade.optimize()` runs the ask/tell loop internally — the parallel path explicitly brackets `facade.ask()` and `facade.tell()`, but sequential mode had no comparable hook.

Track `time.monotonic()` at the end of each `objective()` invocation. When the next call begins, the gap between `iter[N].end` and `iter[N+1].start` is the work `facade.optimize()` did between evaluations (surrogate query, model update, SMAC bookkeeping). Attribute the gap retroactively to the previous iteration's `bo_overhead_seconds`. The final iteration keeps 0.0 because it has no successor — a known boundary effect, ≤1 iteration's worth of overhead.

Smoke-tested with 5 sequential iterations: total `bo_overhead = 4.79s` (was always 0.0). The 4.75s spike on iter 1 is exactly when SMAC switches from random sampling to surrogate-driven search — a real signal.

### 3. `feat(config): Default tuning_mode to OFFLINE`

`BenchmarkConfig.tuning_mode` defaulted to `TuningMode.ONLINE`, so every research script had to pass `--tuning-mode offline` explicitly or risk silently running the wrong mode. Flip the default to OFFLINE (the recommended Tier 1 mode); ONLINE remains fully supported and has explicit Tier 2 rows in the experiment matrix (`t2_online_sysbench_ro`, `t2_online_tpch_sf1`) and a Tier 3 warm-start ablation.

Single-source-of-truth flip in `BenchmarkConfig` propagates to both PBT and BO via the shared dataclass. CLI help text updated. No test regressions.

### 4. `chore(config): Restore RAPID profile snapshot_restore_interval to 10`

A temporary `interval=1` (made during Phase 4 calibration so the `snapshot_restore` component would emit records on every generation of a 5-gen run) accidentally got carried into the merge of #93. RAPID is the dev-iteration profile and benefits from infrequent snapshotting; production-grade profiles (THOROUGH, RESEARCH, EXTREME) already use `interval=1`. Restore RAPID's original value.

### 5. `feat(experiments): Expand cloud matrix and pin BO/PBT flags for fair comparison`

An audit of `scripts/experiments/` surfaced four correctness issues:

- **C1 — Tier 2 ONLINE rows missing.** Paper claims ONLINE-mode generalizability on read-only workloads (the only mode/workload combination where ONLINE's no-restart promise genuinely holds; verified in Phase 4.3d). Without these rows, the paper's ONLINE-mode column has no data. Added `t2_online_sysbench_ro`, `t2_online_tpch_sf1`.
- **C2 — Warm-start Tier 3 ablation missing.** Added `t3_warm_start_offline_to_online` plus new `warm_start_source` / `warm_start_source_seed` fields on `Experiment`, and `runner._resolve_warm_start_path()` that reads the manifest entry for the upstream PBT phase and derives the sibling `best_config.json` path.
- **C3 — Snapshot interval was implicit** via `THOROUGH_CONFIG`. Pass `--snapshot-restore-interval 1` explicitly to both PBT and BO so experiments are self-documenting.
- **C4 — BO previously inherited workload shape entirely from `--pbt-session` parsing.** Pass every experiment-defining flag explicitly (`--config`, `--tier`, `--knob-source`, `--benchmark`, `--tuning-mode`, `--enable-snapshots`, `--sysbench-workload` / `--scale-factor`). Session-JSON inheritance now only matters for population/budget.

Matrix went from 19 to 23 experiments. Dry-run verifies both PBT and BO commands emit the expected explicit flags.

### 6. `docs: Refresh project docs, agent skills, and tooling for post-instrumentation state`

Companion documentation. No source-behavior changes. Highlights:

- `docs/reference/timing-instrumentation.md` bumped to v1.1; adds an "Algorithm-overhead mapping" section so the cost-decomposition table compares PBT `evolve` against BO `bo_overhead_*` at the same level of the hierarchy.
- Architecture/guides/getting-started updated to reflect the renamed module layout (`orchestrator/`, no more `evaluator/`), the lockstep-barriers design, and the v1.1 schema.
- `CLAUDE.md`, `README.md`, skill docs refreshed for the post-merge state.
- New `.claude/agents/` definitions for tooling (implementation-plan, prd, polyglot-test-generator, postgresql-dba, research-technical-spike).

## Test plan

- [x] `make lint` — clean
- [x] `pytest tests/` — 458 passed, 7 skipped, 1 pre-existing unrelated failure (`test_bo_config_falls_back_when_pbt_session_invalid` — `n_iterations` config-default drift, not introduced by this PR)
- [x] Docker auto.conf-fix regression test added (`test_seed_pgdata_dir_preserves_auto_conf_across_restore`)
- [x] End-to-end calibration on `extensive` tier (179 knobs × 4 workers × 5 gens) — zero verification mismatches
- [x] BO sequential overhead smoke test — non-zero per-iteration overhead with the expected SMAC ramp-up signature
- [x] Cloud-matrix dry-run for `t1_sysbench_rw` and `t3_warm_start_offline_to_online` — all explicit flags emitted; warm-start resolver fails fast with a clear error when source isn't ready