### PR TITLE
Chore/expand lint scope

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,14 +10,14 @@ test:
 	$(PYTHON) -m pytest -q tests/unit
 
 lint:
-	$(PYTHON) -m ruff check src tests
+	$(PYTHON) -m ruff check src tests scripts
 
 lint-fix:
-	$(PYTHON) -m ruff check --fix src tests
-	$(PYTHON) -m ruff format src tests
+	$(PYTHON) -m ruff check --fix src tests scripts
+	$(PYTHON) -m ruff format src tests scripts
 
 typecheck:
-	$(PYTHON) -m mypy src/evaluation src/utils src/scripts
+	$(PYTHON) -m mypy src scripts
 
 check-all: lint typecheck test
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ extend-select = ["F401", "F841", "I", "UP", "B"]
 # Legacy modules are onboarded incrementally for import ordering and pyupgrade rules.
 "src/**/*.py" = ["I001", "UP"]
 "tests/**/*.py" = ["I001", "UP"]
+"scripts/**/*.py" = ["I001"]
 
 [tool.mypy]
 python_version = "3.11"
@@ -24,8 +25,36 @@ follow_imports = "skip"
 warn_unused_ignores = false
 warn_redundant_casts = false
 exclude = ["src/benchmarks/tpch/tpch-dbgen"]
-files = ["src/evaluation", "src/utils/logger", "src/utils", "src/scripts"]
+files = ["src", "scripts"]
 
 [[tool.mypy.overrides]]
 module = ["docker", "docker.*", "psycopg2", "psycopg2.*", "psutil"]
 ignore_missing_imports = true
+
+# Baselined modules that fail typecheck under the expanded scope.
+# Each entry is a follow-up task: drop the module from this list once
+# its type errors are addressed. Do not add new modules here — fix the
+# errors instead. See `make typecheck` for the live error list.
+[[tool.mypy.overrides]]
+module = [
+  "src.analysis.importance",
+  "src.analysis.tier_generator",
+  "src.benchmarks.tpch.setup_dbgen",
+  "src.knobs.knob_metadata",
+  "src.knobs.policy",
+  "src.scripts.bo_baseline.objective",
+  "src.tuner.benchmark.orchestrator",
+  "src.tuner.benchmark.workload",
+  "src.tuner.config.knob_space",
+  "src.tuner.core.population",
+  "src.tuner.main",
+  "src.utils.environments.docker",
+  "src.visualization.loaders.ablation",
+  "src.visualization.loaders.importance",
+  "src.visualization.loaders.session",
+  "src.visualization.plots.knob_dependence",
+  "src.visualization.plots.knob_importance",
+  "src.visualization.registry",
+  "src.visualization.utils",
+]
+ignore_errors = true

--- a/scripts/experiments/__main__.py
+++ b/scripts/experiments/__main__.py
@@ -1,8 +1,13 @@
 import argparse
 import sys
 
-from scripts.experiments.experiment_matrix import build_all_experiments, get_experiments_by_tier, get_experiment_by_id
-from scripts.experiments.runner import ExperimentRunner, MANIFEST_PATH
+from scripts.experiments.experiment_matrix import (
+    build_all_experiments,
+    get_experiment_by_id,
+    get_experiments_by_tier,
+)
+from scripts.experiments.runner import MANIFEST_PATH, ExperimentRunner
+
 
 def main():
     parser = argparse.ArgumentParser(description="Cloud Experiment Suite Runner")

--- a/scripts/experiments/experiment_matrix.py
+++ b/scripts/experiments/experiment_matrix.py
@@ -1,7 +1,6 @@
 import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Optional, Tuple
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 
@@ -9,8 +8,8 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 # patch to one experiment cannot silently violate the cross-experiment
 # seed invariant the paper rests on. Tuples (not lists) so they remain
 # immutable and hashable.
-SEEDS_K5: Tuple[int, ...] = (42, 123, 456, 789, 1024)
-SEEDS_K1: Tuple[int, ...] = (42,)
+SEEDS_K5: tuple[int, ...] = (42, 123, 456, 789, 1024)
+SEEDS_K1: tuple[int, ...] = (42,)
 
 
 @dataclass(frozen=True)
@@ -19,33 +18,33 @@ class Experiment:
     tier: int                           # 1, 2, or 3
     description: str
     benchmark: str                      # "sysbench" | "tpch"
-    sysbench_workload: Optional[str]    # "oltp_read_write" | ...
-    scale_factor: Optional[float]       # TPC-H SF override
+    sysbench_workload: str | None    # "oltp_read_write" | ...
+    scale_factor: float | None       # TPC-H SF override
     config_profile: str                 # always "thorough"
     knob_tier: str                      # "extensive" | "minimal" | "core" | "standard"
     knob_source: str                    # "expert" | "data_driven"
     tuning_mode: str                    # "offline" | "online"
-    seeds: Tuple[int, ...]
+    seeds: tuple[int, ...]
     eval_repetitions: int               # 10 or 5
     run_bo: bool                        # True for Tier 1/2, False for Tier 3
-    population: Optional[int] = None
-    generations: Optional[int] = None
-    parallel_workers: Optional[int] = None
-    exploit_quantile: Optional[float] = None
-    scoring_policy: Optional[str] = None
-    perturbation_factor: Optional[float] = None
-    ablation_variable: Optional[str] = None
-    ablation_value: Optional[str] = None
+    population: int | None = None
+    generations: int | None = None
+    parallel_workers: int | None = None
+    exploit_quantile: float | None = None
+    scoring_policy: str | None = None
+    perturbation_factor: float | None = None
+    ablation_variable: str | None = None
+    ablation_value: str | None = None
     # Warm-start: when set, the runner resolves the best_config.json from
     # the manifest entry for ``(warm_start_source, warm_start_source_seed,
     # pbt)`` and passes it as ``--warm-start <path>``. The source
     # experiment must have completed its PBT phase before this experiment
     # runs.
-    warm_start_source: Optional[str] = None
-    warm_start_source_seed: Optional[int] = None
+    warm_start_source: str | None = None
+    warm_start_source_seed: int | None = None
 
 
-def get_data_driven_tier_experiments(workload_type: str = "oltp_read_write") -> List[Experiment]:
+def get_data_driven_tier_experiments(workload_type: str = "oltp_read_write") -> list[Experiment]:
     """Read data/data_driven_knobs/{workload_type}/data_driven_tiers.json
     and generate one ablation Experiment per non-empty tier.
     """
@@ -80,7 +79,7 @@ def get_data_driven_tier_experiments(workload_type: str = "oltp_read_write") -> 
     return experiments
 
 
-def build_all_experiments() -> List[Experiment]:
+def build_all_experiments() -> list[Experiment]:
     experiments = [
         # Tier 1 — primary, K=5 for Wilcoxon-grade significance
         Experiment(
@@ -239,10 +238,10 @@ def build_all_experiments() -> List[Experiment]:
 
     return experiments
 
-def get_experiments_by_tier(tier: int) -> List[Experiment]:
+def get_experiments_by_tier(tier: int) -> list[Experiment]:
     return [e for e in build_all_experiments() if e.tier == tier]
 
-def get_experiment_by_id(exp_id: str) -> Optional[Experiment]:
+def get_experiment_by_id(exp_id: str) -> Experiment | None:
     for e in build_all_experiments():
         if e.id == exp_id:
             return e

--- a/scripts/experiments/runner.py
+++ b/scripts/experiments/runner.py
@@ -4,10 +4,9 @@ import subprocess
 import time
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Optional
 
-from src.utils.hardware_info import detect_worker_resources
 from scripts.experiments.experiment_matrix import Experiment
+from src.utils.hardware_info import detect_worker_resources
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 RESULTS_DIR = PROJECT_ROOT / "results"
@@ -34,7 +33,7 @@ class ExperimentRunner:
                 format="%(asctime)s [%(levelname)s] %(message)s"
             )
 
-    def _load_manifest(self) -> Dict:
+    def _load_manifest(self) -> dict:
         if MANIFEST_PATH.exists():
             return json.loads(MANIFEST_PATH.read_text())
         return {
@@ -48,7 +47,7 @@ class ExperimentRunner:
         RESULTS_DIR.mkdir(parents=True, exist_ok=True)
         MANIFEST_PATH.write_text(json.dumps(self.manifest, indent=2))
 
-    def _run_command(self, cmd: List[str], cwd: Path = PROJECT_ROOT) -> bool:
+    def _run_command(self, cmd: list[str], cwd: Path = PROJECT_ROOT) -> bool:
         if self.dry_run:
             LOGGER.info(f"DRY RUN: {' '.join(cmd)}")
             return True
@@ -82,7 +81,7 @@ class ExperimentRunner:
         except subprocess.CalledProcessError as e:
             LOGGER.error(f"Failed to commit/push results: {e}")
 
-    def _find_latest_session_json(self, output_dir: Path, prefix: str) -> Optional[Path]:
+    def _find_latest_session_json(self, output_dir: Path, prefix: str) -> Path | None:
         if not output_dir.exists():
             return None
         candidates = sorted(output_dir.rglob(f"{prefix}*.json"), key=lambda p: p.stat().st_mtime)
@@ -196,7 +195,7 @@ class ExperimentRunner:
             else:
                 LOGGER.info(f"Skipping EVAL (already done/failed)")
 
-    def _resolve_warm_start_path(self, exp: Experiment) -> Optional[Path]:
+    def _resolve_warm_start_path(self, exp: Experiment) -> Path | None:
         """Resolve the best_config.json path for a warm-start experiment.
 
         The source experiment's PBT phase must have completed and recorded
@@ -257,7 +256,7 @@ class ExperimentRunner:
 
         return best_config_path
 
-    def _build_pbt_cmd(self, exp: Experiment, seed: int) -> List[str]:
+    def _build_pbt_cmd(self, exp: Experiment, seed: int) -> list[str]:
         cmd = [
             "python", "-m", "src.tuner.main",
             "--config", exp.config_profile,
@@ -314,7 +313,7 @@ class ExperimentRunner:
 
         return cmd
 
-    def _build_bo_cmd(self, exp: Experiment, pbt_session: Optional[Path], seed: int) -> List[str]:
+    def _build_bo_cmd(self, exp: Experiment, pbt_session: Path | None, seed: int) -> list[str]:
         # BO inherits population/budget from the PBT session via
         # --pbt-session, but every experiment-defining flag is passed
         # explicitly so a stale or partial session JSON cannot silently
@@ -347,7 +346,7 @@ class ExperimentRunner:
             cmd.extend(["--pbt-session", "DRY_RUN_PBT_SESSION_PATH.json"])
         return cmd
 
-    def _build_eval_cmd(self, pbt_session: Optional[Path], bo_session: Optional[Path], repetitions: int, seed: int) -> List[str]:
+    def _build_eval_cmd(self, pbt_session: Path | None, bo_session: Path | None, repetitions: int, seed: int) -> list[str]:
         cmd = [
             "python", "-m", "src.evaluation",
             "--repetitions", str(repetitions),


### PR DESCRIPTION
## Summary

Expand `make lint` and `make typecheck` to cover all of `src/` and project-level `scripts/`, closing the gap where newer modules (`src/analysis`, `src/benchmarks`, `src/visualization`, `src/knobs`, `src/database`, `scripts/experiments/`) were not gated on either tool.

## Approach

`make lint` already runs `ruff check src tests`. Extending to `scripts` adds 35 issues, all auto-fixable; commit 1 applies them.

`make typecheck` previously ran `mypy src/evaluation src/utils src/scripts`. Extending to `src scripts` surfaces **77 errors across 19 modules** in pre-existing code (visualization plot helpers, tuner core, knob_space, etc.). Rather than fix them blind in a scope-expansion PR, each failing module is baselined via `[[tool.mypy.overrides]] ignore_errors = true` with a clear backlog comment: *"drop entries by fixing the underlying type errors, do not extend the list"*. New code is type-checked from day one; the baselined list is the explicit cleanup queue.

`scripts/**/*.py` gets `I001` added to ruff per-file-ignores (matching `src/` and `tests/`) but **not** `UP` — future scripts/ code is held to modern PEP 585/604 annotations from the start.

## Baselined modules (follow-up cleanup backlog)

- `src.analysis.{importance, tier_generator}`
- `src.benchmarks.tpch.setup_dbgen`
- `src.knobs.{knob_metadata, policy}`
- `src.scripts.bo_baseline.objective`
- `src.tuner.benchmark.{orchestrator, workload}`
- `src.tuner.config.knob_space`
- `src.tuner.core.population`
- `src.tuner.main`
- `src.utils.environments.docker`
- `src.visualization.{utils, registry}`
- `src.visualization.loaders.{ablation, importance, session}`
- `src.visualization.plots.{knob_dependence, knob_importance}`

Error mix: 34 attr-defined (mostly numpy/matplotlib Axes vs ndarray confusion in visualization), 11 arg-type, 7 each operator/assignment, 6 var-annotated, smaller counts of dict-item/call-arg/etc. Several are genuine bugs worth surfacing during cleanup.

## Test plan

- [x] `make lint` — clean
- [x] `make typecheck` — Success: no issues found in 116 source files
- [x] `make test` — 441 passed, 7 skipped
- [x] Verified `scripts/experiments/` auto-fix is pure formatting (PEP 585/604 + isort), no semantic change