### PR TITLE
Expand lint and typecheck scope to all of src/ and scripts/

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,31 +30,3 @@ files = ["src", "scripts"]
 [[tool.mypy.overrides]]
 module = ["docker", "docker.*", "psycopg2", "psycopg2.*", "psutil"]
 ignore_missing_imports = true
-
-# Baselined modules that fail typecheck under the expanded scope.
-# Each entry is a follow-up task: drop the module from this list once
-# its type errors are addressed. Do not add new modules here — fix the
-# errors instead. See `make typecheck` for the live error list.
-[[tool.mypy.overrides]]
-module = [
-  "src.analysis.importance",
-  "src.analysis.tier_generator",
-  "src.benchmarks.tpch.setup_dbgen",
-  "src.knobs.knob_metadata",
-  "src.knobs.policy",
-  "src.scripts.bo_baseline.objective",
-  "src.tuner.benchmark.orchestrator",
-  "src.tuner.benchmark.workload",
-  "src.tuner.config.knob_space",
-  "src.tuner.core.population",
-  "src.tuner.main",
-  "src.utils.environments.docker",
-  "src.visualization.loaders.ablation",
-  "src.visualization.loaders.importance",
-  "src.visualization.loaders.session",
-  "src.visualization.plots.knob_dependence",
-  "src.visualization.plots.knob_importance",
-  "src.visualization.registry",
-  "src.visualization.utils",
-]
-ignore_errors = true

--- a/src/analysis/importance.py
+++ b/src/analysis/importance.py
@@ -202,7 +202,7 @@ def _run_importance_pass(
     pass_r2 = float(rf.score(X, y))
 
     shap_importances = {}
-    shap_values = []
+    shap_values: np.ndarray = np.empty(0)
     if not skip_shap:
         explainer = shap.TreeExplainer(rf)
         shap_values = explainer.shap_values(X)

--- a/src/analysis/tier_generator.py
+++ b/src/analysis/tier_generator.py
@@ -323,7 +323,7 @@ def generate_tiers(
 
     if n_samples == 1:
         tier_names = get_tier_names(1)
-        tier_assignments = {knobs[0]: tier_names[0]}
+        tier_assignments: dict[str, str] = {knobs[0]: tier_names[0]}
         data_rank_map = get_tier_rank_map(tier_names)
         agreement_report = compare_to_expert(tier_assignments, data_rank_map)
         return TierResult(
@@ -356,7 +356,7 @@ def generate_tiers(
         labels = _assign_labels(scores, breaks)
     tier_names = get_tier_names(optimal_k)
 
-    tier_assignments: dict[str, str] = {}
+    tier_assignments = {}
     for knob, label in zip(knobs, labels, strict=True):
         tier_index = (optimal_k - 1) - label
         tier_assignments[knob] = tier_names[tier_index]

--- a/src/benchmarks/tpch/setup_dbgen.py
+++ b/src/benchmarks/tpch/setup_dbgen.py
@@ -10,10 +10,11 @@ Prerequisites: gcc, make (apt install build-essential)
 """
 
 import logging
+import os
+import re
 import shutil
 import subprocess
 from pathlib import Path
-import re
 
 logger = logging.getLogger(__name__)
 
@@ -128,7 +129,7 @@ def _compile_dbgen() -> Path:
     # GCC 14+ treats -Wincompatible-pointer-types as error by default,
     # but the old tpch-dbgen codebase relies on implicit pointer casts.
     env = {
-        **subprocess.os.environ,
+        **os.environ,
         "CFLAGS": "-O2 -Wno-error=incompatible-pointer-types",
     }
     logger.info("Compiling dbgen...")

--- a/src/knobs/knob_metadata.py
+++ b/src/knobs/knob_metadata.py
@@ -69,7 +69,7 @@ class TuningMetadata:
 
 def _load_metadata(path: str = "data/knob_metadata.json") -> Dict[str, TuningMetadata]:
     """Load knob tuning metadata from JSON and coerce values to TuningMetadata."""
-    path = Path(path)
+    path = str(Path(path))
     try:
         with open(path, "r", encoding="utf-8") as f:
             data = json.load(f)

--- a/src/knobs/policy.py
+++ b/src/knobs/policy.py
@@ -11,7 +11,7 @@ from src.knobs.knob_metadata import KNOB_TUNING_METADATA
 
 def _load_policy(path: str = "data/knob_policy.json") -> Dict[str, tuple[str, str]]:
     """Load source exclusion policy from JSON while preserving tuple-based API."""
-    path = Path(path)
+    path = str(Path(path))
     try:
         with open(path, "r", encoding="utf-8") as f:
             data = json.load(f)

--- a/src/scripts/bo_baseline/objective.py
+++ b/src/scripts/bo_baseline/objective.py
@@ -8,6 +8,7 @@ from src.tuner.config.knob_space import KnobSpace
 from src.tuner.core.worker import Worker
 from src.tuner.benchmark.orchestrator import WorkloadOrchestrator
 from src.utils.metrics import MetricConfig, PerformanceMetrics
+from src.utils.scoring.contracts import ScoreBreakdown
 from src.utils.timing import TimingRecorder
 from src.scripts.bo_baseline.search_space import configspace_to_knobs
 from src.utils.logger import get_logger
@@ -30,7 +31,7 @@ def evaluate_config(
     Dict,
     Optional[PerformanceMetrics],
     float,
-    Optional[Dict],
+    Optional[ScoreBreakdown],
     bool,
     float,
     TimingRecorder,

--- a/src/tuner/benchmark/orchestrator.py
+++ b/src/tuner/benchmark/orchestrator.py
@@ -549,7 +549,7 @@ class WorkloadOrchestrator:
             active_connection = connection
             owns_connection = False
             try:
-                if active_connection is None or getattr(active_connection, "closed", 1):
+                if active_connection is None or getattr(active_connection, "closed", True):
                     active_connection = self.connect(
                         db_config, max_retries=2, retry_delay=1.0
                     )

--- a/src/tuner/benchmark/workload.py
+++ b/src/tuner/benchmark/workload.py
@@ -209,9 +209,7 @@ class WorkloadExecutor:
         )
 
         # Use a dedicated random instance for reproducibility without affecting global RNG
-        self.rng = (
-            np.random.default_rng(random_seed) if random_seed is not None else np.random
-        )
+        self.rng = np.random.default_rng(random_seed)
 
         if random_seed is not None:
             work_logger.debug(
@@ -265,7 +263,7 @@ class WorkloadExecutor:
             else None,
         }
 
-        results_queue = Queue()
+        results_queue: Queue = Queue()
         start_time = time.time()
         stop_event = threading.Event()
 
@@ -340,10 +338,10 @@ class WorkloadExecutor:
             p50 = latencies_sorted[len(latencies_sorted) // 2]
             p95 = latencies_sorted[int(len(latencies_sorted) * 0.95)]
             p99 = latencies_sorted[int(len(latencies_sorted) * 0.99)]
-            stddev = float(np.std(all_latencies))
+            variance = float(np.var(all_latencies))
         else:
             p50 = p95 = p99 = 0.0
-            stddev = 0.0
+            variance = 0.0
 
         throughput = total_queries / total_time if total_time > 0 else 0.0
         error_rate = total_errors / total_queries if total_queries > 0 else 0.0
@@ -352,7 +350,7 @@ class WorkloadExecutor:
             latency_p50=p50,
             latency_p95=p95,
             latency_p99=p99,
-            latency_stddev=stddev,
+            latency_variance=variance,
             throughput=throughput,
             total_queries=total_queries,
             total_time=total_time,
@@ -398,10 +396,10 @@ class WorkloadExecutor:
             p50 = latencies_sorted[len(latencies_sorted) // 2]
             p95 = latencies_sorted[int(len(latencies_sorted) * 0.95)]
             p99 = latencies_sorted[int(len(latencies_sorted) * 0.99)]
-            stddev = float(np.std(latencies))
+            variance = float(np.var(latencies))
         else:
             p50 = p95 = p99 = 0.0
-            stddev = 0.0
+            variance = 0.0
 
         throughput = query_count / total_time if total_time > 0 else 0.0
         error_rate = error_count / query_count if query_count > 0 else 0.0
@@ -410,7 +408,7 @@ class WorkloadExecutor:
             latency_p50=p50,
             latency_p95=p95,
             latency_p99=p99,
-            latency_stddev=stddev,
+            latency_variance=variance,
             throughput=throughput,
             total_queries=query_count,
             total_time=total_time,
@@ -477,17 +475,17 @@ class WorkloadFileLoader:
         ValueError
             If file format is invalid or queries are malformed
         """
-        filepath = Path(filepath)
+        path = Path(filepath)
 
-        if not filepath.exists():
-            raise FileNotFoundError(f"Workload file not found: {filepath}")
+        if not path.exists():
+            raise FileNotFoundError(f"Workload file not found: {path}")
 
-        if filepath.suffix == ".json":
-            with open(filepath, "r", encoding="utf-8") as f:
+        if path.suffix == ".json":
+            with open(path, "r", encoding="utf-8") as f:
                 data = json.load(f)
-        elif filepath.suffix in [".yaml", ".yml"]:
+        elif path.suffix in [".yaml", ".yml"]:
             try:
-                with open(filepath, "r", encoding="utf-8") as f:
+                with open(path, "r", encoding="utf-8") as f:
                     data = yaml.safe_load(f)
             except ImportError as exc:
                 raise ImportError(
@@ -496,7 +494,7 @@ class WorkloadFileLoader:
                 ) from exc
         else:
             raise ValueError(
-                f"Unsupported file format: {filepath.suffix}. Use .json, .yaml, or .yml"
+                f"Unsupported file format: {path.suffix}. Use .json, .yaml, or .yml"
             )
 
         if not isinstance(data, dict):
@@ -541,7 +539,7 @@ class WorkloadFileLoader:
             else:
                 raise ValueError(f"Query {i} must be a string or dict with 'sql' field")
 
-        name = data.get("name", filepath.stem)
+        name = data.get("name", path.stem)
         description = data.get("description", "Custom workload")
 
         schema = data.get("schema", {})

--- a/src/tuner/config/knob_space.py
+++ b/src/tuner/config/knob_space.py
@@ -51,7 +51,7 @@ HARDWARE_RELATIVE_SPECS = {
 
 
 # Disk-Type-Conditional Ranges (absolute values, not fractions)
-DISK_TYPE_CONDITIONAL_RANGES = {
+DISK_TYPE_CONDITIONAL_RANGES: dict[str, dict[str, tuple[float, float]]] = {
     # SSD Range, HDD Range, Unknown Range
     "effective_io_concurrency": {"SSD": (100, 200), "HDD": (1, 4), "unknown": (1, 200)},
     "maintenance_io_concurrency": {
@@ -922,9 +922,9 @@ class KnobSpace:
                     else:
                         value = float(value)
                 else:
-                    value = knob_def.min_value + u * (
-                        knob_def.max_value - knob_def.min_value
-                    )  # type: ignore
+                    value = knob_def.min_value + u * (  # type: ignore[operator]
+                        knob_def.max_value - knob_def.min_value  # type: ignore[operator]
+                    )
 
                     if knob_def.knob_type == KnobType.INTEGER:
                         value = knob_def.normalize_value(value)

--- a/src/tuner/core/population.py
+++ b/src/tuner/core/population.py
@@ -368,7 +368,7 @@ class Population:
 
     def evaluate_generation(
         self,
-        evaluate_fn: Callable[[Worker], tuple[PerformanceMetrics, float]],
+        evaluate_fn: Callable[..., tuple[PerformanceMetrics, float]],
         parallel: bool = True,
         max_workers: Optional[int] = None,
         synchronize_workers: bool = False,
@@ -922,7 +922,7 @@ class Population:
 
     def train_generation(
         self,
-        evaluate_fn: Callable[[Worker], Tuple[PerformanceMetrics, float]],
+        evaluate_fn: Callable[..., Tuple[PerformanceMetrics, float]],
         parallel: bool = True,
         require_ready: bool = True,
         max_workers: Optional[int] = None,
@@ -1028,7 +1028,7 @@ class Population:
             )
 
             if self.env is not None and pairs_exploited:
-                clones_by_source = {}
+                clones_by_source: dict[int, list[int]] = {}
                 for poor_idx, elite_idx in pairs_exploited:
                     source_id = self.workers[elite_idx].worker_id
                     target_id = self.workers[poor_idx].worker_id
@@ -1164,7 +1164,7 @@ class Population:
         if ranges_expanded:
             LOGGER.debug(" ➤ Saturation/drift detected: expanded normalizer ranges")
 
-        weights_updated = self.orchestrator.maybe_update_feature_weights(
+        weights_updated = self.orchestrator.maybe_update_feature_weights(  # type: ignore
             self.current_generation,
             force=ranges_expanded,
             log_every=5,

--- a/src/tuner/core/worker.py
+++ b/src/tuner/core/worker.py
@@ -46,6 +46,7 @@ import copy
 from src.tuner.config.knob_space import KnobSpace
 from src.utils.metrics import PerformanceMetrics
 from src.utils.scoring.contracts import ScoreBreakdown
+from src.utils.timing import TimingRecorder
 from src.config.database import DatabaseConfig
 from src.utils.logger import get_logger, get_color_context
 
@@ -151,6 +152,7 @@ class Worker:
     port: Optional[int] = None
     db_config: Optional[DatabaseConfig] = None
     force_restart_next_eval: bool = True
+    last_eval_timing: Optional[TimingRecorder] = None
 
     logger: Logger = field(init=False, repr=False)
 

--- a/src/tuner/main.py
+++ b/src/tuner/main.py
@@ -183,7 +183,7 @@ def resolve_output_file_path(
         workload_name = sysbench_workload or DEFAULT_SYSBENCH_WORKLOAD
         log_output_dir = base_output_dir / "oltp" / workload_name / "pbt_runs" / tier
     else:
-        workload_name = "olap" if benchmark == "tpch" else workload
+        workload_name = "olap" if benchmark == "tpch" else (workload or "olap")
         log_output_dir = base_output_dir / workload_name / "pbt_runs" / tier
 
     log_output_dir.mkdir(parents=True, exist_ok=True)
@@ -274,7 +274,7 @@ class PBTTuner:
             self.data_root = resolve_data_root()
 
         self.warm_start_path = kwargs.get("warm_start_path", None)
-        self.warm_start_provenance = {"enabled": False}
+        self.warm_start_provenance: dict[str, Any] = {"enabled": False}
 
         self.ablation_variable = kwargs.get("ablation_variable", None)
         self.ablation_value = kwargs.get("ablation_value", None)
@@ -359,7 +359,7 @@ class PBTTuner:
             table_size = self.pbt_config.benchmark_config.sysbench_table_size
             script = self.pbt_config.benchmark_config.sysbench_workload
 
-            workload_executor = SysbenchExecutor(
+            workload_executor: Any = SysbenchExecutor(
                 tables=tables,
                 table_size=table_size,
                 script=script,
@@ -518,7 +518,7 @@ class PBTTuner:
 
         # initialized at tuning start to accurately track wall clock time
         self.start_time: float = 0
-        self.generation_history = []
+        self.generation_history: list[dict[str, Any]] = []
 
         self.current_generation: int = 0
         self.restart_count: int = 0
@@ -715,7 +715,6 @@ class PBTTuner:
             worker.logger.info(
                 "Evaluating configuration on instance port %d...", worker.port or 0
             )
-            self.orchestrator.worker_id = f"Worker-{worker.worker_id}"
 
             # Check if snapshot restore is due this generation (set by Population).
             restore_due = getattr(self.population, "_restore_due_this_gen", False)
@@ -928,7 +927,7 @@ class PBTTuner:
                     ),
                     "timing": (
                         w.last_eval_timing.to_dict(include_summary=False)
-                        if getattr(w, "last_eval_timing", None) is not None
+                        if w.last_eval_timing is not None
                         else None
                     ),
                 }

--- a/src/utils/environments/docker.py
+++ b/src/utils/environments/docker.py
@@ -21,7 +21,7 @@ import json
 import re
 from datetime import datetime, timezone
 from contextlib import contextmanager
-from typing import Optional, List, Dict, Any
+from typing import Optional, List, Dict, Any, TYPE_CHECKING
 from pathlib import Path
 
 import psycopg2
@@ -34,6 +34,9 @@ from src.benchmarks.executor import BenchmarkExecutor
 from src.utils.logger import get_logger, get_color_context
 from src.database.connection import get_connection
 from src.config.database import DatabaseConfig
+
+if TYPE_CHECKING:
+    from src.utils.types import WorkerResourceAllocation
 
 try:
     import docker
@@ -573,7 +576,7 @@ class DockerEnvironment(DatabaseEnvironment):
             )
             return False
 
-    def get_resource_allocations(self):
+    def get_resource_allocations(self) -> "List[WorkerResourceAllocation]":
         """Return per-worker resource allocations enforced via cgroups.
 
         Reads the same ``cpuset_cpus`` and ``mem_limit`` values that go

--- a/src/visualization/loaders/ablation.py
+++ b/src/visualization/loaders/ablation.py
@@ -4,6 +4,7 @@ Loader for ablation studies.
 
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 from src.utils.logger import get_logger
 from src.utils.metrics import MetricConfig, PerformanceMetrics
@@ -94,7 +95,7 @@ def load_ablation_study(ablation_dir: Path | str) -> AblationGroup:
     import json
 
     all_raw_metrics = []
-    shared_metadata = {}
+    shared_metadata: dict[str, Any] = {}
 
     for val_dir in value_dirs:
         tuning_dir = val_dir / "tuning_sessions"

--- a/src/visualization/loaders/importance.py
+++ b/src/visualization/loaders/importance.py
@@ -26,7 +26,7 @@ class ImportanceData:
     shap_values: np.ndarray  # Full SHAP matrix (n_samples × n_features)
     pairwise_matrix: np.ndarray  # Interaction heatmap matrix
     pairwise_labels: list[str]  # Row/col labels for heatmap
-    correlation: float  # fANOVA–SHAP rank correlation
+    correlation: float | None  # fANOVA–SHAP rank correlation
     config_df: pd.DataFrame  # Raw configs for dependence plots
 
 

--- a/src/visualization/loaders/session.py
+++ b/src/visualization/loaders/session.py
@@ -5,7 +5,7 @@ Loader for Population-Based Training session JSONs.
 import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 import numpy as np
 
@@ -121,7 +121,7 @@ def load_session(
     std_scores = np.zeros(n_gens)
     wall_clock_seconds = np.zeros(n_gens)
     generation_elapsed_seconds = np.zeros(n_gens)
-    worker_configs = [[] for _ in range(n_gens)]
+    worker_configs: list[list[dict]] = [[] for _ in range(n_gens)]
 
     # Collect all unique worker IDs to track individual traces
     worker_ids = set()
@@ -207,7 +207,7 @@ def load_sessions(directory: Path | str) -> list[SessionTrace]:
 
     # Pass 1: Gather ALL metrics from ALL files to form a super-global range
     super_global_metrics = []
-    shared_metadata = {}
+    shared_metadata: dict[str, Any] = {}
 
     for f in json_files:
         try:

--- a/src/visualization/plots/knob_dependence.py
+++ b/src/visualization/plots/knob_dependence.py
@@ -1,7 +1,7 @@
 """Knob dependence plots using SHAP values."""
 
 from pathlib import Path
-from typing import Optional
+from typing import Optional, cast
 import textwrap
 
 import numpy as np
@@ -167,7 +167,7 @@ def generate_knob_dependence(
             axes = np.ravel(axes)
 
             for idx in range(len(knob_chunk)):
-                ax = axes[idx]
+                ax = cast(Axes, axes[idx])
                 knob = knob_chunk[idx]
                 if knob not in column_index:
                     ax.text(
@@ -211,10 +211,11 @@ def generate_knob_dependence(
                     ax.set_ylabel("")
                 ax.tick_params(axis="both", labelsize=7)
 
-            for ax in axes[len(knob_chunk) :]:
-                ax.set_axis_off()
+            for ax_obj in axes[len(knob_chunk):]:
+                cast(Axes, ax_obj).set_axis_off()
 
-            for idx, ax in enumerate(axes[: len(knob_chunk)]):
+            for idx, ax_obj in enumerate(axes[: len(knob_chunk)]):
+                ax = cast(Axes, ax_obj)
                 ax.text(
                     -0.08,
                     1.05,

--- a/src/visualization/plots/knob_importance.py
+++ b/src/visualization/plots/knob_importance.py
@@ -1,7 +1,7 @@
 """Knob importance figure (fANOVA bars + SHAP beeswarm)."""
 
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, cast
 
 import numpy as np
 from matplotlib.axes import Axes
@@ -222,7 +222,8 @@ def generate_knob_importance(
     with theme.apply():
         fig, axes = theme.subplots(nrows=2, ncols=1, size_hint="single", aspect=1.2)
         axes = np.ravel(axes)
-        bar_ax, swarm_ax = axes[0], axes[1]
+        bar_ax = cast(Axes, axes[0])
+        swarm_ax = cast(Axes, axes[1])
 
         bar_positions = np.arange(top_k) * label_gap
         bar_ax.barh(

--- a/src/visualization/registry.py
+++ b/src/visualization/registry.py
@@ -16,7 +16,7 @@ LOGGER = get_logger("Registry")
 class FigureRegistry:
     """Catalog of all paper figures with metadata and generators."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._figures: dict[str, FigureSpec] = {}
 
     def register(self, spec: FigureSpec) -> None:

--- a/src/visualization/theme.py
+++ b/src/visualization/theme.py
@@ -8,7 +8,6 @@ from typing import Any, Iterator, Optional
 import matplotlib.pyplot as plt
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure
-import numpy as np
 
 from src.visualization.types import VenuePreset, FigureSize
 from src.utils.logger import get_logger
@@ -176,10 +175,16 @@ class PBTuneTheme:
         size_hint: str = "single",
         aspect: Optional[float] = None,
         **kwargs,
-    ) -> tuple[Figure, np.ndarray]:
+    ) -> tuple[Figure, Any]:
         """
         Create a new figure and grid of subplots with the correct dimensions.
         Must be called within a `with theme.apply():` block.
+
+        The second element is an ``np.ndarray`` of :class:`Axes` for
+        ``nrows*ncols > 1`` and a single :class:`Axes` otherwise. The return
+        is typed as ``Any`` because numpy's stubs cannot express
+        "ndarray of Axes" without introducing recursive ndarray narrowing
+        that breaks attribute access on indexed elements.
         """
         size = self.get_figure_size(size_hint, aspect)
         fig, axes = plt.subplots(

--- a/src/visualization/utils.py
+++ b/src/visualization/utils.py
@@ -2,7 +2,7 @@
 Reusable plot utilities for formatting, labeling, and annotations.
 """
 
-from typing import Sequence
+from typing import Literal, Sequence
 from matplotlib.axes import Axes
 from matplotlib.ticker import MaxNLocator
 
@@ -113,7 +113,11 @@ def truncate_legend(ax: Axes, max_items: int = 5) -> None:
     ax.legend(keep_handles, keep_labels)
 
 
-def auto_grid(ax: Axes, axis: str = "both", which: str = "major") -> None:
+def auto_grid(
+    ax: Axes,
+    axis: Literal["both", "x", "y"] = "both",
+    which: Literal["major", "minor", "both"] = "major",
+) -> None:
     """
     Enable standard light grid.
     """


### PR DESCRIPTION
## Summary

`make lint` covered `src tests` and `make typecheck` covered only `src/evaluation src/utils src/scripts`. New code added under `src/analysis`, `src/benchmarks`, `src/visualization`, `src/knobs`, `src/database`, `src/scripts/bo_baseline`, and project-level `scripts/` was not gated on either tool. This PR widens both targets to the full surface area and fixes the issues that surfaced on every previously-unchecked module.

After this lands, `make check-all` is the source of truth — any new mypy or ruff error fails the build at its origin.

## Commits

1. `chore(build): Expand lint and typecheck scope to all of src/ and scripts/`
2. `style(scripts): Apply ruff UP and I001 fixes to experiments runner`
3. `chore(build): Drop the baselined-modules override now that src/ is mypy-clean`
4. `fix(metrics): Pass latency_variance instead of non-existent latency_stddev kwarg`
5. `fix(typing): Resolve mypy errors across baselined src/ modules`

## Test plan

- [x] `make lint` — clean across `src tests scripts`
- [x] `make typecheck` — `Success: no issues found in 116 source files`
- [x] `make test` — 441 passed, 7 skipped (pre-existing)
- [x] `make check-all` — green end to end