### PR TITLE
feat(isolation): Per-worker disk I/O limits via cgroup blkio

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -66,22 +66,22 @@ install_system_packages() {
             sudo apt-get update
             sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
                 build-essential libpq-dev libreadline-dev zlib1g-dev \
-                libxml2-dev libssl-dev libffi-dev swig g++ curl
+                libxml2-dev libssl-dev libffi-dev swig g++ curl fio
             ;;
         dnf|yum)
             sudo $pm install -y \
                 gcc gcc-c++ make postgresql-devel readline-devel zlib-devel \
-                libxml2-devel openssl-devel libffi-devel swig curl
+                libxml2-devel openssl-devel libffi-devel swig curl fio
             ;;
         pacman)
             sudo pacman -Sy --noconfirm --needed \
                 base-devel postgresql-libs readline zlib \
-                libxml2 openssl libffi swig curl
+                libxml2 openssl libffi swig curl fio
             ;;
         zypper)
             sudo zypper install -y \
                 gcc gcc-c++ make postgresql-devel readline-devel zlib-devel \
-                libxml2-devel libopenssl-devel libffi-devel swig curl
+                libxml2-devel libopenssl-devel libffi-devel swig curl fio
             ;;
     esac
 }

--- a/src/evaluation/loader.py
+++ b/src/evaluation/loader.py
@@ -112,6 +112,11 @@ def load_tuning_session(path: Path) -> TuningSessionData:
         ram_bytes=int(wr_raw["ram_bytes"]),
         cpu_cores=int(wr_raw["cpu_cores"]),
         disk_type=str(wr_raw["disk_type"]),
+        disk_read_bps=int(wr_raw.get("disk_read_bps", 0) or 0),
+        disk_write_bps=int(wr_raw.get("disk_write_bps", 0) or 0),
+        disk_read_iops=int(wr_raw.get("disk_read_iops", 0) or 0),
+        disk_write_iops=int(wr_raw.get("disk_write_iops", 0) or 0),
+        disk_class=str(wr_raw.get("disk_class", "unknown") or "unknown"),
     )
 
     if worker_resources.ram_bytes <= 0:

--- a/src/evaluation/runner.py
+++ b/src/evaluation/runner.py
@@ -724,6 +724,11 @@ class ComparisonRunner:
             ram_bytes=session.worker_resources.ram_bytes,
             cpu_cores=session.worker_resources.cpu_cores,
             disk_type=session.worker_resources.disk_type,
+            disk_read_bps=session.worker_resources.disk_read_bps,
+            disk_write_bps=session.worker_resources.disk_write_bps,
+            disk_read_iops=session.worker_resources.disk_read_iops,
+            disk_write_iops=session.worker_resources.disk_write_iops,
+            disk_class=session.worker_resources.disk_class,
         )
         knob_space.resolve_hardware_ranges(runtime_resources)
         resolved = knob_space.fractions_to_config(session.best_knobs)

--- a/src/scripts/bo_baseline/config.py
+++ b/src/scripts/bo_baseline/config.py
@@ -72,6 +72,11 @@ class BOConfig:
     resource_division: int = 1
     worker_ram: Optional[str] = None
     worker_cpus: Optional[int] = None
+    worker_disk_read_bps: Optional[int] = None
+    worker_disk_write_bps: Optional[int] = None
+    worker_disk_read_iops: Optional[int] = None
+    worker_disk_write_iops: Optional[int] = None
+    probe_disk: bool = True
 
     # Scoring policy
     # Available options:
@@ -374,6 +379,27 @@ class BOConfig:
             early_stopping_patience=early_stopping_patience,
             worker_ram=args.worker_ram if hasattr(args, "worker_ram") else None,
             worker_cpus=args.worker_cpus if hasattr(args, "worker_cpus") else None,
+            worker_disk_read_bps=(
+                args.worker_disk_read_bps
+                if hasattr(args, "worker_disk_read_bps")
+                else None
+            ),
+            worker_disk_write_bps=(
+                args.worker_disk_write_bps
+                if hasattr(args, "worker_disk_write_bps")
+                else None
+            ),
+            worker_disk_read_iops=(
+                args.worker_disk_read_iops
+                if hasattr(args, "worker_disk_read_iops")
+                else None
+            ),
+            worker_disk_write_iops=(
+                args.worker_disk_write_iops
+                if hasattr(args, "worker_disk_write_iops")
+                else None
+            ),
+            probe_disk=args.probe_disk if hasattr(args, "probe_disk") else True,
         )
 
         if args.pbt_session:

--- a/src/scripts/bo_baseline/result_writer.py
+++ b/src/scripts/bo_baseline/result_writer.py
@@ -344,6 +344,11 @@ def write_bo_results(
             "ram_bytes": worker_resources.ram_bytes,
             "cpu_cores": worker_resources.cpu_cores,
             "disk_type": worker_resources.disk_type,
+            "disk_read_bps": worker_resources.disk_read_bps,
+            "disk_write_bps": worker_resources.disk_write_bps,
+            "disk_read_iops": worker_resources.disk_read_iops,
+            "disk_write_iops": worker_resources.disk_write_iops,
+            "disk_class": worker_resources.disk_class,
         },
         "generation_history": generation_history,
         "bootstrap_breakdown": (

--- a/src/scripts/bo_baseline/runner.py
+++ b/src/scripts/bo_baseline/runner.py
@@ -111,6 +111,22 @@ class BOBaselineRunner:
                 ram_bytes=int(config.pbt_worker_resources.get("ram_bytes", 0)),
                 cpu_cores=int(config.pbt_worker_resources.get("cpu_cores", 1)),
                 disk_type=str(config.pbt_worker_resources.get("disk_type", "unknown")),
+                disk_read_bps=int(
+                    config.pbt_worker_resources.get("disk_read_bps", 0) or 0
+                ),
+                disk_write_bps=int(
+                    config.pbt_worker_resources.get("disk_write_bps", 0) or 0
+                ),
+                disk_read_iops=int(
+                    config.pbt_worker_resources.get("disk_read_iops", 0) or 0
+                ),
+                disk_write_iops=int(
+                    config.pbt_worker_resources.get("disk_write_iops", 0) or 0
+                ),
+                disk_class=str(
+                    config.pbt_worker_resources.get("disk_class", "unknown")
+                    or "unknown"
+                ),
             )
             self.logger.info(
                 "Using PBT-derived per-worker resources: %d cores, %.1f GB RAM",
@@ -120,12 +136,25 @@ class BOBaselineRunner:
             self.logger.debug(
                 "PBT-derived worker resources object: %s", self.worker_resources
             )
-        elif config.worker_ram is not None or config.worker_cpus is not None:
+        elif config.worker_ram is not None or config.worker_cpus is not None or any(
+            v is not None
+            for v in (
+                config.worker_disk_read_bps,
+                config.worker_disk_write_bps,
+                config.worker_disk_read_iops,
+                config.worker_disk_write_iops,
+            )
+        ):
             self.worker_resources = resolve_manual_worker_resources(
                 worker_ram=config.worker_ram,
                 worker_cpus=config.worker_cpus,
                 num_workers=config.resource_division,
                 data_path=self.data_root,
+                worker_disk_read_bps=config.worker_disk_read_bps,
+                worker_disk_write_bps=config.worker_disk_write_bps,
+                worker_disk_read_iops=config.worker_disk_read_iops,
+                worker_disk_write_iops=config.worker_disk_write_iops,
+                probe_disk=config.probe_disk,
             )
             self.logger.info(
                 "Using manual per-worker resources: "
@@ -134,7 +163,9 @@ class BOBaselineRunner:
             )
         else:
             self.worker_resources = detect_worker_resources(
-                max_parallel_workers=config.resource_division, data_path=self.data_root
+                max_parallel_workers=config.resource_division,
+                data_path=self.data_root,
+                probe_disk=config.probe_disk,
             )
             self.logger.info(
                 "Dividing host resources by %s: %d cores, %.1f GB RAM per instance",
@@ -1687,6 +1718,51 @@ def main():
             "When set, bypasses auto-detection. Total across all workers must "
             "not exceed host physical CPU cores."
         ),
+    )
+    parser.add_argument(
+        "--worker-disk-read-bps",
+        type=int,
+        default=None,
+        help=(
+            "Per-worker disk read bandwidth in bytes/sec (cgroup blkio / io.max). "
+            "When unset, auto-detected via fio probe (when available) or heuristic."
+        ),
+    )
+    parser.add_argument(
+        "--worker-disk-write-bps",
+        type=int,
+        default=None,
+        help="Per-worker disk write bandwidth in bytes/sec.",
+    )
+    parser.add_argument(
+        "--worker-disk-read-iops",
+        type=int,
+        default=None,
+        help="Per-worker disk read IOPS ceiling.",
+    )
+    parser.add_argument(
+        "--worker-disk-write-iops",
+        type=int,
+        default=None,
+        help="Per-worker disk write IOPS ceiling.",
+    )
+    probe_group = parser.add_mutually_exclusive_group()
+    probe_group.add_argument(
+        "--probe-disk",
+        dest="probe_disk",
+        action="store_true",
+        default=True,
+        help=(
+            "Run a short fio probe at startup to calibrate per-worker disk "
+            "I/O budget. Falls back to heuristic when fio is unavailable. "
+            "Default: enabled."
+        ),
+    )
+    probe_group.add_argument(
+        "--no-probe-disk",
+        dest="probe_disk",
+        action="store_false",
+        help="Skip the fio probe and use heuristic disk I/O budget directly.",
     )
     parser.add_argument(
         "--scoring-policy",

--- a/src/tuner/main.py
+++ b/src/tuner/main.py
@@ -320,18 +320,43 @@ class PBTTuner:
 
         worker_ram_str = kwargs.get("worker_ram")
         worker_cpus = kwargs.get("worker_cpus")
+        worker_disk_read_bps = kwargs.get("worker_disk_read_bps")
+        worker_disk_write_bps = kwargs.get("worker_disk_write_bps")
+        worker_disk_read_iops = kwargs.get("worker_disk_read_iops")
+        worker_disk_write_iops = kwargs.get("worker_disk_write_iops")
+        probe_disk = bool(kwargs.get("probe_disk", True))
 
-        if worker_ram_str is not None or worker_cpus is not None:
+        manual_disk_provided = any(
+            v is not None
+            for v in (
+                worker_disk_read_bps,
+                worker_disk_write_bps,
+                worker_disk_read_iops,
+                worker_disk_write_iops,
+            )
+        )
+
+        if (
+            worker_ram_str is not None
+            or worker_cpus is not None
+            or manual_disk_provided
+        ):
             self.worker_resources = resolve_manual_worker_resources(
                 worker_ram=worker_ram_str,
                 worker_cpus=worker_cpus,
                 num_workers=self.pbt_config.num_parallel_workers,
                 data_path=self.data_root,
+                worker_disk_read_bps=worker_disk_read_bps,
+                worker_disk_write_bps=worker_disk_write_bps,
+                worker_disk_read_iops=worker_disk_read_iops,
+                worker_disk_write_iops=worker_disk_write_iops,
+                probe_disk=probe_disk,
             )
         else:
             self.worker_resources = detect_worker_resources(
                 self.pbt_config.num_parallel_workers,
                 data_path=self.data_root,
+                probe_disk=probe_disk,
             )
 
         LOGGER.info(
@@ -1327,6 +1352,11 @@ class PBTTuner:
                 "ram_bytes": worker_resources.ram_bytes,  # type: ignore
                 "cpu_cores": worker_resources.cpu_cores,  # type: ignore
                 "disk_type": worker_resources.disk_type,  # type: ignore
+                "disk_read_bps": worker_resources.disk_read_bps,  # type: ignore
+                "disk_write_bps": worker_resources.disk_write_bps,  # type: ignore
+                "disk_read_iops": worker_resources.disk_read_iops,  # type: ignore
+                "disk_write_iops": worker_resources.disk_write_iops,  # type: ignore
+                "disk_class": worker_resources.disk_class,  # type: ignore
             },
             "warm_start": self.warm_start_provenance,
             "generation_history": convert_numpy_types(self.generation_history),
@@ -1654,6 +1684,52 @@ on your hardware, configuration, and workload/benchmark.
             "When set, bypasses auto-detection. Total across all workers must "
             "not exceed host physical CPU cores."
         ),
+    )
+
+    config_group.add_argument(
+        "--worker-disk-read-bps",
+        type=int,
+        default=None,
+        help=(
+            "Per-worker disk read bandwidth in bytes/sec (cgroup blkio / io.max). "
+            "When unset, auto-detected via fio probe (when available) or heuristic."
+        ),
+    )
+    config_group.add_argument(
+        "--worker-disk-write-bps",
+        type=int,
+        default=None,
+        help="Per-worker disk write bandwidth in bytes/sec.",
+    )
+    config_group.add_argument(
+        "--worker-disk-read-iops",
+        type=int,
+        default=None,
+        help="Per-worker disk read IOPS ceiling.",
+    )
+    config_group.add_argument(
+        "--worker-disk-write-iops",
+        type=int,
+        default=None,
+        help="Per-worker disk write IOPS ceiling.",
+    )
+    probe_group = config_group.add_mutually_exclusive_group()
+    probe_group.add_argument(
+        "--probe-disk",
+        dest="probe_disk",
+        action="store_true",
+        default=True,
+        help=(
+            "Run a short fio probe at startup to calibrate per-worker disk "
+            "I/O budget. Falls back to heuristic when fio is unavailable. "
+            "Default: enabled."
+        ),
+    )
+    probe_group.add_argument(
+        "--no-probe-disk",
+        dest="probe_disk",
+        action="store_false",
+        help="Skip the fio probe and use heuristic disk I/O budget directly.",
     )
 
     config_group.add_argument(
@@ -2128,6 +2204,11 @@ def main():
             ablation_value=args.ablation_value,
             worker_ram=args.worker_ram,
             worker_cpus=args.worker_cpus,
+            worker_disk_read_bps=args.worker_disk_read_bps,
+            worker_disk_write_bps=args.worker_disk_write_bps,
+            worker_disk_read_iops=args.worker_disk_read_iops,
+            worker_disk_write_iops=args.worker_disk_write_iops,
+            probe_disk=args.probe_disk,
         )
 
         tuner.run()

--- a/src/utils/environments/docker.py
+++ b/src/utils/environments/docker.py
@@ -71,6 +71,7 @@ class DockerEnvironment(DatabaseEnvironment):
         base_dir: Path = Path("./.instances"),
         container_prefix: str = "pbt-worker",
         force_recreate_baseline: bool = False,
+        data_device_node: Optional[str] = None,
     ):
         """Initialize Docker environment with configuration."""
         super().__init__(
@@ -86,6 +87,7 @@ class DockerEnvironment(DatabaseEnvironment):
         self.base_port = base_port
         self.base_dir = base_dir
         self.container_prefix = container_prefix
+        self.data_device_node = data_device_node
 
         self.client = docker.from_env(timeout=30)
         self.instances: Dict[int, InstanceConfig] = {}
@@ -212,6 +214,31 @@ class DockerEnvironment(DatabaseEnvironment):
             "network": self.network_name,
             "detach": True,
         }
+
+        # Per-worker disk I/O bandwidth + IOPS limits via cgroup blkio /
+        # cgroup v2 io.max. Only emit kwargs when (a) the worker resources
+        # carry a non-zero budget for that field and (b) we have a device
+        # node to target -- omitting the kwargs entirely is the safe
+        # default (Docker treats absence as unlimited).
+        wr = self.worker_resources
+        device_node = self.data_device_node
+        if wr is not None and device_node:
+            if getattr(wr, "disk_read_bps", 0) > 0:
+                kwargs["device_read_bps"] = [
+                    {"Path": device_node, "Rate": int(wr.disk_read_bps)}
+                ]
+            if getattr(wr, "disk_write_bps", 0) > 0:
+                kwargs["device_write_bps"] = [
+                    {"Path": device_node, "Rate": int(wr.disk_write_bps)}
+                ]
+            if getattr(wr, "disk_read_iops", 0) > 0:
+                kwargs["device_read_iops"] = [
+                    {"Path": device_node, "Rate": int(wr.disk_read_iops)}
+                ]
+            if getattr(wr, "disk_write_iops", 0) > 0:
+                kwargs["device_write_iops"] = [
+                    {"Path": device_node, "Rate": int(wr.disk_write_iops)}
+                ]
 
         if volumes is not None:
             kwargs["volumes"] = volumes
@@ -603,6 +630,11 @@ class DockerEnvironment(DatabaseEnvironment):
             else int(self.cpu_cores) if self.cpu_cores else 0
         )
         docker_mem_limit = self.ram_bytes if self.ram_bytes > 0 else None
+        wr = self.worker_resources
+        per_worker_disk_read_bps = int(getattr(wr, "disk_read_bps", 0)) if wr else 0
+        per_worker_disk_write_bps = int(getattr(wr, "disk_write_bps", 0)) if wr else 0
+        per_worker_disk_read_iops = int(getattr(wr, "disk_read_iops", 0)) if wr else 0
+        per_worker_disk_write_iops = int(getattr(wr, "disk_write_iops", 0)) if wr else 0
         for worker_id in worker_ids:
             allocations.append(
                 WorkerResourceAllocation(
@@ -611,6 +643,11 @@ class DockerEnvironment(DatabaseEnvironment):
                     cpuset_cpus=self._worker_cpuset_cpus(worker_id, num_workers),
                     ram_bytes=per_worker_ram,
                     docker_memory_limit_bytes=docker_mem_limit,
+                    disk_read_bps=per_worker_disk_read_bps,
+                    disk_write_bps=per_worker_disk_write_bps,
+                    disk_read_iops=per_worker_disk_read_iops,
+                    disk_write_iops=per_worker_disk_write_iops,
+                    disk_device_path=self.data_device_node,
                 )
             )
         return allocations

--- a/src/utils/environments/factory.py
+++ b/src/utils/environments/factory.py
@@ -21,7 +21,7 @@ from src.utils.environments.docker import DockerEnvironment
 from src.utils.environments.bare_metal import BareMetalEnvironment
 from src.benchmarks.executor import BenchmarkExecutor
 from src.config.database import DatabaseConfig
-from src.utils.hardware_info import detect_pg_version
+from src.utils.hardware_info import detect_pg_version, _resolve_block_device_node
 
 LOGGER = get_logger("EnvironmentFactory")
 COLORS = get_color_context()
@@ -96,6 +96,23 @@ class EnvironmentFactory:
                 resolved_image_name = EnvironmentFactory._resolve_docker_image(
                     image_name
                 )
+                # Resolve the host block-device node backing base_dir so the
+                # container's blkio limits target the right device. Falls
+                # back to None when the path can't be mapped (non-Linux,
+                # tmpfs, overlay) -- DockerEnvironment skips blkio kwargs
+                # in that case.
+                data_device_node = _resolve_block_device_node(base_dir)
+                if data_device_node is None:
+                    LOGGER.warning(
+                        "Could not resolve a host block device for '%s'; "
+                        "per-worker disk I/O limits will not be enforced.",
+                        base_dir,
+                    )
+                else:
+                    LOGGER.info(
+                        "Resolved host block device for blkio limits: %s",
+                        data_device_node,
+                    )
                 return DockerEnvironment(
                     run_id=run_id,
                     db_config=db_config,
@@ -108,6 +125,7 @@ class EnvironmentFactory:
                     base_dir=base_dir,
                     container_prefix=container_prefix,
                     force_recreate_baseline=force_recreate_baseline,
+                    data_device_node=data_device_node,
                 )
             except (
                 ImportError,

--- a/src/utils/hardware_info.py
+++ b/src/utils/hardware_info.py
@@ -122,13 +122,56 @@ def _normalize_dev_basename(device_path: str) -> str:
     return os.path.basename(os.path.realpath(device_path))
 
 
+def _resolve_parent_block_device(device_path: str) -> str:
+    """Walk a partition device node up to its parent disk node.
+
+    cgroup v2 ``io.max`` (and cgroup v1 ``blkio.throttle.*``) are
+    enforced on the parent block device, not on individual partitions.
+    Writing ``"8:3 rbps=..."`` to ``io.max`` for partition ``/dev/sda3``
+    raises ``ENODEV`` ("no such device") because the kernel's I/O
+    scheduler lives on the parent disk (``/dev/sda``, ``8:0``).
+
+    For partitions (``/sys/class/block/<name>/partition`` exists), this
+    walks ``/sys/class/block/<name>/..`` to the parent disk basename.
+    For non-partition block devices (whole disks, dm-X, md-X), returns
+    the input unchanged.
+    """
+    dev_basename = os.path.basename(device_path)
+    sys_block_link = Path(f"/sys/class/block/{dev_basename}")
+    if not sys_block_link.exists():
+        return device_path
+
+    partition_marker = sys_block_link / "partition"
+    if not partition_marker.exists():
+        # Whole disk, dm-X, md-X, etc. — no parent walk needed.
+        return device_path
+
+    try:
+        # /sys/class/block/sda3 -> /sys/devices/.../sda/sda3
+        # parent dir basename gives us "sda".
+        resolved = sys_block_link.resolve(strict=True)
+        parent_basename = resolved.parent.name
+    except OSError:
+        return device_path
+
+    if not parent_basename:
+        return device_path
+
+    parent_node = f"/dev/{parent_basename}"
+    if Path(parent_node).exists():
+        return parent_node
+    return device_path
+
+
 def _resolve_block_device_node(target_path: Path) -> Optional[str]:
     """Return the host block-device node path (``/dev/sdX`` or ``/dev/nvmeXnY``)
     whose filesystem contains ``target_path``.
 
     Needed because Docker's ``device_*_bps`` kwargs require a device-node
     path (the daemon resolves it to ``(major, minor)`` for the cgroup
-    write). Returns ``None`` when the path can't be resolved (non-Linux,
+    write). Always returns the **parent disk** rather than a partition,
+    so the cgroup write targets the device the I/O scheduler is bound to.
+    Returns ``None`` when the path can't be resolved (non-Linux,
     bind-mount from a container, etc.).
     """
     if platform.system() != "Linux":
@@ -144,11 +187,12 @@ def _resolve_block_device_node(target_path: Path) -> Optional[str]:
     # daemon sees a stable device node.
     try:
         resolved = os.path.realpath(device)
-        if resolved.startswith("/dev/"):
-            return resolved
+        if not resolved.startswith("/dev/"):
+            resolved = device
     except OSError:
-        pass
-    return device
+        resolved = device
+
+    return _resolve_parent_block_device(resolved)
 
 
 def _is_usb_attached(dev_basename: str) -> bool:

--- a/src/utils/hardware_info.py
+++ b/src/utils/hardware_info.py
@@ -10,12 +10,14 @@ All detection functions are designed to fail gracefully, returning
 "unknown" values rather than raising exceptions.
 """
 
+import json
 import logging
 import os
 import platform
 import shutil
 import subprocess
 import re
+import tempfile
 from pathlib import Path
 from typing import Any, Dict, Optional
 import math
@@ -32,11 +34,361 @@ COLORS = get_color_context()
 
 @dataclass
 class WorkerResources:
-    """Per-worker hardware resources for hardware-aware knob ranges."""
+    """Per-worker hardware resources for hardware-aware knob ranges.
+
+    Disk bandwidth/IOPS fields default to ``0`` (= unlimited / unenforced)
+    so legacy call sites that construct ``WorkerResources(ram_bytes=...,
+    cpu_cores=..., disk_type=...)`` remain valid. When non-zero, they
+    are enforced per worker container via Docker's ``device_read_bps``,
+    ``device_write_bps``, ``device_read_iops``, and ``device_write_iops``
+    (cgroup v1 ``blkio`` or cgroup v2 ``io.max``). The accompanying
+    device-node path is resolved separately and held on the environment.
+    """
 
     ram_bytes: int  # Available RAM for this worker (already divided if bare-metal)
     cpu_cores: int  # Available CPU cores for this worker
     disk_type: str  # "SSD", "HDD", or "unknown"
+    disk_read_bps: int = 0
+    disk_write_bps: int = 0
+    disk_read_iops: int = 0
+    disk_write_iops: int = 0
+    disk_class: str = "unknown"  # Refined classification used for heuristics
+
+
+# ---------------------------------------------------------------------------
+# Disk bandwidth detection
+# ---------------------------------------------------------------------------
+
+# Floor budgets to avoid pathological zero-budget configs when many workers
+# share a slow disk. 1 MB/s and 100 IOPS still let the database make forward
+# progress while remaining clearly throttled.
+_DISK_MIN_BPS_PER_WORKER = 1 * 1024 * 1024
+_DISK_MIN_IOPS_PER_WORKER = 100
+
+# Heuristic sustained-throughput ceilings per disk class.
+# Values reflect realistic sustained (not peak-burst) numbers for the
+# 4k-random write workloads PostgreSQL produces. Read budgets are larger
+# than write because SSD endurance + WAL fsync dominate the write path.
+_DISK_CLASS_BUDGETS: Dict[str, Dict[str, int]] = {
+    "hdd": {
+        "read_bps": 150 * 1024 * 1024,
+        "write_bps": 100 * 1024 * 1024,
+        "read_iops": 200,
+        "write_iops": 200,
+    },
+    "sata_ssd": {
+        "read_bps": 500 * 1024 * 1024,
+        "write_bps": 250 * 1024 * 1024,
+        "read_iops": 80_000,
+        "write_iops": 60_000,
+    },
+    "nvme_pcie3": {
+        "read_bps": int(2.5 * 1024 * 1024 * 1024),
+        "write_bps": int(1.5 * 1024 * 1024 * 1024),
+        "read_iops": 400_000,
+        "write_iops": 300_000,
+    },
+    "nvme_pcie4": {
+        "read_bps": 6 * 1024 * 1024 * 1024,
+        "write_bps": 4 * 1024 * 1024 * 1024,
+        "read_iops": 700_000,
+        "write_iops": 600_000,
+    },
+    "nvme_pcie5": {
+        "read_bps": 12 * 1024 * 1024 * 1024,
+        "write_bps": 10 * 1024 * 1024 * 1024,
+        "read_iops": 1_500_000,
+        "write_iops": 1_200_000,
+    },
+    # USB / external is overlaid as a min() cap on top of the underlying
+    # class default — the bus is the bottleneck, not the media.
+    "usb_external": {
+        "read_bps": 400 * 1024 * 1024,
+        "write_bps": 200 * 1024 * 1024,
+        "read_iops": 50_000,
+        "write_iops": 40_000,
+    },
+    "unknown": {
+        "read_bps": 500 * 1024 * 1024,
+        "write_bps": 250 * 1024 * 1024,
+        "read_iops": 50_000,
+        "write_iops": 30_000,
+    },
+}
+
+
+def _normalize_dev_basename(device_path: str) -> str:
+    """Resolve symlinks and return the bare kernel device name (e.g. nvme0n1)."""
+    return os.path.basename(os.path.realpath(device_path))
+
+
+def _resolve_block_device_node(target_path: Path) -> Optional[str]:
+    """Return the host block-device node path (``/dev/sdX`` or ``/dev/nvmeXnY``)
+    whose filesystem contains ``target_path``.
+
+    Needed because Docker's ``device_*_bps`` kwargs require a device-node
+    path (the daemon resolves it to ``(major, minor)`` for the cgroup
+    write). Returns ``None`` when the path can't be resolved (non-Linux,
+    bind-mount from a container, etc.).
+    """
+    if platform.system() != "Linux":
+        return None
+
+    mount_point, device = _find_mount_point(target_path)
+    if not device:
+        return None
+    if not device.startswith("/dev/"):
+        return None
+
+    # Resolve symlinks (e.g. /dev/mapper/cryptroot -> /dev/dm-0) so the
+    # daemon sees a stable device node.
+    try:
+        resolved = os.path.realpath(device)
+        if resolved.startswith("/dev/"):
+            return resolved
+    except OSError:
+        pass
+    return device
+
+
+def _is_usb_attached(dev_basename: str) -> bool:
+    """Return True if the block device is attached over USB."""
+    sys_block = Path(f"/sys/block/{dev_basename}")
+    try:
+        resolved = sys_block.resolve(strict=False)
+    except OSError:
+        return False
+    return "/usb" in str(resolved).lower()
+
+
+def _detect_nvme_pcie_class(dev_basename: str) -> str:
+    """Resolve NVMe PCIe generation from sysfs.
+
+    Reads ``/sys/class/nvme/<ctrl>/device/current_link_speed`` which the
+    kernel populates as e.g. ``8.0 GT/s PCIe`` (PCIe 3), ``16.0 GT/s
+    PCIe`` (PCIe 4), ``32.0 GT/s PCIe`` (PCIe 5). Falls back to
+    ``nvme_pcie3`` when the speed string is missing or unrecognised
+    (conservative, matches typical consumer drives).
+    """
+    # nvme0n1 -> nvme0
+    match = re.match(r"^(nvme\d+)", dev_basename)
+    if not match:
+        return "nvme_pcie3"
+    controller = match.group(1)
+    speed_path = Path(f"/sys/class/nvme/{controller}/device/current_link_speed")
+    try:
+        speed = speed_path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return "nvme_pcie3"
+    speed_lower = speed.lower()
+    if "32" in speed_lower or "32.0 gt/s" in speed_lower:
+        return "nvme_pcie5"
+    if "16" in speed_lower or "16.0 gt/s" in speed_lower:
+        return "nvme_pcie4"
+    if "8" in speed_lower or "8.0 gt/s" in speed_lower:
+        return "nvme_pcie3"
+    return "nvme_pcie3"
+
+
+def _detect_disk_class(device_path: Optional[str]) -> str:
+    """Classify the backing block device into one of the budget buckets.
+
+    Returns one of ``hdd | sata_ssd | nvme_pcie3 | nvme_pcie4 |
+    nvme_pcie5 | usb_external | unknown``. ``usb_external`` is special:
+    it indicates the bus is the bottleneck and the caller should overlay
+    the USB cap on top of the underlying media's budget.
+    """
+    if platform.system() != "Linux" or not device_path:
+        return "unknown"
+
+    dev_basename = _normalize_dev_basename(device_path)
+
+    # Strip partition suffix to find the parent block device.
+    if dev_basename.startswith("nvme"):
+        base = dev_basename.split("p")[0] if "p" in dev_basename[4:] else dev_basename
+    else:
+        base = dev_basename.rstrip("0123456789")
+
+    rotational_path = Path(f"/sys/block/{base}/queue/rotational")
+    rotational = "unknown"
+    try:
+        rotational = rotational_path.read_text(encoding="utf-8").strip()
+    except OSError:
+        pass
+
+    if _is_usb_attached(base):
+        return "usb_external"
+
+    if base.startswith("nvme"):
+        return _detect_nvme_pcie_class(base)
+
+    if rotational == "1":
+        return "hdd"
+    if rotational == "0":
+        return "sata_ssd"
+    return "unknown"
+
+
+def _heuristic_disk_budget(disk_class: str) -> Dict[str, int]:
+    """Return host-level disk bandwidth/IOPS budget for a disk class."""
+    if disk_class == "usb_external":
+        usb = _DISK_CLASS_BUDGETS["usb_external"]
+        # USB-attached drives almost always have HDD/SATA-SSD media — cap
+        # the bus, but never claim more than the media would deliver.
+        media = _DISK_CLASS_BUDGETS["sata_ssd"]
+        return {
+            key: min(usb[key], media[key])
+            for key in ("read_bps", "write_bps", "read_iops", "write_iops")
+        }
+    return dict(_DISK_CLASS_BUDGETS.get(disk_class, _DISK_CLASS_BUDGETS["unknown"]))
+
+
+def _probe_disk_with_fio(
+    data_path: Path, timeout_s: int = 8
+) -> Optional[Dict[str, int]]:
+    """Measure host disk bandwidth and IOPS with a short ``fio`` probe.
+
+    Runs a sequential write at 1 MiB blocks for sustained-bps and a
+    4k random read for IOPS. The probe file is created under
+    ``data_path`` so the measurement reflects the filesystem the
+    workers actually write to. Returns ``None`` when fio is missing or
+    any probe fails — callers fall back to the heuristic.
+    """
+    fio_bin = shutil.which("fio")
+    if not fio_bin:
+        return None
+    if not data_path.exists():
+        try:
+            data_path.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            return None
+
+    with tempfile.NamedTemporaryFile(
+        prefix=".pbt_fio_probe_", dir=str(data_path), delete=False
+    ) as fh:
+        probe_file = Path(fh.name)
+
+    common_args = [
+        fio_bin,
+        f"--filename={probe_file}",
+        "--size=64M",
+        "--time_based",
+        "--output-format=json",
+        "--group_reporting",
+    ]
+
+    def _run(args: list[str]) -> Optional[Dict[str, Any]]:
+        try:
+            result = subprocess.run(
+                args,
+                capture_output=True,
+                text=True,
+                timeout=timeout_s,
+                check=False,
+            )
+            if result.returncode != 0:
+                return None
+            return json.loads(result.stdout)
+        except (subprocess.TimeoutExpired, OSError, json.JSONDecodeError):
+            return None
+
+    try:
+        write_payload = _run(
+            common_args
+            + [
+                "--name=write_probe",
+                "--rw=write",
+                "--bs=1M",
+                "--runtime=3",
+                "--ioengine=psync",
+                "--direct=0",
+                "--fsync_on_close=1",
+            ]
+        )
+        read_payload = _run(
+            common_args
+            + [
+                "--name=read_probe",
+                "--rw=randread",
+                "--bs=4k",
+                "--runtime=2",
+                "--ioengine=psync",
+                "--direct=0",
+            ]
+        )
+    finally:
+        try:
+            probe_file.unlink()
+        except OSError:
+            pass
+
+    if not write_payload or not read_payload:
+        return None
+
+    try:
+        write_job = write_payload["jobs"][0]["write"]
+        read_job = read_payload["jobs"][0]["read"]
+        # fio reports bandwidth in KiB/s (`bw`) and IOPS as a float.
+        return {
+            "read_bps": int(read_job.get("bw", 0)) * 1024,
+            "write_bps": int(write_job.get("bw", 0)) * 1024,
+            "read_iops": int(read_job.get("iops", 0)),
+            "write_iops": int(write_job.get("iops", 0)),
+        }
+    except (KeyError, IndexError, TypeError, ValueError):
+        return None
+
+
+def _resolve_host_disk_budget(
+    data_path: Optional[Path],
+    *,
+    probe_disk: bool,
+) -> tuple[Dict[str, int], str]:
+    """Resolve host-level disk budget plus the disk class label used."""
+    device = None
+    if data_path is not None:
+        device = _resolve_block_device_node(data_path)
+    disk_class = _detect_disk_class(device)
+
+    if probe_disk and data_path is not None:
+        probed = _probe_disk_with_fio(data_path)
+        if probed is not None:
+            LOGGER.debug(
+                "  ➤ Disk probe via fio: read=%.1f MB/s, write=%.1f MB/s, "
+                "read_iops=%d, write_iops=%d",
+                probed["read_bps"] / (1024 * 1024),
+                probed["write_bps"] / (1024 * 1024),
+                probed["read_iops"],
+                probed["write_iops"],
+            )
+            return probed, disk_class
+
+    heuristic = _heuristic_disk_budget(disk_class)
+    LOGGER.debug(
+        "  ➤ Disk budget via heuristic (class=%s): read=%.1f MB/s, write=%.1f MB/s",
+        disk_class,
+        heuristic["read_bps"] / (1024 * 1024),
+        heuristic["write_bps"] / (1024 * 1024),
+    )
+    return heuristic, disk_class
+
+
+def _partition_disk_budget(
+    host_budget: Dict[str, int],
+    *,
+    num_workers: int,
+    threshold: float,
+) -> Dict[str, int]:
+    """Divide host-level disk budget by ``num_workers`` with headroom."""
+    num_workers = max(1, num_workers)
+    bps_floor = _DISK_MIN_BPS_PER_WORKER
+    iops_floor = _DISK_MIN_IOPS_PER_WORKER
+    return {
+        "read_bps": max(bps_floor, int(host_budget["read_bps"] * threshold / num_workers)),
+        "write_bps": max(bps_floor, int(host_budget["write_bps"] * threshold / num_workers)),
+        "read_iops": max(iops_floor, int(host_budget["read_iops"] * threshold / num_workers)),
+        "write_iops": max(iops_floor, int(host_budget["write_iops"] * threshold / num_workers)),
+    }
 
 
 def detect_cpu_model() -> str:
@@ -234,6 +586,8 @@ def detect_worker_resources(
     max_parallel_workers: int = 1,
     data_path: Optional[Path] = None,
     threshold: float = 0.8,
+    probe_disk: bool = True,
+    disk_overrides: Optional[Dict[str, Optional[int]]] = None,
 ) -> WorkerResources:
     """
     Detect per-worker hardware resources.
@@ -242,6 +596,12 @@ def detect_worker_resources(
     If bare-metal, divides system resources by max_parallel_workers.
     Reserves (1 - threshold) of resources for OS/tuning system.
     If data_path is provided, detects disk type for that specific path.
+
+    Disk bandwidth/IOPS budgets are resolved by (1) the optional
+    fio probe when available and ``probe_disk`` is True, falling back
+    to (2) a refined heuristic per disk class. Manual per-field
+    overrides in ``disk_overrides`` (``{"read_bps": ..., "write_bps":
+    ..., "read_iops": ..., "write_iops": ...}``) win over both.
     """
     if data_path is not None:
         disk_type = detect_disk_type_for_path(data_path)
@@ -268,15 +628,42 @@ def detect_worker_resources(
         1, math.floor(usable_cpu / max_parallel_workers)
     )  # min 1 logical core
 
+    host_disk_budget, disk_class = _resolve_host_disk_budget(
+        data_path,
+        probe_disk=probe_disk,
+    )
+    per_worker_disk = _partition_disk_budget(
+        host_disk_budget,
+        num_workers=max_parallel_workers,
+        threshold=threshold,
+    )
+    if disk_overrides:
+        for key in ("read_bps", "write_bps", "read_iops", "write_iops"):
+            override = disk_overrides.get(key)
+            if override is not None:
+                per_worker_disk[key] = int(override)
+
     LOGGER.debug(
-        "➤ Worker resources allocated: RAM=%s bytes, CPU=%s cores, Disk=%s",
+        "➤ Worker resources allocated: RAM=%s bytes, CPU=%s cores, Disk=%s, "
+        "read=%.1f MB/s, write=%.1f MB/s, read_iops=%d, write_iops=%d",
         worker_ram,
         worker_cpu,
         disk_type,
+        per_worker_disk["read_bps"] / (1024 * 1024),
+        per_worker_disk["write_bps"] / (1024 * 1024),
+        per_worker_disk["read_iops"],
+        per_worker_disk["write_iops"],
     )
 
     return WorkerResources(
-        ram_bytes=worker_ram, cpu_cores=worker_cpu, disk_type=disk_type
+        ram_bytes=worker_ram,
+        cpu_cores=worker_cpu,
+        disk_type=disk_type,
+        disk_read_bps=per_worker_disk["read_bps"],
+        disk_write_bps=per_worker_disk["write_bps"],
+        disk_read_iops=per_worker_disk["read_iops"],
+        disk_write_iops=per_worker_disk["write_iops"],
+        disk_class=disk_class,
     )
 
 
@@ -307,12 +694,23 @@ def resolve_manual_worker_resources(
     worker_cpus: Optional[int] = None,
     num_workers: int = 1,
     data_path: Optional[Path] = None,
+    worker_disk_read_bps: Optional[int] = None,
+    worker_disk_write_bps: Optional[int] = None,
+    worker_disk_read_iops: Optional[int] = None,
+    worker_disk_write_iops: Optional[int] = None,
+    probe_disk: bool = True,
 ) -> WorkerResources:
     """
     Resolve manual worker resources and validate against host limits.
 
     Allows up to 95% of host capacity. Warns if > 80% is used.
     Falls back entirely to auto-detection if > 95% is requested.
+
+    Disk bandwidth / IOPS may be partially overridden -- fields left as
+    ``None`` fall back to auto-detection (fio probe, then heuristic).
+    Manual values that would push the total beyond 95% of the detected
+    host ceiling are dropped in favour of auto-detected values, mirroring
+    the RAM/CPU overflow behaviour.
     """
     if data_path is not None:
         disk_type = detect_disk_type_for_path(data_path)
@@ -333,6 +731,16 @@ def resolve_manual_worker_resources(
     auto_ram = max(100 * 1024 * 1024, int(usable_ram / num_workers))
     auto_cpu = max(1, math.floor(usable_cpu / num_workers))
 
+    host_disk_budget, disk_class = _resolve_host_disk_budget(
+        data_path,
+        probe_disk=probe_disk,
+    )
+    auto_disk = _partition_disk_budget(
+        host_disk_budget,
+        num_workers=num_workers,
+        threshold=0.8,
+    )
+
     resolved_ram = auto_ram
     if worker_ram is not None:
         resolved_ram = parse_ram_value(worker_ram)
@@ -341,32 +749,61 @@ def resolve_manual_worker_resources(
     if worker_cpus is not None:
         resolved_cpu = int(worker_cpus)
 
+    manual_disk: Dict[str, Optional[int]] = {
+        "read_bps": worker_disk_read_bps,
+        "write_bps": worker_disk_write_bps,
+        "read_iops": worker_disk_read_iops,
+        "write_iops": worker_disk_write_iops,
+    }
+    resolved_disk = dict(auto_disk)
+    for key in ("read_bps", "write_bps", "read_iops", "write_iops"):
+        override = manual_disk[key]
+        if override is not None:
+            resolved_disk[key] = int(override)
+
     total_req_ram = resolved_ram * num_workers
     total_req_cpu = resolved_cpu * num_workers
 
     # Validation logic (95% cap)
     ram_exceeded = total_req_ram > (total_ram * 0.95)
     cpu_exceeded = total_req_cpu > (total_cpus * 0.95)
+    disk_exceeded = any(
+        manual_disk[key] is not None
+        and resolved_disk[key] * num_workers > host_disk_budget[key] * 0.95
+        for key in ("read_bps", "write_bps", "read_iops", "write_iops")
+    )
 
-    if ram_exceeded or cpu_exceeded:
+    if ram_exceeded or cpu_exceeded or disk_exceeded:
+        reasons = []
+        if ram_exceeded:
+            reasons.append("RAM")
+        if cpu_exceeded:
+            reasons.append("CPU")
+        if disk_exceeded:
+            reasons.append("disk I/O")
         LOGGER.warning(
-            "Manual resource allocation (%d workers \u00d7 %s bytes RAM, %d CPUs) "
-            "exceeds 95%% of host physical capacity (RAM: %s bytes, CPU: %d). "
-            "Falling back to auto-detected resources.",
-            num_workers,
-            resolved_ram,
-            resolved_cpu,
-            total_ram,
-            total_cpus,
+            "Manual resource allocation exceeds 95%% of host capacity (%s); "
+            "falling back to auto-detected resources.",
+            ", ".join(reasons),
         )
         LOGGER.debug(
-            "➤ Worker resources allocated (fallback): RAM=%s bytes, CPU=%s cores, Disk=%s",
+            "Worker resources allocated (fallback): RAM=%s bytes, CPU=%s cores, "
+            "Disk=%s, read=%.1f MB/s, write=%.1f MB/s",
             auto_ram,
             auto_cpu,
             disk_type,
+            auto_disk["read_bps"] / (1024 * 1024),
+            auto_disk["write_bps"] / (1024 * 1024),
         )
         return WorkerResources(
-            ram_bytes=auto_ram, cpu_cores=auto_cpu, disk_type=disk_type
+            ram_bytes=auto_ram,
+            cpu_cores=auto_cpu,
+            disk_type=disk_type,
+            disk_read_bps=auto_disk["read_bps"],
+            disk_write_bps=auto_disk["write_bps"],
+            disk_read_iops=auto_disk["read_iops"],
+            disk_write_iops=auto_disk["write_iops"],
+            disk_class=disk_class,
         )
 
     # Warning logic (> 80% and <= 95%)
@@ -381,13 +818,25 @@ def resolve_manual_worker_resources(
         )
 
     LOGGER.info(
-        "Using manual worker resources: RAM=%s bytes, CPU=%s cores, Disk=%s",
+        "Using manual worker resources: RAM=%s bytes, CPU=%s cores, Disk=%s, "
+        "read=%.1f MB/s, write=%.1f MB/s, read_iops=%d, write_iops=%d",
         resolved_ram,
         resolved_cpu,
         disk_type,
+        resolved_disk["read_bps"] / (1024 * 1024),
+        resolved_disk["write_bps"] / (1024 * 1024),
+        resolved_disk["read_iops"],
+        resolved_disk["write_iops"],
     )
     return WorkerResources(
-        ram_bytes=resolved_ram, cpu_cores=resolved_cpu, disk_type=disk_type
+        ram_bytes=resolved_ram,
+        cpu_cores=resolved_cpu,
+        disk_type=disk_type,
+        disk_read_bps=resolved_disk["read_bps"],
+        disk_write_bps=resolved_disk["write_bps"],
+        disk_read_iops=resolved_disk["read_iops"],
+        disk_write_iops=resolved_disk["write_iops"],
+        disk_class=disk_class,
     )
 
 

--- a/src/utils/types.py
+++ b/src/utils/types.py
@@ -183,6 +183,19 @@ class WorkerResourceAllocation:
         Per-worker RAM budget in bytes.
     docker_memory_limit_bytes
         ``mem_limit`` enforced via Docker, or ``None`` for bare-metal.
+    disk_read_bps
+        Per-worker disk read bandwidth in bytes/sec enforced via cgroup
+        ``blkio``/``io.max``. ``0`` means unlimited.
+    disk_write_bps
+        Per-worker disk write bandwidth in bytes/sec. ``0`` means unlimited.
+    disk_read_iops
+        Per-worker disk read IOPS ceiling. ``0`` means unlimited.
+    disk_write_iops
+        Per-worker disk write IOPS ceiling. ``0`` means unlimited.
+    disk_device_path
+        Device node (e.g. ``/dev/sda`` or ``/dev/nvme0n1``) the blkio
+        limits target. ``None`` when blkio enforcement is unavailable
+        (bare-metal or device-node resolution failed).
     """
 
     worker_id: int
@@ -190,6 +203,11 @@ class WorkerResourceAllocation:
     cpuset_cpus: Optional[str]
     ram_bytes: int
     docker_memory_limit_bytes: Optional[int]
+    disk_read_bps: int = 0
+    disk_write_bps: int = 0
+    disk_read_iops: int = 0
+    disk_write_iops: int = 0
+    disk_device_path: Optional[str] = None
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize for JSON output."""
@@ -199,6 +217,11 @@ class WorkerResourceAllocation:
             "cpuset_cpus": self.cpuset_cpus,
             "ram_bytes": self.ram_bytes,
             "docker_memory_limit_bytes": self.docker_memory_limit_bytes,
+            "disk_read_bps": self.disk_read_bps,
+            "disk_write_bps": self.disk_write_bps,
+            "disk_read_iops": self.disk_read_iops,
+            "disk_write_iops": self.disk_write_iops,
+            "disk_device_path": self.disk_device_path,
         }
 
 

--- a/tests/unit/tuner/test_save_final_results_session_environment.py
+++ b/tests/unit/tuner/test_save_final_results_session_environment.py
@@ -110,6 +110,11 @@ def fake_tuner(tmp_path):
         ram_bytes=8 * 1024**3,
         cpu_cores=4,
         disk_type="SSD",
+        disk_read_bps=100_000_000,
+        disk_write_bps=50_000_000,
+        disk_read_iops=10_000,
+        disk_write_iops=8_000,
+        disk_class="sata_ssd",
     )
 
     env = SimpleNamespace(

--- a/tests/unit/tuner/test_save_final_results_timing_block.py
+++ b/tests/unit/tuner/test_save_final_results_timing_block.py
@@ -189,6 +189,11 @@ def fake_tuner(tmp_path):
         ram_bytes=8 * 1024**3,
         cpu_cores=4,
         disk_type="SSD",
+        disk_read_bps=100_000_000,
+        disk_write_bps=50_000_000,
+        disk_read_iops=10_000,
+        disk_write_iops=8_000,
+        disk_class="sata_ssd",
     )
 
     env = SimpleNamespace(

--- a/tests/unit/utils/test_docker_environment.py
+++ b/tests/unit/utils/test_docker_environment.py
@@ -51,6 +51,7 @@ def _make_environment() -> DockerEnvironment:
     env.base_dir = Path("/tmp")
     env.container_prefix = "pbt-worker"
     env.force_recreate_baseline = False
+    env.data_device_node = None
     env.instances = {
         0: InstanceConfig(
             worker_id=0, port=5440, data_dir=Path("/tmp/worker_0"), running=True
@@ -111,6 +112,70 @@ def test_worker_cpuset_cpus_uses_budget_only(mock_cpu_count: MagicMock) -> None:
     # Batch 2: workers 2-3 (sequential to batch 1, so they cycle back to same CPUs)
     assert env._worker_cpuset_cpus(worker_id=2, num_workers=4) == "0,1"
     assert env._worker_cpuset_cpus(worker_id=3, num_workers=4) == "2,3"
+
+
+def test_container_runtime_kwargs_includes_blkio_when_resources_set() -> None:
+    """blkio kwargs are emitted when worker_resources carry a non-zero budget."""
+    env = _make_environment()
+    env.worker_resources = WorkerResources(
+        ram_bytes=512 * 1024 * 1024,
+        cpu_cores=2,
+        disk_type="SSD",
+        disk_read_bps=20_000_000,
+        disk_write_bps=10_000_000,
+        disk_read_iops=5_000,
+        disk_write_iops=3_000,
+        disk_class="sata_ssd",
+    )
+    env.data_device_node = "/dev/sda"
+
+    kwargs = env._container_runtime_kwargs(worker_id=0, num_workers=1)
+
+    assert kwargs["device_read_bps"] == [{"Path": "/dev/sda", "Rate": 20_000_000}]
+    assert kwargs["device_write_bps"] == [{"Path": "/dev/sda", "Rate": 10_000_000}]
+    assert kwargs["device_read_iops"] == [{"Path": "/dev/sda", "Rate": 5_000}]
+    assert kwargs["device_write_iops"] == [{"Path": "/dev/sda", "Rate": 3_000}]
+
+
+def test_container_runtime_kwargs_omits_blkio_when_zero_budget() -> None:
+    """blkio kwargs absent when WorkerResources keeps disk fields at default 0."""
+    env = _make_environment()
+    env.worker_resources = WorkerResources(
+        ram_bytes=512 * 1024 * 1024,
+        cpu_cores=2,
+        disk_type="SSD",
+    )
+    env.data_device_node = "/dev/sda"
+
+    kwargs = env._container_runtime_kwargs(worker_id=0, num_workers=1)
+
+    assert "device_read_bps" not in kwargs
+    assert "device_write_bps" not in kwargs
+    assert "device_read_iops" not in kwargs
+    assert "device_write_iops" not in kwargs
+
+
+def test_container_runtime_kwargs_omits_blkio_when_no_device_node() -> None:
+    """Never emit blkio kwargs when the device node couldn't be resolved.
+
+    This is the safe path on tmpfs / overlayfs / non-Linux hosts where
+    Docker would otherwise reject the kwarg with an unparseable Path.
+    """
+    env = _make_environment()
+    env.worker_resources = WorkerResources(
+        ram_bytes=512 * 1024 * 1024,
+        cpu_cores=2,
+        disk_type="SSD",
+        disk_write_bps=10_000_000,
+    )
+    env.data_device_node = None
+
+    kwargs = env._container_runtime_kwargs(worker_id=0, num_workers=1)
+
+    assert "device_read_bps" not in kwargs
+    assert "device_write_bps" not in kwargs
+    assert "device_read_iops" not in kwargs
+    assert "device_write_iops" not in kwargs
 
 
 def test_restore_snapshot_returns_false_when_image_missing() -> None:

--- a/tests/unit/utils/test_hardware_info.py
+++ b/tests/unit/utils/test_hardware_info.py
@@ -327,3 +327,180 @@ def test_resolve_manual_worker_resources_disk_type_always_inferred(
         worker_ram="2G", worker_cpus=1, num_workers=4, data_path=Path("/tmp/data")
     )
     assert wr.disk_type == "HDD"
+
+
+# ---------------------------------------------------------------------------
+# Disk bandwidth detection + partitioning
+# ---------------------------------------------------------------------------
+
+
+@patch("src.utils.hardware_info._resolve_host_disk_budget")
+@patch("src.utils.hardware_info.detect_disk_type", return_value="SSD")
+@patch("src.utils.hardware_info.psutil.virtual_memory")
+@patch("src.utils.hardware_info.psutil.cpu_count")
+@patch("src.utils.hardware_info.psutil.Process")
+def test_disk_budget_partitioning_divides_by_workers(
+    mock_process,
+    mock_cpu_count,
+    mock_virtual_memory,
+    _mock_disk_type,
+    mock_resolve_host_budget,
+):
+    """Per-worker disk budget should be (host * 0.8) / num_workers."""
+
+    class MockMem:
+        total = 16 * 1024**3
+
+    mock_virtual_memory.return_value = MockMem()
+
+    class MockProcess:
+        def cpu_affinity(self):
+            return list(range(8))
+
+    mock_process.return_value = MockProcess()
+    mock_cpu_count.return_value = 8
+
+    # NVMe PCIe 4.0 ceilings
+    mock_resolve_host_budget.return_value = (
+        {
+            "read_bps": 6 * 1024 * 1024 * 1024,
+            "write_bps": 4 * 1024 * 1024 * 1024,
+            "read_iops": 700_000,
+            "write_iops": 600_000,
+        },
+        "nvme_pcie4",
+    )
+
+    wr = detect_worker_resources(max_parallel_workers=4)
+
+    expected_read = int(6 * 1024 * 1024 * 1024 * 0.8 / 4)
+    expected_write = int(4 * 1024 * 1024 * 1024 * 0.8 / 4)
+    assert wr.disk_read_bps == expected_read
+    assert wr.disk_write_bps == expected_write
+    assert wr.disk_read_iops == int(700_000 * 0.8 / 4)
+    assert wr.disk_write_iops == int(600_000 * 0.8 / 4)
+    assert wr.disk_class == "nvme_pcie4"
+
+
+@patch("shutil.which", return_value=None)
+def test_probe_disk_returns_none_without_fio(_mock_which, tmp_path):
+    """When fio is not on PATH, the probe falls back gracefully."""
+    from src.utils.hardware_info import _probe_disk_with_fio
+
+    assert _probe_disk_with_fio(tmp_path) is None
+
+
+def test_heuristic_disk_budget_usb_caps_media():
+    """USB attachment caps the underlying SATA-SSD media throughput."""
+    from src.utils.hardware_info import _heuristic_disk_budget, _DISK_CLASS_BUDGETS
+
+    usb_budget = _heuristic_disk_budget("usb_external")
+    sata_budget = _DISK_CLASS_BUDGETS["sata_ssd"]
+    usb_caps = _DISK_CLASS_BUDGETS["usb_external"]
+    for key in ("read_bps", "write_bps", "read_iops", "write_iops"):
+        assert usb_budget[key] == min(usb_caps[key], sata_budget[key])
+
+
+def test_heuristic_disk_budget_falls_back_to_unknown():
+    """Unknown classes still return a non-empty conservative budget."""
+    from src.utils.hardware_info import _heuristic_disk_budget
+
+    budget = _heuristic_disk_budget("definitely-not-a-class")
+    for key in ("read_bps", "write_bps", "read_iops", "write_iops"):
+        assert budget[key] > 0
+
+
+@patch("src.utils.hardware_info._resolve_host_disk_budget")
+@patch("src.utils.hardware_info.detect_disk_type", return_value="SSD")
+@patch("src.utils.hardware_info.psutil.virtual_memory")
+@patch("src.utils.hardware_info.psutil.cpu_count")
+@patch("src.utils.hardware_info.psutil.Process")
+def test_resolve_manual_disk_overrides_take_precedence(
+    mock_process,
+    mock_cpu_count,
+    mock_virtual_memory,
+    _mock_disk_type,
+    mock_resolve_host_budget,
+):
+    """Per-field manual disk overrides win over auto-detected values."""
+    from src.utils.hardware_info import resolve_manual_worker_resources
+
+    class MockMem:
+        total = 16 * 1024**3
+
+    mock_virtual_memory.return_value = MockMem()
+
+    class MockProcess:
+        def cpu_affinity(self):
+            return list(range(8))
+
+    mock_process.return_value = MockProcess()
+    mock_cpu_count.return_value = 8
+
+    mock_resolve_host_budget.return_value = (
+        {
+            "read_bps": 6 * 1024 * 1024 * 1024,
+            "write_bps": 4 * 1024 * 1024 * 1024,
+            "read_iops": 700_000,
+            "write_iops": 600_000,
+        },
+        "nvme_pcie4",
+    )
+
+    wr = resolve_manual_worker_resources(
+        num_workers=2,
+        worker_disk_write_bps=50_000_000,
+        worker_disk_read_iops=10_000,
+    )
+
+    # Overrides preserved verbatim
+    assert wr.disk_write_bps == 50_000_000
+    assert wr.disk_read_iops == 10_000
+    # Non-overridden fields auto-detected
+    assert wr.disk_read_bps == int(6 * 1024 * 1024 * 1024 * 0.8 / 2)
+    assert wr.disk_write_iops == int(600_000 * 0.8 / 2)
+
+
+@patch("src.utils.hardware_info._resolve_host_disk_budget")
+@patch("src.utils.hardware_info.detect_disk_type", return_value="SSD")
+@patch("src.utils.hardware_info.psutil.virtual_memory")
+@patch("src.utils.hardware_info.psutil.cpu_count")
+@patch("src.utils.hardware_info.psutil.Process")
+def test_resolve_manual_disk_overflow_falls_back(
+    mock_process,
+    mock_cpu_count,
+    mock_virtual_memory,
+    _mock_disk_type,
+    mock_resolve_host_budget,
+):
+    """Overrides exceeding 95% of host capacity fall back to auto-detected."""
+    from src.utils.hardware_info import resolve_manual_worker_resources
+
+    class MockMem:
+        total = 16 * 1024**3
+
+    mock_virtual_memory.return_value = MockMem()
+
+    class MockProcess:
+        def cpu_affinity(self):
+            return list(range(8))
+
+    mock_process.return_value = MockProcess()
+    mock_cpu_count.return_value = 8
+
+    host_budget = {
+        "read_bps": 1_000_000_000,
+        "write_bps": 1_000_000_000,
+        "read_iops": 100_000,
+        "write_iops": 100_000,
+    }
+    mock_resolve_host_budget.return_value = (host_budget, "sata_ssd")
+
+    # 600M/worker × 2 workers = 1200M > 95% × 1G
+    wr = resolve_manual_worker_resources(
+        num_workers=2,
+        worker_disk_write_bps=600_000_000,
+    )
+
+    # Falls back to auto-detected
+    assert wr.disk_write_bps == int(1_000_000_000 * 0.8 / 2)

--- a/tests/unit/utils/test_hardware_info.py
+++ b/tests/unit/utils/test_hardware_info.py
@@ -410,6 +410,79 @@ def test_heuristic_disk_budget_falls_back_to_unknown():
         assert budget[key] > 0
 
 
+def test_resolve_parent_block_device_walks_partition_to_disk(tmp_path):
+    """Partition device nodes must resolve to the parent disk node.
+
+    Regression: cgroup v2 io.max is enforced on the parent disk, not on
+    individual partitions. Writing rbps to /dev/sda3 raises ENODEV
+    ("no such device") because the kernel I/O scheduler lives on /dev/sda.
+    """
+    from src.utils.hardware_info import _resolve_parent_block_device
+
+    # Build a fake sysfs layout that mirrors the partition->disk topology.
+    sys_class_block = tmp_path / "sys" / "class" / "block"
+    sys_devices = tmp_path / "sys" / "devices" / "pci0000:00" / "sda"
+    sys_devices_part = sys_devices / "sda3"
+    sys_devices_part.mkdir(parents=True)
+    (sys_devices_part / "partition").write_text("3\n")
+    sys_class_block.mkdir(parents=True)
+    # /sys/class/block/sda3 -> ../../devices/.../sda/sda3
+    (sys_class_block / "sda3").symlink_to(sys_devices_part)
+    (sys_class_block / "sda").symlink_to(sys_devices)
+
+    # Mock the sysfs path used by _resolve_parent_block_device.
+    fake_dev_node = tmp_path / "dev"
+    fake_dev_node.mkdir()
+    (fake_dev_node / "sda").touch()
+    (fake_dev_node / "sda3").touch()
+
+    with patch("src.utils.hardware_info.Path") as mock_path:
+
+        def _path_factory(arg):
+            arg_str = str(arg)
+            if arg_str.startswith("/sys/class/block/"):
+                return sys_class_block / arg_str.split("/")[-1]
+            if arg_str.startswith("/dev/"):
+                return fake_dev_node / arg_str.split("/")[-1]
+            from pathlib import Path as RealPath
+
+            return RealPath(arg)
+
+        mock_path.side_effect = _path_factory
+
+        resolved = _resolve_parent_block_device("/dev/sda3")
+
+    assert resolved == "/dev/sda"
+
+
+def test_resolve_parent_block_device_passes_through_whole_disk(tmp_path):
+    """Whole-disk device nodes (no 'partition' marker) pass through unchanged."""
+    from src.utils.hardware_info import _resolve_parent_block_device
+
+    # No /sys/class/block/<name>/partition file => not a partition.
+    sys_class_block = tmp_path / "sys" / "class" / "block"
+    sys_devices = tmp_path / "sys" / "devices" / "pci0000:00" / "nvme0n1"
+    sys_devices.mkdir(parents=True)
+    sys_class_block.mkdir(parents=True)
+    (sys_class_block / "nvme0n1").symlink_to(sys_devices)
+
+    with patch("src.utils.hardware_info.Path") as mock_path:
+
+        def _path_factory(arg):
+            arg_str = str(arg)
+            if arg_str.startswith("/sys/class/block/"):
+                return sys_class_block / arg_str.split("/")[-1]
+            from pathlib import Path as RealPath
+
+            return RealPath(arg)
+
+        mock_path.side_effect = _path_factory
+
+        resolved = _resolve_parent_block_device("/dev/nvme0n1")
+
+    assert resolved == "/dev/nvme0n1"
+
+
 @patch("src.utils.hardware_info._resolve_host_disk_budget")
 @patch("src.utils.hardware_info.detect_disk_type", return_value="SSD")
 @patch("src.utils.hardware_info.psutil.virtual_memory")


### PR DESCRIPTION
## Summary

PBT workers were partitioned across CPU (cpuset) and RAM (`mem_limit`) but disk I/O bandwidth was unbounded. When a worker died mid-generation due to a bad config, the surviving workers reclaimed its share of disk bandwidth — producing performance jumps that are physically impossible for a properly-isolated instance and that permanently corrupt the `best_overall_score` ratchet.

This PR closes the disk I/O channel — the dominant interference vector for OLTP write-heavy workloads (WAL fsync, checkpoint writes, page-out under pressure) — by partitioning host disk bandwidth across workers and enforcing per-container via Docker's `device_read_bps` / `device_write_bps` / `device_read_iops` / `device_write_iops` (which the daemon translates to cgroup v1 `blkio` or cgroup v2 `io.max` automatically).

## What's in this PR

### Core (`src/utils/`)
- **`hardware_info.py`** — extend `WorkerResources` with `disk_read_bps`, `disk_write_bps`, `disk_read_iops`, `disk_write_iops`, `disk_class`. New helpers:
  - `_resolve_block_device_node()` — maps `base_dir` → `/dev/sdX` or `/dev/nvme0n1`
  - `_detect_disk_class()` — distinguishes HDD / SATA SSD / NVMe (PCIe 3/4/5 via `/sys/class/nvme/<ctrl>/device/current_link_speed`) / USB-attached
  - `_heuristic_disk_budget()` — per-class sustained-throughput ceilings; USB caps the underlying media
  - `_probe_disk_with_fio()` — short fio probe (sequential write 1 MiB blocks for bps, 4k random read for IOPS)
  - `_resolve_host_disk_budget()` — three-tier cascade: **manual override → fio probe → refined heuristic**
  - `_partition_disk_budget()` — `host × 0.8 / num_workers` with floors of 1 MB/s + 100 IOPS

  Both `detect_worker_resources()` and `resolve_manual_worker_resources()` now thread the disk fields through with the same 95%-cap-overflow fallback semantics as RAM/CPU.
- **`types.py`** — mirror the disk fields on `WorkerResourceAllocation` so per-worker budgets land in the session JSON's `session_environment.per_worker_resources`.
- **`environments/docker.py`** — `DockerEnvironment.__init__` accepts `data_device_node`. `_container_runtime_kwargs()` emits the four blkio kwargs only when both a non-zero budget and a device node are present (defensive: never emit blkio kwargs we can't target).
- **`environments/factory.py`** — resolves the host block device backing `base_dir` once via `_resolve_block_device_node()` and passes it into the Docker env.

### Round-trip through the evaluation pipeline
Disk fields survive the full session lifecycle:
1. PBT/BO writes `worker_resources.disk_*_bps/iops/class` to JSON (`tuner/main.py`, `bo_baseline/result_writer.py`)
2. BO warm-start reads them as a passthrough dict via `apply_pbt_session` and reconstructs `WorkerResources` with all five new fields
3. Evaluation loader reads them back via `.get(..., 0)` defaults — old session JSONs load cleanly with disk_*_bps=0 (= unlimited), preserving the previous behavior
4. Evaluation runner copies them into `RuntimeWorkerResources`
5. Factory + Docker env reproduce the same blkio limits during evaluation

### CLI surface (PBT + BO, parallel flags)
- `--worker-disk-read-bps` / `--worker-disk-write-bps` (bytes/sec)
- `--worker-disk-read-iops` / `--worker-disk-write-iops`
- `--probe-disk` / `--no-probe-disk` (mutually exclusive; default-on)

### Bootstrap
- `scripts/bootstrap.sh` installs `fio` across apt / dnf / pacman / zypper. Best-effort — heuristic fallback still works without it.

## Calibration accuracy

Heuristic-by-class alone is unreliable: NVMe spans **14×** in bandwidth across PCIe generations (PCIe 3 ~ 2.5 GB/s vs PCIe 5 ~ 12 GB/s read). Three-tier cascade addresses this:
- **Manual override** — explicit per-field flags, no auto-detection
- **fio probe** — 3 s sustained sequential write + 2 s 4k random read against the actual `base_dir` filesystem; ±10% of true sustained bandwidth
- **Refined heuristic** — uses `current_link_speed` to distinguish PCIe gens; USB cap (400 MB/s read / 200 MB/s write) overlaid when the bus is the bottleneck

## What this does NOT close

- **OS page cache** is a kernel-level resource (not per-cgroup). cgroup v2 `mem_limit` already bounds total residency per worker, but pages first-touched by a dying worker can still benefit survivors after the dead container is reaped. Follow-up options: score-side correction for generations with deaths, or synthetic load on dead workers' cpuset to keep contention envelope steady. Not in this PR.
- **Memory bandwidth + LLC** sharing across cores on the same socket. Outside cgroup control entirely.

Net effect of this PR alone: ~70-80% of the cross-worker leak (disk-bound workloads) eliminated.