### PR TITLE
feat(bo): co-tenant load harness + CPU clock pinning for fair PBT-vs-BO comparison

### DIFF
--- a/scripts/experiments/__main__.py
+++ b/scripts/experiments/__main__.py
@@ -123,8 +123,9 @@ def main():
         manifest_path=args.manifest,
     )
 
-    for exp in experiments_to_run:
-        runner.run_experiment(exp, retry_failed=args.retry_failed)
+    with runner.cpu_performance_session():
+        for exp in experiments_to_run:
+            runner.run_experiment(exp, retry_failed=args.retry_failed)
 
 
 if __name__ == "__main__":

--- a/scripts/experiments/runner.py
+++ b/scripts/experiments/runner.py
@@ -1,13 +1,39 @@
+import atexit
 import json
 import logging
+import signal
 import subprocess
 import time
+from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
 
 from scripts.experiments.experiment_matrix import Experiment
 from src.config.data_root import resolve_data_root
 from src.utils.hardware_info import detect_worker_resources, _resolve_block_device_node
+from src.tuner.config.tuner_config import (
+    RAPID_CONFIG,
+    STANDARD_CONFIG,
+    THOROUGH_CONFIG,
+    RESEARCH_CONFIG,
+)
+
+# Per-experiment parallel-worker resolution must mirror what the PBT CLI
+# (``src.tuner.main``) will actually use as ``num_parallel_workers`` -- that is
+# the denominator ``detect_worker_resources`` divides host capacity by. The CLI
+# uses ``--parallel-workers`` when supplied, else the selected config profile's
+# default. We reproduce that mapping here from the canonical profile configs so
+# resource budgets cannot drift from the real run (the previous code hardcoded
+# 8, which silently mis-sized any experiment whose effective width was not 8).
+_PROFILE_PARALLEL_WORKERS = {
+    "rapid": RAPID_CONFIG.num_parallel_workers,
+    "standard": STANDARD_CONFIG.num_parallel_workers,
+    "thorough": THOROUGH_CONFIG.num_parallel_workers,
+    "research": RESEARCH_CONFIG.num_parallel_workers,
+}
+# Fallback when a profile name is unknown (defensive; the matrix only uses
+# "thorough" and "rapid" today).
+_DEFAULT_PARALLEL_WORKERS = THOROUGH_CONFIG.num_parallel_workers
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 RESULTS_DIR = PROJECT_ROOT / "results"
@@ -74,11 +100,10 @@ class ExperimentRunner:
         # written by a peer machine and pulled via git).
         self._cross_manifest_index = self._build_cross_manifest_index()
         
-        # Calculate resources once
-        resources = detect_worker_resources(max_parallel_workers=8, threshold=0.95)
-        worker_ram_mb = resources.ram_bytes // (1024 * 1024)
-        self.worker_ram = f"{worker_ram_mb}M"
-        self.worker_cpus = max(1, resources.cpu_cores)
+        # Per-experiment worker-resource flags are computed lazily in
+        # ``_worker_resource_flags(exp)`` (the parallel-worker denominator
+        # depends on the experiment), and memoised here keyed by that count.
+        self._worker_flag_cache: dict[int, tuple[str, int]] = {}
         
         # Set up logging
         if not LOGGER.handlers:
@@ -86,6 +111,45 @@ class ExperimentRunner:
                 level=logging.INFO,
                 format="%(asctime)s [%(levelname)s] %(message)s"
             )
+
+    def _effective_parallel_workers(self, exp: Experiment) -> int:
+        """Resolve the parallel-worker count the PBT run will actually use.
+
+        Mirrors ``src.tuner.main``: an explicit ``parallel_workers`` on the
+        experiment wins; otherwise the config profile's default applies. This
+        is the denominator host capacity is divided by, so it must match the
+        real run or per-worker budgets are wrong.
+        """
+        if exp.parallel_workers is not None:
+            return max(1, int(exp.parallel_workers))
+        return _PROFILE_PARALLEL_WORKERS.get(
+            exp.config_profile, _DEFAULT_PARALLEL_WORKERS
+        )
+
+    def _worker_resource_flags(self, exp: Experiment) -> tuple[str, int]:
+        """Return ``(worker_ram, worker_cpus)`` CLI flag values for ``exp``.
+
+        Per-worker budgets are host capacity (at 95%) divided by the
+        experiment's effective parallel-worker count. Memoised by that count so
+        repeated experiments of the same width don't re-probe the host.
+        """
+        n = self._effective_parallel_workers(exp)
+        cached = self._worker_flag_cache.get(n)
+        if cached is not None:
+            return cached
+        resources = detect_worker_resources(max_parallel_workers=n, threshold=0.95)
+        worker_ram_mb = resources.ram_bytes // (1024 * 1024)
+        flags = (f"{worker_ram_mb}M", max(1, resources.cpu_cores))
+        self._worker_flag_cache[n] = flags
+        LOGGER.info(
+            "Experiment %s: per-worker resources for %d parallel workers -> "
+            "%s RAM, %d CPUs",
+            exp.id,
+            n,
+            flags[0],
+            flags[1],
+        )
+        return flags
 
     def _resolve_manifest_path(self, exp_id: str) -> Path:
         """Resolve the manifest path for ``exp_id``.
@@ -377,6 +441,75 @@ class ExperimentRunner:
             device,
         )
 
+    @contextmanager
+    def cpu_performance_session(self):
+        """Pin CPU governor=performance + disable turbo for the batch, then revert.
+
+        Removes per-core throughput variance with active-core count (frequency
+        scaling + turbo) so PBT (N parallel workers) and the co-tenant-loaded BO
+        baseline see identical per-core clocks. The host's original governor/turbo
+        is snapshotted on entry and **always restored on exit** — normal return,
+        exception, or SIGINT/SIGTERM — so the machine is never left mutated.
+
+        Skipped under ``dry_run``. Best-effort: if the host lacks the sysfs
+        interface or we lack root, it logs a warning and proceeds unpinned rather
+        than aborting (the disk-isolation preflight is the hard gate; clock
+        pinning is a quality-of-measurement improvement, not a correctness
+        invariant).
+        """
+        if self.dry_run:
+            yield
+            return
+
+        from src.utils.cpu_perf import (
+            read_cpu_perf_state,
+            set_performance_mode,
+            restore_cpu_perf_state,
+        )
+
+        saved = read_cpu_perf_state()
+        restored = {"done": False}
+
+        def _restore_once(*_args) -> None:
+            if restored["done"]:
+                return
+            restored["done"] = True
+            restore_cpu_perf_state(saved)
+
+        # Belt-and-suspenders: also restore on hard signals and at interpreter
+        # exit, in case the surrounding loop is killed outside the finally.
+        prev_handlers: dict[int, object] = {}
+        for sig in (signal.SIGINT, signal.SIGTERM):
+            try:
+                prev_handlers[sig] = signal.getsignal(sig)
+
+                def _handler(signum, frame, _sig=sig):
+                    _restore_once()
+                    prev = prev_handlers.get(_sig)
+                    if callable(prev):
+                        prev(signum, frame)
+                    else:
+                        # Default behaviour: re-raise as the process terminating.
+                        raise KeyboardInterrupt()
+
+                signal.signal(sig, _handler)
+            except (ValueError, OSError):
+                # Not in main thread or unsupported — skip signal hook.
+                pass
+        atexit.register(_restore_once)
+
+        if saved.supported:
+            set_performance_mode(saved)
+        try:
+            yield
+        finally:
+            _restore_once()
+            for sig, prev in prev_handlers.items():
+                try:
+                    signal.signal(sig, prev)  # type: ignore[arg-type]
+                except (ValueError, OSError, TypeError):
+                    pass
+
     def run_experiment(self, exp: Experiment, retry_failed: bool = False) -> None:
         LOGGER.info(f"Starting experiment {exp.id} (Tier {exp.tier})")
 
@@ -589,6 +722,7 @@ class ExperimentRunner:
         ``--config thorough`` supplies the 512-point design size unless the
         experiment pins ``design_size``.
         """
+        worker_ram, worker_cpus = self._worker_resource_flags(exp)
         cmd = [
             "python", "-m", "src.tuners.lhs_design",
             "--config", exp.config_profile,
@@ -599,8 +733,8 @@ class ExperimentRunner:
             "--tuning-mode", exp.tuning_mode,
             "--snapshot-restore-interval", "1",
             "--force-recreate-instances",
-            "--worker-ram", self.worker_ram,
-            "--worker-cpus", str(self.worker_cpus),
+            "--worker-ram", worker_ram,
+            "--worker-cpus", str(worker_cpus),
             "--verbose", "DEBUG",
         ]
         if exp.sysbench_workload:
@@ -612,6 +746,7 @@ class ExperimentRunner:
         return cmd
 
     def _build_pbt_cmd(self, exp: Experiment, seed: int) -> list[str]:
+        worker_ram, worker_cpus = self._worker_resource_flags(exp)
         cmd = [
             "python", "-m", "src.tuner.main",
             "--config", exp.config_profile,
@@ -626,8 +761,8 @@ class ExperimentRunner:
             # flag makes that contract part of the experiment record.
             "--snapshot-restore-interval", "1",
             "--force-recreate-instances",
-            "--worker-ram", self.worker_ram,
-            "--worker-cpus", str(self.worker_cpus),
+            "--worker-ram", worker_ram,
+            "--worker-cpus", str(worker_cpus),
             "--verbose", "DEBUG"
         ]
 
@@ -673,6 +808,13 @@ class ExperimentRunner:
         # explicitly so a stale or partial session JSON cannot silently
         # change the workload shape. Anything that would mismatch the
         # PBT run breaks the fair-comparison invariant the paper rests on.
+        #
+        # NOTE: when --pbt-session is present (the normal matrix path) the BO
+        # runner inherits per-worker resources AND the co-tenancy degree from
+        # the session JSON, so these --worker-ram/--worker-cpus flags are
+        # intentionally redundant (logged as ignored by the BO runner). They
+        # are kept for the standalone-BO path where no session is supplied.
+        worker_ram, worker_cpus = self._worker_resource_flags(exp)
         cmd = [
             "python", "-m", "src.scripts.bo_baseline",
             "--config", exp.config_profile,
@@ -684,8 +826,8 @@ class ExperimentRunner:
             "--enable-snapshots",
             "--snapshot-restore-interval", "1",
             "--force-recreate-instances",
-            "--worker-ram", self.worker_ram,
-            "--worker-cpus", str(self.worker_cpus),
+            "--worker-ram", worker_ram,
+            "--worker-cpus", str(worker_cpus),
             "--verbose", "INFO"
         ]
         if exp.sysbench_workload:

--- a/src/analysis/scalpel.py
+++ b/src/analysis/scalpel.py
@@ -26,20 +26,17 @@ from __future__ import annotations
 import argparse
 import time
 from dataclasses import dataclass, field
-from typing import Any, Iterable, Mapping, Optional
+from typing import Any, Mapping, Optional
 
 import numpy as np
 import pandas as pd
 
 from src.analysis.scalpel_significance import (
-    BorutaResult,
     _fit_outer_rf,
     boruta_with_group_perm,
     partition_boruta_hits,
 )
 from src.analysis.scalpel_stability import (
-    LorenzTierResult,
-    StabilityResult,
     apply_nuisance_filter,
     assign_lorenz_tiers,
     audit_dba_prior,
@@ -342,7 +339,6 @@ def lorenz_tier_from_importances(
     ``minimal`` / ``core`` / ``standard`` purely by Lorenz cumulative mass.
     """
     from src.analysis.tier_generator import (  # local import to break cycle
-        AgreementReport,
         EXPERT_TIER_ORDER,
         TierResult,
         compare_to_expert,

--- a/src/analysis/scalpel_significance.py
+++ b/src/analysis/scalpel_significance.py
@@ -19,8 +19,7 @@ SCALPEL design (see docs/architecture or /home/eima40x4c/.claude/plans/distribut
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from typing import Optional
+from dataclasses import dataclass
 
 import numpy as np
 import pandas as pd

--- a/src/scripts/analyze_knob_importance.py
+++ b/src/scripts/analyze_knob_importance.py
@@ -14,7 +14,7 @@ import argparse
 import json
 import sys
 from pathlib import Path
-from typing import Any, Iterable, Optional
+from typing import Any, Optional
 
 import pandas as pd
 

--- a/src/scripts/bo_baseline/config.py
+++ b/src/scripts/bo_baseline/config.py
@@ -78,6 +78,17 @@ class BOConfig:
     worker_disk_write_iops: Optional[int] = None
     probe_disk: bool = True
 
+    # Co-tenancy load: number of *total* concurrent instances (foreground BO
+    # trial + background load) to run during each measurement window so the BO
+    # baseline experiences the same single-host contention a PBT generation
+    # does. ``1`` disables background load. When a PBT session is supplied this
+    # is forced to the session's ``num_parallel_workers`` (the matched,
+    # mandatory degree) unless ``no_cotenant`` is set. An explicit
+    # ``--cotenancy-degree`` only applies when no session pins it.
+    # See src/scripts/bo_baseline/cotenant.py.
+    cotenancy_degree: int = 1
+    no_cotenant: bool = False
+
     # Scoring policy
     # Available options:
     # - "fixed_v1": Legacy static weights based on workload type (OLTP/OLAP/MIXED)
@@ -241,16 +252,41 @@ class BOConfig:
         if isinstance(worker_resources, dict):
             self.pbt_worker_resources = worker_resources
 
-        # Extract num_parallel_workers for parallel BO (only if set_max_workers=True)
-        if set_max_workers:
-            num_parallel_workers = int(session.get("num_parallel_workers", 0) or 0)
-            if num_parallel_workers > 0:
+        # Extract num_parallel_workers from the session. It drives two things:
+        #   (1) resource_division for the legacy parallel-BO path (only when
+        #       set_max_workers lets the session override the CLI), and
+        #   (2) cotenancy_degree — the MANDATORY, matched co-tenancy load level
+        #       so each BO measurement window experiences the same single-host
+        #       contention a PBT generation generated. This is enforced
+        #       unconditionally whenever the session reports a positive count.
+        num_parallel_workers = int(session.get("num_parallel_workers", 0) or 0)
+        if self.no_cotenant:
+            self.cotenancy_degree = 1
+            LOGGER.info(
+                "Co-tenancy explicitly disabled (--no-cotenant); BO will run "
+                "WITHOUT background load despite PBT session having "
+                "num_parallel_workers=%d.",
+                num_parallel_workers,
+            )
+            if set_max_workers and num_parallel_workers > 0:
                 self.resource_division = num_parallel_workers
-            else:
-                LOGGER.warning(
-                    "PBT session is missing positive num_parallel_workers; "
-                    "keeping configured BO resource division"
-                )
+        elif num_parallel_workers > 0:
+            self.cotenancy_degree = num_parallel_workers
+            LOGGER.info(
+                "Co-tenancy degree set to %d from matched PBT session "
+                "(num_parallel_workers); BO trials will run with %d background "
+                "load instance(s).",
+                num_parallel_workers,
+                num_parallel_workers - 1,
+            )
+            if set_max_workers:
+                self.resource_division = num_parallel_workers
+        else:
+            LOGGER.warning(
+                "PBT session is missing positive num_parallel_workers; cannot "
+                "enforce matched co-tenancy — BO will run WITHOUT background "
+                "load (this breaks the fair-comparison invariant)."
+            )
 
         # Extract snapshot settings
         if "enable_snapshots" in session:
@@ -419,6 +455,13 @@ class BOConfig:
                 else None
             ),
             probe_disk=args.probe_disk if hasattr(args, "probe_disk") else True,
+            cotenancy_degree=(
+                args.cotenancy_degree
+                if hasattr(args, "cotenancy_degree")
+                and args.cotenancy_degree is not None
+                else base_config.cotenancy_degree
+            ),
+            no_cotenant=getattr(args, "no_cotenant", False),
         )
 
         if args.pbt_session:

--- a/src/scripts/bo_baseline/cotenant.py
+++ b/src/scripts/bo_baseline/cotenant.py
@@ -1,0 +1,242 @@
+"""
+Co-Tenant Load Controller for the BO Baseline
+=============================================
+
+Fair PBT-vs-BO comparison on a single host.
+
+PBT tunes with ``N`` workers running *in parallel* on one machine; the BO
+baseline's optimizer is strictly *sequential* (one ask→eval→tell at a time —
+the wall-clock-efficiency claim the paper rests on). Per-instance Docker cgroup
+limits (cpuset, memory, blkio) equalize *allotment*, but a solo BO trial still
+runs on an otherwise-idle box and enjoys uncontended CPU turbo, memory
+bandwidth, LLC, and disk-queue depth that ``N`` concurrent PBT workers do not.
+On I/O- and bandwidth-bound workloads (TPC-H especially) this makes BO look
+artificially strong *during tuning*.
+
+This controller removes that confound **without** making BO parallel or
+devaluing its measured instance. The BO trial keeps running alone on worker 0's
+full per-worker slice. Around each trial's measurement window, ``N-1``
+**background load instances** (worker ids ``1..N-1``) run the same benchmark on
+their own disjoint cpusets, reproducing exactly the cross-worker contention a
+PBT generation generates. Synchronization reuses the project's own
+:class:`GenerationBarrier`: the foreground trial and every background loader
+share one barrier object, so the background workload runs in lockstep precisely
+during the foreground warmup→measurement window (barriers B8–B9) and nowhere
+else.
+
+Design choices
+--------------
+- **Same path as PBT.** Background loaders call the *same*
+  ``WorkloadOrchestrator.evaluate_worker(..., barriers=...)`` PBT uses (it is
+  already thread-safe and barrier-aware), so they traverse B1–B17 identically
+  and contend during exactly the measurement window. No orchestrator changes.
+- **Fixed LHS load configs.** Each background instance is pinned to one
+  seeded Latin-Hypercube-sampled config drawn once from the same
+  :class:`KnobSpace` (so memory/CPU knob dependencies resolve through the normal
+  pipeline). Constant, reproducible contention across all BO trials, decoupled
+  from PBT internals.
+- **Apply every round for barrier symmetry.** The fixed config is applied
+  (with the single required restart) on the first trial; later trials re-apply
+  the same values without restart (``force_restart_next_eval`` is cleared after
+  the first). ``apply_config=True`` on every round is required because the
+  ``config_applied`` (B2) and ``config_verified`` (B5) barriers are conditional
+  on ``apply_config`` inside ``evaluate_worker`` — mismatch causes deadlock.
+- **Degree is mandatory and matched.** The controller is constructed with
+  ``degree = N`` taken from the matched PBT session's ``num_parallel_workers``;
+  the BO runner enforces this whenever a PBT session is supplied.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from typing import List, Optional
+
+from src.config.database import DatabaseConfig
+from src.tuner.config.knob_space import KnobSpace
+from src.tuner.core.barriers import GenerationBarrier
+from src.tuner.core.worker import Worker
+from src.tuner.benchmark.orchestrator import WorkloadOrchestrator
+from src.utils.environments.base import DatabaseEnvironment
+from src.utils.logger import get_logger
+
+LOGGER = get_logger("CoTenantLoad")
+
+
+class CoTenantLoadController:
+    """Drives ``degree - 1`` background load instances around each BO trial.
+
+    Parameters
+    ----------
+    degree:
+        Total co-tenancy degree ``N`` (= matched PBT ``num_parallel_workers``).
+        ``N - 1`` background instances run alongside the single foreground BO
+        trial. ``degree <= 1`` disables the controller (no background load).
+    env:
+        The already-created :class:`DatabaseEnvironment`. Must have been set up
+        with ``num_workers = degree`` so worker ids ``1..degree-1`` have live
+        containers on disjoint cpusets.
+    orchestrator:
+        The BO runner's :class:`WorkloadOrchestrator`. Reused read-only for the
+        background ``evaluate_worker`` calls (it carries workload + durations).
+    knob_space:
+        Knob space the background load configs are LHS-sampled from.
+    base_db_config:
+        Template DB config; per-worker host/port come from ``env.get_db_config``.
+    seed:
+        Seed for the LHS draw, so the background load is reproducible.
+    """
+
+    def __init__(
+        self,
+        degree: int,
+        env: DatabaseEnvironment,
+        orchestrator: WorkloadOrchestrator,
+        knob_space: KnobSpace,
+        base_db_config: DatabaseConfig,
+        seed: int = 0,
+    ) -> None:
+        self.degree = max(1, int(degree))
+        self.env = env
+        self.orchestrator = orchestrator
+        self.knob_space = knob_space
+        self.base_db_config = base_db_config
+        self.seed = seed
+
+        self._bg_worker_ids: List[int] = list(range(1, self.degree))
+        self._bg_workers: List[Worker] = []
+        self._pool: Optional[ThreadPoolExecutor] = None
+
+        if self.enabled:
+            self._build_background_workers()
+            # One persistent pool sized to run all background loaders at once.
+            self._pool = ThreadPoolExecutor(
+                max_workers=len(self._bg_worker_ids),
+                thread_name_prefix="cotenant",
+            )
+            LOGGER.info(
+                "Co-tenancy ENABLED: degree=%d → %d background load instance(s) "
+                "(worker ids %s) will contend during each BO measurement window.",
+                self.degree,
+                len(self._bg_worker_ids),
+                self._bg_worker_ids,
+            )
+        else:
+            LOGGER.info(
+                "Co-tenancy DISABLED (degree=%d): BO runs without background load.",
+                self.degree,
+            )
+
+    @property
+    def enabled(self) -> bool:
+        """Whether any background load instances exist."""
+        return self.degree > 1 and bool(self._bg_worker_ids)
+
+    @property
+    def barrier_parties(self) -> int:
+        """Number of threads that meet at each barrier (foreground + background)."""
+        return len(self._bg_worker_ids) + 1
+
+    def _build_background_workers(self) -> None:
+        """Create background Workers with fixed, seeded LHS load configs."""
+        # One LHS design row per background worker. Deterministic given the
+        # seed; ``sample_diverse_configs`` uses Latin Hypercube Sampling and
+        # already returns dependency-repaired configs (memory/CPU knob
+        # relationships resolved exactly as a real worker config would be).
+        designs = self.knob_space.sample_diverse_configs(
+            num_samples=len(self._bg_worker_ids), seed=self.seed, quiet=True
+        )
+        for idx, worker_id in enumerate(self._bg_worker_ids):
+            worker = Worker(worker_id=worker_id, knob_space=self.knob_space)
+            worker.db_config = self.env.get_db_config(worker_id)
+            worker.knob_config = dict(designs[idx])
+            # Background instances must restart once to install their config.
+            worker.force_restart_next_eval = True
+            self._bg_workers.append(worker)
+
+    def _run_one_background(
+        self, worker: Worker, barriers: GenerationBarrier
+    ) -> None:
+        """Run a single background loader through the lockstep B1–B17 path.
+
+        Metrics and score are discarded — the only purpose is to contend for
+        host resources during the foreground worker's measurement window. Any
+        failure is swallowed (logged at debug); ``evaluate_worker`` itself
+        drains remaining barriers on error so the foreground never deadlocks.
+
+        ``apply_config=True`` on *every* round is required, not optional: the
+        ``config_applied`` (B2) and ``config_verified`` (B5) barriers are gated
+        by ``apply_config`` inside ``evaluate_worker``. The foreground trial
+        always applies its config, so the background must too, or the two sides
+        would traverse different barrier sets and deadlock. The fixed load
+        config only restarts the instance on the first round
+        (``force_restart_next_eval`` is cleared by ``evaluate_worker`` after the
+        first restart); later rounds are cheap reloads of the same values.
+        """
+        try:
+            self.orchestrator.evaluate_worker(
+                worker,
+                apply_config=True,
+                barriers=barriers,
+                # No snapshot restore for background load: keep contention
+                # constant and avoid per-trial restore cost/drift handling.
+                restore_due=False,
+                next_eval_will_restore=False,
+            )
+        except Exception as exc:  # noqa: BLE001 - background load is best-effort
+            LOGGER.debug(
+                "Background loader (worker %d) raised (ignored): %s",
+                worker.worker_id,
+                exc,
+            )
+
+    def make_barrier(self) -> Optional[GenerationBarrier]:
+        """Return a fresh barrier for the next trial, or ``None`` if disabled.
+
+        The foreground BO trial passes this object to ``evaluate_config`` /
+        ``evaluate_worker`` so it joins the same lockstep as the background
+        loaders. A new object per trial avoids cross-trial barrier state.
+        """
+        if not self.enabled:
+            return None
+        return GenerationBarrier(num_workers=self.barrier_parties, enabled=True)
+
+    def start_round(self, barriers: Optional[GenerationBarrier]) -> List:
+        """Launch all background loaders for one trial; returns their futures.
+
+        Must be paired with :meth:`finish_round`. The foreground trial should be
+        invoked *after* this call (both share ``barriers``), then awaited, then
+        ``finish_round`` joins the loaders.
+        """
+        if not self.enabled or barriers is None or self._pool is None:
+            return []
+        futures = [
+            self._pool.submit(self._run_one_background, worker, barriers)
+            for worker in self._bg_workers
+        ]
+        return futures
+
+    @staticmethod
+    def finish_round(futures: List) -> None:
+        """Join all background loaders for the round (best-effort)."""
+        for fut in futures:
+            try:
+                fut.result()
+            except Exception as exc:  # noqa: BLE001
+                LOGGER.debug("Background loader future error (ignored): %s", exc)
+
+    def shutdown(self) -> None:
+        """Stop the background pool. Containers are torn down by env.cleanup()."""
+        if self._pool is not None:
+            self._pool.shutdown(wait=True)
+            self._pool = None
+
+    def to_metadata(self) -> dict:
+        """Serialise the co-tenancy configuration for the session JSON."""
+        return {
+            "enabled": self.enabled,
+            "degree": self.degree,
+            "background_worker_ids": list(self._bg_worker_ids),
+            "foreground_worker_id": 0,
+            "load_config_seed": self.seed,
+            "load_config_source": "lhs_diverse",
+        }

--- a/src/scripts/bo_baseline/objective.py
+++ b/src/scripts/bo_baseline/objective.py
@@ -6,6 +6,7 @@ from ConfigSpace import Configuration
 
 from src.tuner.config.knob_space import KnobSpace
 from src.tuner.core.worker import Worker
+from src.tuner.core.barriers import GenerationBarrier
 from src.tuner.benchmark.orchestrator import WorkloadOrchestrator
 from src.utils.metrics import PerformanceMetrics
 from src.utils.scoring.contracts import ScoreBreakdown
@@ -29,6 +30,7 @@ def evaluate_config(
     seed: Optional[int] = None,
     restore_due: bool = False,
     next_eval_will_restore: bool = False,
+    barriers: Optional[GenerationBarrier] = None,
 ) -> Tuple[
     Optional[float],
     Dict,
@@ -79,6 +81,12 @@ def evaluate_config(
         skip the post-workload VACUUM ANALYZE, since the restore will
         wipe its on-disk effects (and it cannot influence the metrics
         we just collected).
+    barriers : Optional[GenerationBarrier]
+        Lockstep barrier shared with co-tenant background load workers. When
+        provided, the foreground trial waits at each B1–B17 point so its
+        warmup+measurement window (B8–B9) overlaps the background load exactly,
+        reproducing PBT's single-host contention. ``None`` (the default) runs
+        with no synchronization / no background load.
 
     Returns
     -------
@@ -139,6 +147,7 @@ def evaluate_config(
         random_seed=seed,
         restore_due=restore_due,
         next_eval_will_restore=next_eval_will_restore,
+        barriers=barriers,
     )
 
     # The orchestrator already verified the config and read back the true

--- a/src/scripts/bo_baseline/result_writer.py
+++ b/src/scripts/bo_baseline/result_writer.py
@@ -90,6 +90,7 @@ def write_bo_results(
     requested_iterations: Optional[int] = None,
     requested_pilot_size: Optional[int] = None,
     actual_pilot_size: Optional[int] = None,
+    cotenancy: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """
     Serialize Bayesian Optimization results in PBT-compatible JSON format.
@@ -380,6 +381,14 @@ def write_bo_results(
 
     if session_environment is not None:
         result["session_environment"] = session_environment.to_dict()
+
+    if cotenancy is not None:
+        # Honest record of the co-tenant load applied during each measurement
+        # window so the BO session documents the contention it ran under
+        # (degree, background worker ids, load-config seed). The foreground BO
+        # trial is always worker 0; ids in ``background_worker_ids`` are pure
+        # load and were not measured.
+        result["cotenancy"] = convert_numpy_types(cotenancy)
 
     # Create output directory structure
     bo_root = resolve_bo_output_root(

--- a/src/scripts/bo_baseline/runner.py
+++ b/src/scripts/bo_baseline/runner.py
@@ -51,6 +51,7 @@ from src.scripts.bo_baseline.search_space import (
     knobs_to_configspace,
 )
 from src.scripts.bo_baseline.objective import evaluate_config
+from src.scripts.bo_baseline.cotenant import CoTenantLoadController
 from src.scripts.bo_baseline.result_writer import (
     write_bo_results,
     resolve_bo_output_root,
@@ -107,6 +108,29 @@ class BOBaselineRunner:
 
         # Resource equalization: PBT-derived > manual CLI override > auto detection
         if config.pbt_worker_resources:
+            # PBT inheritance wins for fairness, but make the precedence
+            # explicit: if manual --worker-ram/--worker-cpus/--worker-disk-*
+            # flags were ALSO supplied they are intentionally ignored here.
+            # Surfacing this avoids the silent-override footgun where a caller
+            # believes their flags took effect.
+            manual_flags_present = config.worker_ram is not None or (
+                config.worker_cpus is not None
+            ) or any(
+                v is not None
+                for v in (
+                    config.worker_disk_read_bps,
+                    config.worker_disk_write_bps,
+                    config.worker_disk_read_iops,
+                    config.worker_disk_write_iops,
+                )
+            )
+            if manual_flags_present:
+                self.logger.warning(
+                    "Manual --worker-ram/--worker-cpus/--worker-disk-* flags are "
+                    "IGNORED because a PBT session was supplied; per-worker "
+                    "resources are inherited from the PBT session to preserve the "
+                    "fair-comparison invariant."
+                )
             self.worker_resources = WorkerResources(
                 ram_bytes=int(config.pbt_worker_resources.get("ram_bytes", 0)),
                 cpu_cores=int(config.pbt_worker_resources.get("cpu_cores", 1)),
@@ -222,6 +246,10 @@ class BOBaselineRunner:
         # Captured at the start of optimize() (after bootstrap). Used to
         # report a leak-free ``tuning_time_seconds`` excluding bootstrap.
         self.tuning_start_time: Optional[float] = None
+        # Co-tenant load controller; replaced with a real one in run() once the
+        # environment/orchestrator exist. Defaults to a disabled no-op so any
+        # early cleanup path is safe.
+        self.cotenant: Optional[CoTenantLoadController] = None
 
     def _create_workload_executor(self):
         """Create appropriate workload executor based on benchmark type."""
@@ -315,6 +343,43 @@ class BOBaselineRunner:
             skipped,
         )
         return relabeled
+
+    def _evaluate_with_cotenancy(
+        self,
+        config,
+        worker: Worker,
+        orchestrator: WorkloadOrchestrator,
+        previous_engine_config,
+        seed=None,
+        restore_due: bool = False,
+        next_eval_will_restore: bool = False,
+    ):
+        """Evaluate one foreground BO trial under matched co-tenant load.
+
+        Creates a fresh per-trial barrier shared by the foreground worker and
+        the ``degree - 1`` background loaders, launches the loaders, runs the
+        foreground evaluation in lockstep (its workload contends with the
+        background load during B8–B9), then joins the loaders. When co-tenancy
+        is disabled the barrier is ``None`` and this reduces to a plain
+        ``evaluate_config`` call (zero overhead).
+        """
+        barriers = self.cotenant.make_barrier() if self.cotenant else None
+        futures = self.cotenant.start_round(barriers) if self.cotenant else []
+        try:
+            return evaluate_config(
+                config,
+                worker,
+                orchestrator,
+                self.knob_space,
+                previous_engine_config,
+                seed=seed,
+                restore_due=restore_due,
+                next_eval_will_restore=next_eval_will_restore,
+                barriers=barriers,
+            )
+        finally:
+            if self.cotenant:
+                self.cotenant.finish_round(futures)
 
     def _run_sequential_optimization(
         self,
@@ -415,14 +480,14 @@ class BOBaselineRunner:
                     restarted,
                     wall_time,
                     eval_timing,
-                ) = evaluate_config(
+                ) = self._evaluate_with_cotenancy(
                     sobol_config,
                     worker,
                     orchestrator,
-                    self.knob_space,
                     previous_engine_config,
                     restore_due=restore_due,
                     next_eval_will_restore=next_eval_will_restore,
+                    seed=None,
                 )
                 previous_engine_config = dict(
                     configspace_to_knobs(sobol_config, self.knob_space)
@@ -685,11 +750,10 @@ class BOBaselineRunner:
                     restarted,
                     wall_time,
                     eval_timing,
-                ) = evaluate_config(
+                ) = self._evaluate_with_cotenancy(
                     trial_info.config,
                     worker,
                     orchestrator,
-                    self.knob_space,
                     previous_engine_config,
                     seed=trial_info.seed,
                     restore_due=restore_due,
@@ -1199,9 +1263,25 @@ class BOBaselineRunner:
                 "Database environment created: %s", type(self.env).__name__
             )
 
-            # Single worker bound to the single PostgreSQL instance
-            num_instances = 1
-            self.logger.info("Setting up 1 PostgreSQL instance...")
+            # Foreground BO trial always runs on worker 0. When co-tenancy is
+            # enabled (degree > 1, matched to the PBT session's parallel-worker
+            # count) we additionally bring up ``degree - 1`` background load
+            # instances (worker ids 1..degree-1) on their own disjoint cpusets,
+            # so each BO measurement window experiences the same single-host
+            # contention a PBT generation does. Worker 0 keeps its full
+            # per-worker slice either way (not devalued).
+            degree = max(1, int(getattr(self.config, "cotenancy_degree", 1)))
+            num_instances = degree
+            if degree > 1:
+                self.logger.info(
+                    "Setting up %d PostgreSQL instances (1 foreground BO + %d "
+                    "co-tenant load) under matched co-tenancy degree %d...",
+                    num_instances,
+                    degree - 1,
+                    degree,
+                )
+            else:
+                self.logger.info("Setting up 1 PostgreSQL instance...")
             with self.bootstrap_timing.span("setup_instances", num_workers=num_instances):
                 self.env.setup_instances(
                     num_workers=num_instances, num_parallel_workers=num_instances
@@ -1228,9 +1308,22 @@ class BOBaselineRunner:
             )
             self.logger.debug("Orchestrator configuration: %s", orchestrator_config)
 
-            # Single worker
+            # Single (foreground) worker
             worker = Worker(worker_id=0, knob_space=self.knob_space)
             worker.db_config = self.env.get_db_config(0)
+
+            # Co-tenant load controller: drives the background load instances
+            # in lockstep with worker 0's measurement window. A no-op when
+            # degree <= 1. Stored on self so the sequential-optimization loop
+            # and the finally-cleanup can reach it.
+            self.cotenant = CoTenantLoadController(
+                degree=degree,
+                env=self.env,
+                orchestrator=orchestrator,
+                knob_space=self.knob_space,
+                base_db_config=self.db_config,
+                seed=self.config.random_seed,
+            )
 
             # Build ConfigSpace
             self.logger.info("Building ConfigSpace...")
@@ -1500,6 +1593,9 @@ class BOBaselineRunner:
                 requested_iterations=self.config.n_iterations,
                 requested_pilot_size=requested_pilot_size,
                 actual_pilot_size=actual_pilot_size,
+                cotenancy=(
+                    self.cotenant.to_metadata() if self.cotenant is not None else None
+                ),
             )
 
             self.logger.info("BO tuning completed in %.2f seconds", total_time)
@@ -1509,6 +1605,12 @@ class BOBaselineRunner:
 
         finally:
             # Cleanup
+            _cotenant = getattr(self, "cotenant", None)
+            if _cotenant is not None:
+                try:
+                    _cotenant.shutdown()
+                except Exception as e:  # noqa: BLE001
+                    self.logger.warning("Error shutting down co-tenant pool: %s", e)
             if hasattr(self, "env"):
                 self.logger.info("Cleaning up environment...")
                 try:
@@ -1791,6 +1893,29 @@ def main():
         default=None,
         choices=["fixed_v1", "feature_driven_v2"],
         help="Scoring policy to use (default: feature_driven_v2 via per-workload config)",
+    )
+    parser.add_argument(
+        "--cotenancy-degree",
+        type=int,
+        default=None,
+        help=(
+            "Total concurrent instances (foreground BO trial + background load) "
+            "during each measurement window, so BO sees the same single-host "
+            "contention a PBT generation does. 1 disables background load. When "
+            "--pbt-session is given this is FORCED to that session's "
+            "num_parallel_workers (matched, mandatory) unless --no-cotenant is "
+            "set; this flag only applies for standalone BO runs without a session."
+        ),
+    )
+    parser.add_argument(
+        "--no-cotenant",
+        action="store_true",
+        default=False,
+        help=(
+            "Disable co-tenancy background load entirely, even when --pbt-session "
+            "is given. BO runs solo on the host (degree=1). Useful for ablation "
+            "studies or debugging."
+        ),
     )
     parser.add_argument(
         "--enable-snapshots",

--- a/src/utils/cpu_perf.py
+++ b/src/utils/cpu_perf.py
@@ -1,0 +1,311 @@
+"""
+CPU Performance State Control
+=============================
+
+Reproducible per-core throughput for fair benchmarking.
+
+When PBT runs N workers in parallel and the BO baseline runs (even under matched
+co-tenancy), per-core delivered performance must not silently vary with how many
+cores are active. The two confounds this module removes are:
+
+1. **CPU frequency scaling** — the ``ondemand``/``schedutil``/``powersave``
+   governors clock cores down when load is low, so a lightly-loaded instance
+   runs faster per-core than a heavily-loaded one for reasons unrelated to the
+   knob configuration. Pinning the ``performance`` governor holds clocks high.
+
+2. **Turbo / boost** — single-/few-core turbo lets an under-subscribed host hit
+   higher clocks than a saturated one. Disabling turbo makes the per-core clock
+   ceiling independent of how many cores are busy.
+
+The control is **save → set → restore**: :func:`read_cpu_perf_state` snapshots
+the host's current governor/turbo, :func:`set_performance_mode` applies the
+benchmarking state, and :func:`restore_cpu_perf_state` returns the host to
+*exactly* its original state. Restore is best-effort and never raises — a failed
+restore is logged loudly but must not mask the experiment's own outcome.
+
+Linux-only (sysfs). On non-Linux or when sysfs is unwritable (no root /
+unsupported), every function degrades gracefully: reads return ``supported=False``
+and set/restore become no-ops that log a warning.
+
+Sysfs paths
+-----------
+- Governor (per CPU): ``/sys/devices/system/cpu/cpu<N>/cpufreq/scaling_governor``
+- Intel turbo (inverted): ``/sys/devices/system/cpu/intel_pstate/no_turbo``
+  (``1`` == turbo disabled)
+- Generic/AMD boost: ``/sys/devices/system/cpu/cpufreq/boost``
+  (``1`` == boost enabled)
+- Current freq (per CPU): ``/sys/devices/system/cpu/cpu<N>/cpufreq/scaling_cur_freq``
+"""
+
+from __future__ import annotations
+
+import glob
+import os
+import platform
+import shlex
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+from src.utils.logger import get_logger
+
+LOGGER = get_logger("CPUPerf")
+
+_CPU_ROOT = Path("/sys/devices/system/cpu")
+_INTEL_NO_TURBO = _CPU_ROOT / "intel_pstate" / "no_turbo"
+_GENERIC_BOOST = _CPU_ROOT / "cpufreq" / "boost"
+
+_PERFORMANCE_GOVERNOR = "performance"
+
+
+@dataclass
+class CPUPerfState:
+    """Snapshot of host CPU performance state, sufficient to restore it.
+
+    Attributes
+    ----------
+    supported:
+        Whether this host exposes a controllable governor/turbo interface.
+        When ``False`` the other fields are best-effort/empty and set/restore
+        are no-ops.
+    governors:
+        Map of ``cpu<N>`` → governor string at snapshot time.
+    turbo_enabled:
+        Whether turbo/boost was enabled at snapshot time, or ``None`` if the
+        host exposes no turbo control.
+    turbo_mechanism:
+        ``"intel_pstate"`` | ``"boost"`` | ``None`` — which knob drives turbo.
+    cur_freqs_khz:
+        Current per-CPU frequency (kHz) at snapshot time, for the session
+        metadata record (not used by restore).
+    """
+
+    supported: bool
+    governors: Dict[str, str] = field(default_factory=dict)
+    turbo_enabled: Optional[bool] = None
+    turbo_mechanism: Optional[str] = None
+    cur_freqs_khz: List[int] = field(default_factory=list)
+
+    def to_metadata(self) -> Dict[str, object]:
+        """Serialise for the session-environment JSON record."""
+        unique_governors = sorted(set(self.governors.values()))
+        return {
+            "supported": self.supported,
+            "governors": unique_governors,
+            "governor_uniform": len(unique_governors) <= 1,
+            "turbo_enabled": self.turbo_enabled,
+            "turbo_mechanism": self.turbo_mechanism,
+            "cur_freq_khz_min": min(self.cur_freqs_khz) if self.cur_freqs_khz else None,
+            "cur_freq_khz_max": max(self.cur_freqs_khz) if self.cur_freqs_khz else None,
+        }
+
+
+def _governor_paths() -> List[Path]:
+    return [
+        Path(p)
+        for p in glob.glob(str(_CPU_ROOT / "cpu[0-9]*" / "cpufreq" / "scaling_governor"))
+    ]
+
+
+def _read_text(path: Path) -> Optional[str]:
+    try:
+        return path.read_text().strip()
+    except (OSError, ValueError):
+        return None
+
+
+def _write_text(path: Path, value: str) -> bool:
+    """Direct sysfs write (works when running as root). Returns True on success."""
+    try:
+        path.write_text(value)
+        return True
+    except (OSError, ValueError) as exc:
+        LOGGER.debug("sysfs write failed (%s ← %r): %s", path, value, exc)
+        return False
+
+
+def _cpu_id_from_governor_path(path: Path) -> str:
+    # .../cpu/cpu7/cpufreq/scaling_governor -> "cpu7"
+    return path.parent.parent.name
+
+
+def _direct_write_all(writes: Dict[str, str]) -> bool:
+    """Try to write all sysfs values directly. Returns True only if all succeed."""
+    for path_str, value in writes.items():
+        if not _write_text(Path(path_str), value):
+            return False
+    return True
+
+
+def _sudo_write_batch(writes: Dict[str, str]) -> bool:
+    """Write multiple sysfs values in a single ``sudo sh -c`` invocation.
+
+    Batching all writes into one ``sudo`` call means the user is prompted for
+    their password exactly once. Uses ``os.system`` so the child process gets
+    full terminal control for password entry — ``subprocess.run`` inherits
+    Python's stdio which can corrupt interactive password input.
+    """
+    if not writes:
+        return True
+    lines = []
+    for path_str, value in writes.items():
+        lines.append(
+            f"printf %s {shlex.quote(value)} > {shlex.quote(path_str)}"
+        )
+    script = " && ".join(lines)
+    ret = os.system(f"sudo sh -c {shlex.quote(script)}")
+    ok = (ret == 0)
+    if ok:
+        LOGGER.debug("sudo batch write succeeded for %d sysfs path(s)", len(writes))
+    else:
+        LOGGER.debug("sudo batch write failed (exit %d) for %d path(s)", ret, len(writes))
+    return ok
+
+
+def _collect_perf_writes(saved: CPUPerfState) -> Dict[str, str]:
+    """Build the sysfs write set for performance mode."""
+    writes: Dict[str, str] = {}
+    for cpu_id in saved.governors:
+        gov_path = str(_CPU_ROOT / cpu_id / "cpufreq" / "scaling_governor")
+        writes[gov_path] = _PERFORMANCE_GOVERNOR
+    if saved.turbo_mechanism == "intel_pstate":
+        writes[str(_INTEL_NO_TURBO)] = "1"
+    elif saved.turbo_mechanism == "boost":
+        writes[str(_GENERIC_BOOST)] = "0"
+    return writes
+
+
+def _collect_restore_writes(saved: CPUPerfState) -> Dict[str, str]:
+    """Build the sysfs write set that restores the snapshot."""
+    writes: Dict[str, str] = {}
+    for cpu_id, gov in saved.governors.items():
+        gov_path = str(_CPU_ROOT / cpu_id / "cpufreq" / "scaling_governor")
+        writes[gov_path] = gov
+    if saved.turbo_enabled is not None:
+        if saved.turbo_mechanism == "intel_pstate":
+            writes[str(_INTEL_NO_TURBO)] = "0" if saved.turbo_enabled else "1"
+        elif saved.turbo_mechanism == "boost":
+            writes[str(_GENERIC_BOOST)] = "1" if saved.turbo_enabled else "0"
+    return writes
+
+
+def _apply_writes(writes: Dict[str, str]) -> Tuple[bool, str]:
+    """Try direct writes first; fall back to a single sudo call.
+
+    Returns ``(success, method)`` where *method* is ``"direct"`` or ``"sudo"``.
+    """
+    if _direct_write_all(writes):
+        return True, "direct"
+    if _sudo_write_batch(writes):
+        return True, "sudo"
+    return False, "failed"
+
+
+def read_cpu_perf_state() -> CPUPerfState:
+    """Snapshot the current CPU governor, turbo, and per-core frequencies.
+
+    Never raises. On a host without the sysfs interface (non-Linux, container
+    without the cpufreq subsystem, etc.) returns ``CPUPerfState(supported=False)``.
+    """
+    if platform.system() != "Linux":
+        return CPUPerfState(supported=False)
+
+    gov_paths = _governor_paths()
+    if not gov_paths:
+        LOGGER.debug("No cpufreq scaling_governor entries; CPU perf control unavailable")
+        return CPUPerfState(supported=False)
+
+    governors: Dict[str, str] = {}
+    for p in gov_paths:
+        val = _read_text(p)
+        if val is not None:
+            governors[_cpu_id_from_governor_path(p)] = val
+
+    # Turbo: prefer Intel's no_turbo (inverted), fall back to generic boost.
+    turbo_enabled: Optional[bool] = None
+    turbo_mechanism: Optional[str] = None
+    no_turbo = _read_text(_INTEL_NO_TURBO)
+    if no_turbo is not None:
+        turbo_mechanism = "intel_pstate"
+        turbo_enabled = no_turbo.strip() == "0"
+    else:
+        boost = _read_text(_GENERIC_BOOST)
+        if boost is not None:
+            turbo_mechanism = "boost"
+            turbo_enabled = boost.strip() == "1"
+
+    cur_freqs: List[int] = []
+    for cur_path in glob.glob(
+        str(_CPU_ROOT / "cpu[0-9]*" / "cpufreq" / "scaling_cur_freq")
+    ):
+        val = _read_text(Path(cur_path))
+        if val and val.isdigit():
+            cur_freqs.append(int(val))
+
+    return CPUPerfState(
+        supported=bool(governors),
+        governors=governors,
+        turbo_enabled=turbo_enabled,
+        turbo_mechanism=turbo_mechanism,
+        cur_freqs_khz=cur_freqs,
+    )
+
+
+def set_performance_mode(saved: CPUPerfState) -> bool:
+    """Pin the ``performance`` governor on all CPUs and disable turbo.
+
+    Tries direct sysfs writes first (works as root). On failure, falls back to
+    a single ``sudo sh -c '...'`` that batches all writes — one password prompt
+    covers everything. Returns ``True`` only if every write succeeded.
+    """
+    if not saved.supported:
+        LOGGER.warning(
+            "CPU performance control unsupported on this host; skipping "
+            "governor/turbo pinning (per-core throughput may vary with load)."
+        )
+        return False
+
+    writes = _collect_perf_writes(saved)
+    ok, method = _apply_writes(writes)
+
+    gov_count = sum(1 for k in writes if k.endswith("scaling_governor"))
+    if ok:
+        LOGGER.info(
+            "Pinned '%s' governor on %d CPU(s)%s [via %s]",
+            _PERFORMANCE_GOVERNOR,
+            gov_count,
+            "; turbo disabled" if saved.turbo_mechanism else "",
+            method,
+        )
+    else:
+        LOGGER.warning(
+            "CPU performance pinning failed (need root or sudo to write "
+            "/sys/devices/system/cpu/*). Per-core throughput may vary with load."
+        )
+    return ok
+
+
+def restore_cpu_perf_state(saved: CPUPerfState) -> None:
+    """Restore the host to ``saved`` exactly. Best-effort; never raises.
+
+    Returns the governor of every CPU and the turbo state to what they were
+    when :func:`read_cpu_perf_state` was called. A failure to restore is logged
+    at WARNING (it leaves the host mutated) but never propagates, so it cannot
+    mask the experiment's own result or exit path.
+    """
+    if not saved.supported:
+        return
+
+    writes = _collect_restore_writes(saved)
+    ok, _method = _apply_writes(writes)
+
+    if not ok:
+        LOGGER.warning(
+            "CPU perf restore failed. Host may remain in 'performance' mode "
+            "— restore manually with: cpupower frequency-set -g <governor>.",
+        )
+    else:
+        LOGGER.info(
+            "Restored original CPU governor/turbo state on %d CPU(s).",
+            len(saved.governors),
+        )

--- a/src/utils/environments/docker.py
+++ b/src/utils/environments/docker.py
@@ -209,7 +209,17 @@ class DockerEnvironment(DatabaseEnvironment):
             },
             "ports": {"5432/tcp": self._worker_port(worker_id)},
             "mem_limit": self.ram_bytes if self.ram_bytes > 0 else None,
-            "nano_cpus": int(self.cpu_cores * 1e9) if self.cpu_cores > 0 else None,
+            # CPU quota and cpuset must agree on the per-worker budget. Both
+            # read ``_worker_cpu_budget()`` (which prefers the canonical
+            # ``worker_resources.cpu_cores`` and falls back to the legacy
+            # ``cpu_cores`` scalar) so a direct constructor call that leaves
+            # ``cpu_cores`` at its 0.0 default cannot silently drop the CPU
+            # quota while cpuset still pins cores.
+            "nano_cpus": (
+                int(self._worker_cpu_budget() * 1e9)
+                if self._worker_cpu_budget() > 0
+                else None
+            ),
             "cpuset_cpus": self._worker_cpuset_cpus(worker_id, num_workers),
             "network": self.network_name,
             "detach": True,

--- a/src/utils/hardware_info.py
+++ b/src/utils/hardware_info.py
@@ -445,7 +445,12 @@ def _probe_disk_with_fio(
         except OSError:
             pass
 
-    if not all((write_bw, read_bw, write_io, read_io)):
+    if (
+        write_bw is None
+        or read_bw is None
+        or write_io is None
+        or read_io is None
+    ):
         return None
 
     try:
@@ -918,6 +923,7 @@ def resolve_manual_worker_resources(
     worker_disk_read_iops: Optional[int] = None,
     worker_disk_write_iops: Optional[int] = None,
     probe_disk: bool = True,
+    threshold: float = 0.8,
 ) -> WorkerResources:
     """
     Resolve manual worker resources and validate against host limits.
@@ -930,6 +936,13 @@ def resolve_manual_worker_resources(
     Manual values that would push the total beyond 95% of the detected
     host ceiling are dropped in favour of auto-detected values, mirroring
     the RAM/CPU overflow behaviour.
+
+    ``threshold`` is the fraction of host capacity the auto-detection
+    *fallback* divides across workers (CPU, RAM, and disk alike). It mirrors
+    :func:`detect_worker_resources` so a caller asking for, e.g., 0.95 gets a
+    consistent fallback across all three dimensions instead of a disk budget
+    silently locked to 0.8. The 95% hard cap and 80% warning below are
+    separate guardrails on the *manual* request and are intentionally fixed.
     """
     if data_path is not None:
         disk_type = detect_disk_type_for_path(data_path)
@@ -945,8 +958,8 @@ def resolve_manual_worker_resources(
         total_cpus = psutil.cpu_count(logical=True) or 1
 
     # Fallback auto-detection values
-    usable_ram = int(total_ram * 0.8)
-    usable_cpu = total_cpus * 0.8
+    usable_ram = int(total_ram * threshold)
+    usable_cpu = total_cpus * threshold
     auto_ram = max(100 * 1024 * 1024, int(usable_ram / num_workers))
     auto_cpu = max(1, math.floor(usable_cpu / num_workers))
 
@@ -957,7 +970,7 @@ def resolve_manual_worker_resources(
     auto_disk = _partition_disk_budget(
         host_disk_budget,
         num_workers=num_workers,
-        threshold=0.8,
+        threshold=threshold,
     )
 
     resolved_ram = auto_ram
@@ -1290,6 +1303,18 @@ def get_system_info(data_path: Optional[Path] = None) -> Dict[str, Any]:
             "version": "",
             "machine": "",
         }
+
+    try:
+        # Record CPU governor / turbo / current-frequency span so a session's
+        # per-core throughput context is reproducible and auditable. Import
+        # locally to avoid a module-level cycle (cpu_perf imports the logger,
+        # which is fine, but keep hardware_info's import surface minimal).
+        from src.utils.cpu_perf import read_cpu_perf_state
+
+        info["cpu_perf"] = read_cpu_perf_state().to_metadata()
+    except (OSError, ValueError, TypeError, ImportError) as e:
+        LOGGER.warning("Failed to detect CPU performance state: %s", e)
+        info["cpu_perf"] = {"supported": False}
 
     return info
 

--- a/tests/unit/bo/test_cotenant.py
+++ b/tests/unit/bo/test_cotenant.py
@@ -1,0 +1,109 @@
+"""Unit tests for the BO co-tenant load controller.
+
+These validate the controller's wiring — degree gating, background worker
+construction, barrier party count, per-round apply semantics, and metadata —
+with the environment and orchestrator mocked so no containers are launched.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from src.config.database import DatabaseConfig
+from src.tuner.config import get_knob_space
+from src.tuner.core.barriers import GenerationBarrier
+from src.scripts.bo_baseline.cotenant import CoTenantLoadController
+
+
+def _make_controller(degree: int) -> CoTenantLoadController:
+    knob_space = get_knob_space("minimal")
+    env = MagicMock()
+    env.get_db_config.side_effect = lambda wid: DatabaseConfig(
+        host="127.0.0.1", port=5440 + wid, dbname="t", user="u", password="p"
+    )
+    orchestrator = MagicMock()
+    base_db = DatabaseConfig(
+        host="127.0.0.1", port=5440, dbname="t", user="u", password="p"
+    )
+    return CoTenantLoadController(
+        degree=degree,
+        env=env,
+        orchestrator=orchestrator,
+        knob_space=knob_space,
+        base_db_config=base_db,
+        seed=42,
+    )
+
+
+def test_disabled_when_degree_one():
+    ctrl = _make_controller(degree=1)
+    assert ctrl.enabled is False
+    assert ctrl.make_barrier() is None
+    # No background workers, start_round is a no-op returning no futures.
+    assert ctrl.start_round(None) == []
+    ctrl.shutdown()
+
+
+def test_enabled_builds_degree_minus_one_background_workers():
+    ctrl = _make_controller(degree=4)
+    assert ctrl.enabled is True
+    assert ctrl._bg_worker_ids == [1, 2, 3]
+    assert len(ctrl._bg_workers) == 3
+    # Each background worker is bound to its own port and carries a config.
+    ports = {w.db_config.port for w in ctrl._bg_workers}
+    assert ports == {5441, 5442, 5443}
+    for w in ctrl._bg_workers:
+        assert w.knob_config  # non-empty LHS config
+        assert w.force_restart_next_eval is True
+    ctrl.shutdown()
+
+
+def test_barrier_parties_is_degree():
+    ctrl = _make_controller(degree=8)
+    barrier = ctrl.make_barrier()
+    assert isinstance(barrier, GenerationBarrier)
+    # foreground (1) + background (degree-1) == degree parties
+    assert ctrl.barrier_parties == 8
+    ctrl.shutdown()
+
+
+def test_background_configs_are_deterministic_for_seed():
+    a = _make_controller(degree=4)
+    b = _make_controller(degree=4)
+    cfgs_a = [w.knob_config for w in a._bg_workers]
+    cfgs_b = [w.knob_config for w in b._bg_workers]
+    assert cfgs_a == cfgs_b  # same seed → identical load configs
+    a.shutdown()
+    b.shutdown()
+
+
+def test_start_round_always_applies_config():
+    ctrl = _make_controller(degree=3)
+    barrier = ctrl.make_barrier()
+
+    # First round.
+    futures1 = ctrl.start_round(barrier)
+    ctrl.finish_round(futures1)
+    # Second round.
+    futures2 = ctrl.start_round(ctrl.make_barrier())
+    ctrl.finish_round(futures2)
+
+    calls = ctrl.orchestrator.evaluate_worker.call_args_list
+    # 2 background workers × 2 rounds = 4 calls.
+    assert len(calls) == 4
+    apply_flags = [c.kwargs["apply_config"] for c in calls]
+    # apply_config=True on EVERY round — required so background loaders
+    # traverse the same B2/B5 barriers as the foreground (deadlock fix).
+    assert apply_flags == [True, True, True, True]
+    ctrl.shutdown()
+
+
+def test_metadata_records_degree_and_worker_ids():
+    ctrl = _make_controller(degree=4)
+    meta = ctrl.to_metadata()
+    assert meta["enabled"] is True
+    assert meta["degree"] == 4
+    assert meta["background_worker_ids"] == [1, 2, 3]
+    assert meta["foreground_worker_id"] == 0
+    assert meta["load_config_seed"] == 42
+    ctrl.shutdown()

--- a/tests/unit/evaluation/test_static_prior_in_eval_rescore.py
+++ b/tests/unit/evaluation/test_static_prior_in_eval_rescore.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
-import pytest
 
 PROJECT_ROOT = Path(__file__).resolve().parents[3]
 RUNNER_PATH = PROJECT_ROOT / "src" / "evaluation" / "runner.py"

--- a/tests/unit/tuner/test_knob_loader.py
+++ b/tests/unit/tuner/test_knob_loader.py
@@ -9,7 +9,6 @@ the tuner at LHS-sample time.
 
 from __future__ import annotations
 
-import io
 from pathlib import Path
 
 import pandas as pd

--- a/tests/unit/tuners/test_base.py
+++ b/tests/unit/tuners/test_base.py
@@ -1,6 +1,5 @@
 """Tests for the BaseTuner lifecycle ABC using a fake in-memory strategy."""
 
-from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 import pytest

--- a/tests/unit/utils/test_cpu_perf.py
+++ b/tests/unit/utils/test_cpu_perf.py
@@ -1,0 +1,139 @@
+"""Unit tests for src.utils.cpu_perf — governor/turbo save→set→restore.
+
+These exercise the pure control logic with sysfs reads/writes faked, so they
+run on any host (including CI without cpufreq sysfs). The contract under test:
+
+- ``read_cpu_perf_state`` snapshots governors + turbo.
+- ``set_performance_mode`` writes ``performance`` to every governor and disables
+  turbo via the detected mechanism.
+- ``restore_cpu_perf_state`` returns every governor + turbo to the snapshot and
+  never raises.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import src.utils.cpu_perf as cpu_perf
+from src.utils.cpu_perf import (
+    CPUPerfState,
+    read_cpu_perf_state,
+    restore_cpu_perf_state,
+    set_performance_mode,
+)
+
+
+class _FakeSysfs:
+    """In-memory stand-in for the cpufreq sysfs tree."""
+
+    def __init__(self, cpus, governor="ondemand", no_turbo="0"):
+        # Map of governor path -> value
+        self.values: dict[str, str] = {}
+        self.cpus = cpus
+        for n in cpus:
+            self.values[
+                f"/sys/devices/system/cpu/cpu{n}/cpufreq/scaling_governor"
+            ] = governor
+            self.values[
+                f"/sys/devices/system/cpu/cpu{n}/cpufreq/scaling_cur_freq"
+            ] = "2400000"
+        self.values["/sys/devices/system/cpu/intel_pstate/no_turbo"] = no_turbo
+        self.write_failures: set[str] = set()
+
+    def governor_paths(self):
+        return [
+            Path(p)
+            for p in self.values
+            if p.endswith("scaling_governor")
+        ]
+
+    def read(self, path: Path):
+        return self.values.get(str(path))
+
+    def write(self, path: Path, value: str) -> bool:
+        key = str(path)
+        if key in self.write_failures:
+            return False
+        self.values[key] = value
+        return True
+
+
+@pytest.fixture
+def fake_sysfs(monkeypatch):
+    fs = _FakeSysfs(cpus=range(4), governor="ondemand", no_turbo="0")
+    monkeypatch.setattr(cpu_perf.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(cpu_perf, "_governor_paths", fs.governor_paths)
+    monkeypatch.setattr(cpu_perf, "_read_text", fs.read)
+    monkeypatch.setattr(cpu_perf, "_write_text", fs.write)
+    # Fake _direct_write_all to use our in-memory store.
+    def _fake_direct_write_all(writes):
+        for path_str, value in writes.items():
+            if not fs.write(Path(path_str), value):
+                return False
+        return True
+    monkeypatch.setattr(cpu_perf, "_direct_write_all", _fake_direct_write_all)
+    # sudo path should never be reached in tests.
+    monkeypatch.setattr(cpu_perf, "_sudo_write_batch", lambda writes: False)
+    # Point the turbo path constant at our fake key so reads/writes resolve.
+    monkeypatch.setattr(
+        cpu_perf, "_INTEL_NO_TURBO", Path("/sys/devices/system/cpu/intel_pstate/no_turbo")
+    )
+    return fs
+
+
+def test_read_state_snapshots_governors_and_turbo(fake_sysfs):
+    state = read_cpu_perf_state()
+    assert state.supported is True
+    assert set(state.governors.values()) == {"ondemand"}
+    assert state.turbo_mechanism == "intel_pstate"
+    assert state.turbo_enabled is True  # no_turbo == "0"
+    assert len(state.cur_freqs_khz) == 4
+
+
+def test_set_performance_mode_pins_governor_and_disables_turbo(fake_sysfs):
+    saved = read_cpu_perf_state()
+    ok = set_performance_mode(saved)
+    assert ok is True
+    govs = {
+        v for k, v in fake_sysfs.values.items() if k.endswith("scaling_governor")
+    }
+    assert govs == {"performance"}
+    # no_turbo flipped to "1" (turbo disabled).
+    assert fake_sysfs.values["/sys/devices/system/cpu/intel_pstate/no_turbo"] == "1"
+
+
+def test_restore_returns_exact_original_state(fake_sysfs):
+    saved = read_cpu_perf_state()
+    set_performance_mode(saved)
+    restore_cpu_perf_state(saved)
+    govs = {
+        v for k, v in fake_sysfs.values.items() if k.endswith("scaling_governor")
+    }
+    assert govs == {"ondemand"}  # restored
+    assert fake_sysfs.values["/sys/devices/system/cpu/intel_pstate/no_turbo"] == "0"
+
+
+def test_restore_is_noop_and_silent_when_unsupported():
+    # No fake_sysfs fixture → real read on a (possibly) non-Linux/no-sysfs host
+    # is not used; construct an explicitly-unsupported state.
+    state = CPUPerfState(supported=False)
+    # Must not raise.
+    restore_cpu_perf_state(state)
+    assert set_performance_mode(state) is False
+
+
+def test_set_partial_failure_reports_false_but_still_restorable(fake_sysfs):
+    saved = read_cpu_perf_state()
+    # Simulate one CPU's governor write failing (e.g. permission).
+    fake_sysfs.write_failures.add(
+        "/sys/devices/system/cpu/cpu2/cpufreq/scaling_governor"
+    )
+    # Direct writes fail (one path blocked), sudo batch also fails (mocked False).
+    ok = set_performance_mode(saved)
+    assert ok is False
+    # Restore still drives every CPU back (remove the failure for restore);
+    # the call does not raise.
+    fake_sysfs.write_failures.clear()
+    restore_cpu_perf_state(saved)

--- a/tests/unit/utils/test_disk_probe_trust_floor.py
+++ b/tests/unit/utils/test_disk_probe_trust_floor.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-import pytest
 
 from src.utils.hardware_info import (
     _DISK_CLASS_BUDGETS,

--- a/tests/unit/utils/test_docker_environment.py
+++ b/tests/unit/utils/test_docker_environment.py
@@ -85,6 +85,41 @@ def test_worker_cpu_budget_prefers_worker_resources() -> None:
     assert env._worker_cpu_budget() == 2
 
 
+def test_nano_cpus_follows_worker_budget_not_legacy_scalar() -> None:
+    """nano_cpus (CPU quota) must agree with the cpuset budget.
+
+    Regression: nano_cpus previously read the legacy ``cpu_cores`` scalar
+    while cpuset read ``worker_resources.cpu_cores``. When a caller leaves
+    ``cpu_cores`` at its 0.0 default but supplies ``worker_resources``, the
+    quota would silently drop to None while cpuset still pinned cores. Both
+    must now derive from ``_worker_cpu_budget()``.
+    """
+    env = _make_environment()
+    env.worker_resources = WorkerResources(
+        ram_bytes=512 * 1024 * 1024,
+        cpu_cores=4,
+        disk_type="SSD",
+    )
+    env.cpu_cores = 0.0  # legacy scalar left unset
+
+    kwargs = env._container_runtime_kwargs(worker_id=0, num_workers=1)
+
+    assert kwargs["nano_cpus"] == 4 * 1_000_000_000
+    # cpuset and quota agree on the same 4-core budget.
+    assert kwargs["cpuset_cpus"] is not None
+
+
+def test_nano_cpus_none_when_no_budget_available() -> None:
+    """No CPU budget (no worker_resources, zero legacy scalar) → unlimited."""
+    env = _make_environment()
+    env.worker_resources = None
+    env.cpu_cores = 0.0
+
+    kwargs = env._container_runtime_kwargs(worker_id=0, num_workers=1)
+
+    assert kwargs["nano_cpus"] is None
+
+
 from unittest.mock import MagicMock, patch
 
 

--- a/tests/unit/utils/test_hardware_info.py
+++ b/tests/unit/utils/test_hardware_info.py
@@ -217,6 +217,80 @@ def test_resolve_manual_worker_resources_valid(
 @patch("src.utils.hardware_info.psutil.virtual_memory")
 @patch("src.utils.hardware_info.psutil.cpu_count")
 @patch("src.utils.hardware_info.psutil.Process")
+def test_resolve_manual_worker_resources_threshold_threads_to_auto_fallback(
+    mock_process,
+    mock_cpu_count,
+    mock_virtual_memory,
+    _mock_disk_type,
+):
+    """The ``threshold`` arg must drive the CPU/RAM auto-fallback budget.
+
+    Regression for Bug 4: ``resolve_manual_worker_resources`` previously
+    hardcoded 0.8 for the auto-detect fallback (and for disk), ignoring the
+    caller's intended fraction. With no manual RAM/CPU supplied, the function
+    takes the auto path, so a higher threshold must yield a larger per-worker
+    budget.
+    """
+
+    class MockMem:
+        total = 16 * 1024**3
+
+    mock_virtual_memory.return_value = MockMem()
+
+    class MockProcess:
+        def cpu_affinity(self):
+            return list(range(8))
+
+    mock_process.return_value = MockProcess()
+    mock_cpu_count.return_value = 8
+
+    # No manual ram/cpus -> auto fallback. 8 cores, 4 workers.
+    # threshold=0.8 -> floor(8*0.8/4) = floor(1.6) = 1 core
+    wr_080 = resolve_manual_worker_resources(num_workers=4, threshold=0.8)
+    # threshold=0.95 -> floor(8*0.95/4) = floor(1.9) = 1 core (cpu unchanged here),
+    # but RAM scales: int(16G*0.95/4) > int(16G*0.8/4)
+    wr_095 = resolve_manual_worker_resources(num_workers=4, threshold=0.95)
+
+    assert wr_095.ram_bytes > wr_080.ram_bytes
+    # RAM fallback must equal threshold * total / num_workers exactly.
+    assert wr_080.ram_bytes == int(16 * 1024**3 * 0.8) // 4
+    assert wr_095.ram_bytes == int(16 * 1024**3 * 0.95) // 4
+
+
+@patch("src.utils.hardware_info.detect_disk_type", return_value="SSD")
+@patch("src.utils.hardware_info.psutil.virtual_memory")
+@patch("src.utils.hardware_info.psutil.cpu_count")
+@patch("src.utils.hardware_info.psutil.Process")
+def test_resolve_manual_worker_resources_threshold_defaults_to_080(
+    mock_process,
+    mock_cpu_count,
+    mock_virtual_memory,
+    _mock_disk_type,
+):
+    """Omitting ``threshold`` preserves the historical 0.8 behaviour."""
+
+    class MockMem:
+        total = 16 * 1024**3
+
+    mock_virtual_memory.return_value = MockMem()
+
+    class MockProcess:
+        def cpu_affinity(self):
+            return list(range(8))
+
+    mock_process.return_value = MockProcess()
+    mock_cpu_count.return_value = 8
+
+    wr_default = resolve_manual_worker_resources(num_workers=4)
+    wr_080 = resolve_manual_worker_resources(num_workers=4, threshold=0.8)
+    assert wr_default.ram_bytes == wr_080.ram_bytes
+    assert wr_default.cpu_cores == wr_080.cpu_cores
+
+
+@patch("src.utils.hardware_info.detect_disk_type", return_value="SSD")
+@patch("src.utils.hardware_info.psutil.virtual_memory")
+@patch("src.utils.hardware_info.psutil.cpu_count")
+@patch("src.utils.hardware_info.psutil.Process")
 def test_resolve_manual_worker_resources_exceeds_ram(
     mock_process,
     mock_cpu_count,


### PR DESCRIPTION
## Summary

BO's sequential optimizer ran on an otherwise-idle host, enjoying uncontended turbo, memory bandwidth, LLC, and disk-queue depth that N concurrent PBT workers do not — making BO look artificially strong during tuning (>2× on TPC-H). This PR removes that confound with three workstreams:

- Co-tenant load controller (CoTenantLoadController): N−1 background load instances run the same benchmark on disjoint cpusets during each BO trial's measurement window, reproducing PBT's contention via the existing GenerationBarrier B1–B17 lockstep. Fixed LHS-sampled configs, deterministic seed, --no-cotenant CLI flag for ablation. Degree is mandatory-matched from the PBT session's num_parallel_workers.
- CPU frequency pinning (cpu_perf.py): save→set→restore of per-core governor (pinned to performance) and turbo (disabled via intel_pstate/boost). Batch sudo via os.system("sudo sh -c '...'") for single-prompt password entry. Signal handlers + atexit guarantee host state is always restored. Recorded in every session JSON under system_info.cpu_perf.
- Four latent resource-allocation bug fixes: nano_cpus/cpuset source mismatch, hardcoded max_parallel_workers=8, silently-ignored BO CLI flags, and disk threshold not threaded to resolve_manual_worker_resources.

## Test plan
 
- ruff check passes on all changed files
- 77 unit tests pass (tests/unit/bo/, tests/unit/utils/test_cpu_perf.py, test_hardware_info.py, test_docker_environment.py)
- Sysbench-RW smoke (--smoke --no-push): PBT→BO→EVAL pipeline completes end-to-end with co-tenancy degree=2 and CPU perf pinning recorded in session JSONs
- Resource parity verified: all 8 per-worker resource fields identical between PBT and BO sessions (cpuset, ram, disk bps/iops, docker memory limit)
- CPU perf parity verified: both sessions record governors: ["performance"], turbo_enabled: false, turbo_mechanism: "intel_pstate"
- Full-tier TPC-H run to confirm BO tuning scores collapse toward PBT range (headline effect)