### PR TITLE
feat(distributed): add multi-device tuning mode (one worker per device)

### DIFF
--- a/configs/distributed/devices.example.yaml
+++ b/configs/distributed/devices.example.yaml
@@ -1,0 +1,30 @@
+# Example device fleet inventory for DISTRIBUTED tuning mode.
+#
+# In distributed mode each population worker runs on its own dedicated device
+# (one PostgreSQL instance per device) so measurements are free of co-tenant
+# contention — fairness is structural. Devices are bound to workers by list
+# order: the first device is worker 0, the second is worker 1, and so on.
+#
+# The fleet must have at least as many devices as --population.
+# For a fair comparison the devices should be IDENTICAL hardware.
+#
+# Usage (once the distributed CLI lands in Phase 5):
+#   python -m src.tuner.main --distributed --inventory configs/distributed/devices.example.yaml \
+#       --tier core --config standard --population 4
+
+# Fleet-wide defaults. Any device entry may override any of these.
+fleet:
+  agent_port: 8770          # HTTP port each device agent listens on
+  ssh_user: pbt             # SSH user used by the Phase 3 bootstrap
+  ssh_key: ~/.ssh/id_rsa    # SSH private key (path is ~ / $VAR expanded)
+  data_dir: /var/lib/pbt    # remote base dir for the PG instance's data
+  python: python3           # remote interpreter used to launch the agent
+
+devices:
+  - host: 10.0.0.11         # -> worker 0
+  - host: 10.0.0.12         # -> worker 1
+    agent_port: 8771        # per-device override
+  - host: 10.0.0.13         # -> worker 2
+    ssh_user: ubuntu
+  - host: 10.0.0.14         # -> worker 3
+    label: rack-a-node-4    # optional friendly name for logs/reports

--- a/docs/architecture/distributed-tuning.md
+++ b/docs/architecture/distributed-tuning.md
@@ -1,0 +1,170 @@
+# Distributed Multi-Device Tuning
+
+> Status: coordinator, device agent, remote environment, SSH bootstrap, and CLI
+> wiring implemented (Phases 0–5). Runs against a real fleet require identical
+> devices reachable over a trusted network with SSH-key access.
+
+## Why this mode exists — fairness
+
+In the default **`local`** mode every population worker runs as a co-tenant
+PostgreSQL instance on one machine. The [B1–B17 lockstep barriers](generation-barriers.md)
+exist specifically to make noisy-neighbour contention *identical* across
+workers — fairness by cancellation.
+
+**`distributed`** mode assigns **one worker per dedicated, identical device**.
+With no co-tenancy there is no contention to cancel, so fairness becomes
+**structural**:
+
+1. **No co-tenancy** — one worker per device.
+2. **Identical hardware** — a config's score reflects the config, not the host.
+3. **Byte-identical start state** — each device holds its own base snapshot and
+   resets to it before every evaluation.
+4. **Local benchmark client** — the benchmark runs on the device next to its DB,
+   so no network latency ever enters the measurement window.
+
+The existing `local` code paths are never modified; distributed mode is entirely
+additive and selected with `--distributed`.
+
+## Topology
+
+```
+┌─────────────────────────────────────────────┐
+│  COORDINATOR (control plane, 1 process)       │
+│  Population loop · evolution (exploit/explore) │
+│  central CompositeScorer · generation barrier  │
+│  RemoteEnvironment ── HTTP/JSON RPC ──┐        │
+└───────────────────────────────────────┼───────┘
+         ┌───────────────┬───────────────┼───────────────┐
+         ▼               ▼               ▼               ▼
+    ┌─────────┐     ┌─────────┐     ┌─────────┐     ┌─────────┐
+    │ Device 0│     │ Device 1│     │ Device 2│ …   │ Device N│
+    │ agent   │     │ agent   │     │ agent   │     │ agent   │
+    │ +1 PG   │     │ +1 PG   │     │ +1 PG   │     │ +1 PG   │
+    │ +bench  │     │ +bench  │     │ +bench  │     │ +bench  │
+    └─────────┘     └─────────┘     └─────────┘     └─────────┘
+```
+
+- **Coordinator** runs the *unchanged* PBT algorithm. It only swaps two
+  components: `env` → `RemoteEnvironment` and `orchestrator` →
+  `RemoteWorkloadOrchestrator`. `Population`, `evolution`, and the scorer are
+  untouched.
+- **Device agent** (`src/tuners/distributed/device_agent.py`) is a long-running
+  HTTP/JSON server that owns one local PostgreSQL instance and runs today's real
+  `WorkloadOrchestrator` pipeline locally, returning **raw metrics**.
+- **Scoring is central.** Devices return `PerformanceMetrics`; the coordinator
+  scores with `engine.compute_breakdown`, so adaptive normalisation spans the
+  whole population exactly as in local mode.
+
+Because there is no co-tenancy, distributed runs set
+`synchronize_workers=False`: the B1–B17 substep barriers run *locally* on each
+device, and the coordinator's only synchronisation point is the generation
+boundary (the `ThreadPoolExecutor` join in `Population.evaluate_generation`).
+
+## Wire protocol
+
+JSON over HTTP (stdlib only — no web framework), defined in
+`src/tuners/distributed/agent_api.py`:
+
+| Route | Purpose |
+|---|---|
+| `GET /health` | Liveness + protocol/version + hardware handshake |
+| `POST /setup` | Stand up the device's single local PG instance |
+| `POST /snapshot` | Create the device's local base snapshot |
+| `POST /reset` | Restore data to the local base snapshot (exploit target) |
+| `POST /run_eval` | Run one apply→run→measure locally; return raw metrics |
+| `POST /cleanup` | Tear down the instance |
+| `POST /shutdown` | Stop the agent |
+
+## Config-only exploit clone
+
+PBT *exploit* copies an elite worker onto poor workers. Across devices this is
+**config-only**: the elite's knobs are copied in coordinator RAM by the
+evolution step (tiny), and `RemoteEnvironment.clone_instances` merely tells each
+target device to `/reset` its data to the byte-identical local baseline. **No
+gigabyte-scale PGDATA is transferred over the network.**
+
+## Fleet inventory
+
+Devices are described by a `devices.yaml` (see
+`configs/distributed/devices.example.yaml`). Devices are bound to workers by
+list order (device 0 → worker 0). The fleet must have at least `--population`
+devices.
+
+```yaml
+fleet:
+  agent_port: 8770
+  ssh_user: pbt
+  ssh_key: ~/.ssh/id_rsa
+  data_dir: /var/lib/pbt
+  python: python3
+devices:
+  - host: 10.0.0.11
+  - host: 10.0.0.12
+  - host: 10.0.0.13
+  - host: 10.0.0.14
+```
+
+## Bootstrap (SSH)
+
+`src/tuners/distributed/bootstrap.py` provisions each device: `rsync` the repo,
+optionally `pip install -r requirements.txt`, then launch the agent detached
+(`nohup`, recording a pidfile + logfile). Teardown stops each agent via its
+pidfile. Command construction is pure/unit-tested; execution is a thin
+`subprocess` wrapper.
+
+## Usage
+
+```bash
+# Distributed run (tool bootstraps the fleet, then tunes)
+python -m src.tuners.pbt --distributed \
+    --inventory configs/distributed/devices.example.yaml \
+    --benchmark sysbench --tier core --config standard --population 4
+
+# Agents already running (skip SSH bootstrap)
+python -m src.tuners.pbt --distributed --inventory devices.yaml --no-bootstrap ...
+
+# Run a device agent by hand (for debugging on one box)
+python -m src.tuners.distributed.device_agent --worker-id 0 --port 8770 \
+    --knob-tier core --base-dir ./.instances
+```
+
+Relevant flags: `--distributed`, `--inventory`, `--no-bootstrap`,
+`--no-remote-deps`, `--eval-timeout`, `--agent-timeout`.
+
+## Fault handling
+
+A `run_eval` RPC timeout or transport error is treated as a dead worker: the
+worker gets a failure metric and is handed to the standard population rescue
+path (resample / config-clone). Recovery re-runs `/setup` on the device.
+
+## Assumptions & current limitations
+
+- **Identical hardware fleet.** Heterogeneous fleets are out of scope. Note the
+  coordinator itself can be any light machine: agents report their detected
+  `WorkerResources` from `/setup` and the coordinator resolves hardware-aware
+  knob ranges against **device** hardware (see `_resolve_device_hardware_ranges`
+  in `src/tuners/pbt/tuner.py`), not its own. `--worker-ram`/`--worker-cpus` remain a manual
+  override if no device reports resources.
+- **Version-based knob pruning is skipped** in distributed mode (the coordinator
+  has no direct TCP path to remote instances); it relies on the identical-fleet
+  assumption that every device runs the same PostgreSQL.
+- **Synchronized measurement windows** are approximated by an agent-side
+  "don't start before epoch" gate; a full two-phase prepare→go protocol (to
+  align the *measurement* sub-window rather than the eval start) is future work.
+- **`LocalDeviceBackend`** wires `sysbench` and `tpch`; custom-workload wiring
+  is a marked `NotImplementedError`.
+- Trusted network + SSH-key access; secrets pass via SSH, never the repo.
+
+## Code map
+
+| File | Role |
+|---|---|
+| `src/tuners/distributed/inventory.py` | Parse/validate `devices.yaml` |
+| `src/tuners/distributed/config.py` | `ExecutionMode`, `DistributedConfig` |
+| `src/tuners/distributed/agent_api.py` | Wire schemas |
+| `src/tuners/distributed/transport.py` | Stdlib HTTP client + server helpers |
+| `src/tuners/distributed/device_agent.py` | Device HTTP server + `LocalDeviceBackend` |
+| `src/tuners/distributed/remote_environment.py` | `DatabaseEnvironment` RPC proxy |
+| `src/tuners/distributed/remote_orchestrator.py` | RPC eval + central scoring |
+| `src/tuners/distributed/coordinator.py` | Client mgmt, health handshake, factories |
+| `src/tuners/distributed/bootstrap.py` | SSH provisioning + agent launch/teardown |

--- a/docs/guides/distributed-tuning.md
+++ b/docs/guides/distributed-tuning.md
@@ -1,0 +1,378 @@
+# Distributed Multi-Device Tuning — Complete Guide
+
+A practical, end-to-end reference for the **distributed** execution mode: what
+was built, how the pieces fit, how to run it against a device fleet, and how to
+test it. For the design rationale and diagrams see the architecture reference,
+[distributed-tuning.md](../architecture/distributed-tuning.md).
+
+---
+
+## 1. What this feature does
+
+By default (`local` mode) every population worker runs as a **co-tenant**
+PostgreSQL instance on one machine. Distributed mode instead places **one worker
+on its own dedicated device**, so measurements are free of noisy-neighbour
+contention. Fairness becomes *structural* rather than something the algorithm
+has to correct for.
+
+**Goal (per requirements): 100% fair tuning.** Four properties deliver it:
+
+1. **No co-tenancy** — one worker per device.
+2. **Identical hardware** — a config's score reflects the config, not the host.
+3. **Byte-identical start state** — each device holds its own base snapshot and
+   resets to it before every evaluation.
+4. **Local benchmark client** — the benchmark runs on the device next to its DB,
+   so no network latency enters the measurement window.
+
+The existing `local` code paths are **never modified**; distributed mode is
+entirely additive and selected with `--distributed`.
+
+---
+
+## 2. Architecture at a glance
+
+```
+┌─────────────────────────────────────────────┐
+│  COORDINATOR (control plane, one process)     │
+│  Population loop · evolution · central scorer  │
+│  RemoteEnvironment  ── HTTP/JSON RPC ──┐       │
+│  RemoteWorkloadOrchestrator ───────────┤       │
+└─────────────────────────────────────────┼──────┘
+        ┌────────────┬────────────┬────────┼────────────┐
+        ▼            ▼            ▼         ▼            ▼
+   ┌─────────┐  ┌─────────┐  ┌─────────┐        ┌─────────┐
+   │ Device 0│  │ Device 1│  │ Device 2│  …     │ Device N│
+   │ agent   │  │ agent   │  │ agent   │        │ agent   │
+   │ +1 PG   │  │ +1 PG   │  │ +1 PG   │        │ +1 PG   │
+   │ +bench  │  │ +bench  │  │ +bench  │        │ +bench  │
+   └─────────┘  └─────────┘  └─────────┘        └─────────┘
+```
+
+- The **coordinator** runs the *unchanged* PBT algorithm. It only swaps two
+  objects: `env` → `RemoteEnvironment`, `orchestrator` →
+  `RemoteWorkloadOrchestrator`. `Population`, `evolution`, and the `CompositeScorer`
+  are untouched.
+- Each **device agent** is a long-running HTTP/JSON server that owns one local
+  PostgreSQL instance and runs today's real `WorkloadOrchestrator` pipeline
+  locally, returning **raw metrics**.
+- **Scoring is central**: devices return `PerformanceMetrics`; the coordinator
+  computes the score with the same `engine.compute_breakdown` call local mode
+  uses, so adaptive normalisation spans the whole population identically.
+- Distributed runs set `synchronize_workers=False`: the B1–B17 substep barriers
+  run *locally* on each device; the coordinator's only sync point is the
+  generation boundary.
+
+---
+
+## 3. Code inventory — what we changed and added
+
+### 3.1 New package: `src/tuners/distributed/`
+
+| File | Responsibility |
+|---|---|
+| `__init__.py` | Package docstring, re-exports, `AGENT_PROTOCOL_VERSION` |
+| `inventory.py` | Parse/validate `devices.yaml`; `DeviceSpec`, `FleetInventory`, `load_inventory`, `parse_inventory`; binds devices→workers by list order |
+| `config.py` | `ExecutionMode` (LOCAL/DISTRIBUTED) enum + `DistributedConfig` (timeouts, inventory) |
+| `agent_api.py` | JSON wire schemas: `SetupRequest/Response`, `RunEvalRequest/Response`, `HealthResponse`, `ResetRequest`, `SnapshotResponse`, `CleanupRequest`, `AckResponse`, `ErrorResponse`, `ROUTES` |
+| `transport.py` | Stdlib HTTP client `AgentClient` + server helpers `read_json_body`/`write_json`; `AgentRPCError` |
+| `device_agent.py` | Device HTTP server (`DeviceAgent`), request handler, `EvaluationBackend` seam, real `LocalDeviceBackend`, `python -m` CLI |
+| `remote_environment.py` | `RemoteEnvironment(DatabaseEnvironment)` — proxies lifecycle to agents; **config-only clone**; fan-out snapshot |
+| `remote_orchestrator.py` | `RemoteWorkloadOrchestrator(WorkloadOrchestrator)` — RPC eval + **central scoring**; `metrics_from_dict` |
+| `coordinator.py` | `Coordinator` — builds clients from inventory, health handshake + protocol check, factories for env/orchestrator, fleet shutdown |
+| `bootstrap.py` | `FleetBootstrapper` + pure command builders (`rsync_command`, `ssh_command`, `launch_agent_command`, `install_deps_command`, `stop_agent_command`, `RemoteLayout`) |
+
+### 3.2 Edits to existing files (additive, backward-compatible)
+
+| File | Change |
+|---|---|
+| `src/utils/environments/base.py` | Added defaulted `host: str = "127.0.0.1"` to `InstanceConfig` |
+| `src/tuners/pbt/population.py` | Worker binding reads `getattr(instance, "host", "127.0.0.1")` instead of a hardcoded literal — local mode still resolves to loopback |
+| `src/tuners/pbt/tuner.py` | New `--distributed`/`--inventory`/… args; `_build_distributed_stack()` + `_start_distributed_fleet()`; distributed branch in `__init__`; bootstrap/health in `run()`; fleet shutdown in cleanup. All new `run()` references are `getattr`-guarded so partial-construction tests still pass |
+
+### 3.3 Supporting files
+
+| Path | Purpose |
+|---|---|
+| `configs/distributed/devices.example.yaml` | Example fleet inventory |
+| `docs/architecture/distributed-tuning.md` | Design reference |
+| `docs/guides/distributed-tuning.md` | This guide |
+| `tests/unit/tuners/distributed/` | Test suite (see §7) |
+
+---
+
+## 4. The wire protocol
+
+JSON over HTTP (stdlib only — no web framework), rooted at each agent's
+`http://<host>:<agent_port>`:
+
+| Method & Route | Request → Response | Purpose |
+|---|---|---|
+| `GET /health` | — → `HealthResponse` | Liveness + protocol version + hardware handshake |
+| `POST /setup` | `SetupRequest` → `SetupResponse` | Stand up the device's single local PG instance |
+| `POST /snapshot` | — → `SnapshotResponse` | Create the device's local base snapshot |
+| `POST /reset` | `ResetRequest` → `AckResponse` | Restore data to the local base snapshot (exploit target) |
+| `POST /run_eval` | `RunEvalRequest` → `RunEvalResponse` | Run one apply→run→measure locally; return raw metrics |
+| `POST /cleanup` | `CleanupRequest` → `AckResponse` | Tear down the instance |
+| `POST /shutdown` | — → `AckResponse` | Stop the agent |
+
+On any error the agent returns a non-2xx status with an `ErrorResponse` body.
+An RPC timeout or transport error is treated by the coordinator as a **dead
+worker** — it gets a failure metric and is handed to the standard population
+rescue path (resample / config-clone).
+
+### Config-only exploit clone
+
+PBT *exploit* copies an elite worker onto poor ones. Across devices this is
+**config-only**: the elite's knobs are copied in coordinator RAM by the
+evolution step (tiny), and `RemoteEnvironment.clone_instances` merely tells each
+target device to `/reset` its data to the byte-identical local baseline. **No
+gigabyte-scale PGDATA moves over the network.**
+
+---
+
+## 5. Prerequisites
+
+**Coordinator machine**
+- The repo + Python env (this project's `requirements.txt`).
+- Network reachability to each device's `agent_port`.
+- For bootstrap: `ssh` and `rsync` on PATH, plus SSH-key access to the devices.
+
+**Each device (identical hardware recommended)**
+- A Python 3.11 interpreter able to import this project.
+- Docker (default backend) or a local PostgreSQL for `--no-docker`.
+- For sysbench/TPC-H: the benchmark tooling the local mode already needs.
+- `DB_PASSWORD` available to the agent process (the bootstrap exports it; the
+  agent reads `os.getenv("DB_PASSWORD", "")`).
+
+> **Note on dependencies.** `src/__init__.py` eagerly imports the analysis chain,
+> so the agent process needs the full environment (including `shap`) present on
+> each device — the bootstrap's `pip install -r requirements.txt` handles this
+> unless you pass `--no-remote-deps`.
+
+---
+
+## 6. How to run
+
+### 6.1 Fleet inventory (`devices.yaml`)
+
+Devices bind to workers by **list order** (device 0 → worker 0). The fleet must
+have at least `--population` devices. See
+`configs/distributed/devices.example.yaml`.
+
+```yaml
+# Fleet-wide defaults (each device may override any of these)
+fleet:
+  agent_port: 8770          # HTTP port each device agent listens on
+  ssh_user: pbt             # SSH user for bootstrap
+  ssh_key: ~/.ssh/id_rsa    # SSH private key (~ and $VARS expanded)
+  data_dir: /var/lib/pbt    # remote base dir for the instance's data
+  python: python3           # remote interpreter used to launch the agent
+
+devices:
+  - host: 10.0.0.11         # -> worker 0
+  - host: 10.0.0.12         # -> worker 1
+    agent_port: 8771        # per-device override
+  - host: 10.0.0.13         # -> worker 2
+    ssh_user: ubuntu
+  - host: 10.0.0.14         # -> worker 3
+    label: rack-a-node-4    # optional friendly name for logs
+```
+
+### 6.2 Full run (tool bootstraps the fleet, then tunes)
+
+```bash
+python -m src.tuners.pbt --distributed \
+    --inventory configs/distributed/devices.example.yaml \
+    --benchmark sysbench --tier core --config standard --population 4
+```
+
+What happens, in order:
+1. `__init__` builds the coordinator + `RemoteEnvironment` +
+   `RemoteWorkloadOrchestrator` (no agents contacted yet) and sets
+   `synchronize_workers=False`.
+2. `run()` **bootstraps** each device over SSH (rsync repo → optional
+   `pip install` → launch agent detached), then **waits for health** (with a
+   protocol-version handshake).
+3. `setup_instances` fans `/setup` out to every agent; `create_snapshot` fans
+   `/snapshot` out so every device holds its baseline.
+4. The normal PBT loop runs; each `evaluate_worker` is an RPC to the owning
+   device, scored centrally. Exploit uses config-only clone.
+5. On exit, the coordinator `/shutdown`s the agents (and the bootstrap tears
+   down launched processes).
+
+### 6.3 Agents already running (skip SSH bootstrap)
+
+```bash
+python -m src.tuners.pbt --distributed --inventory devices.yaml --no-bootstrap \
+    --benchmark sysbench --tier core --config standard --population 4
+```
+
+### 6.4 Coordinator CLI flags
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--distributed` | off | Enable distributed mode (requires `--inventory`) |
+| `--inventory PATH` | — | Path to `devices.yaml` |
+| `--no-bootstrap` | off | Assume agents already running; skip SSH bootstrap |
+| `--no-remote-deps` | off | During bootstrap, skip `pip install -r requirements.txt` |
+| `--eval-timeout SECS` | 1800 | Per-worker `run_eval` RPC timeout |
+| `--agent-timeout SECS` | 60 | Per-agent control RPC timeout |
+
+All existing local-mode flags (`--tier`, `--config`, `--population`,
+`--benchmark`, `--generations`, …) apply unchanged.
+
+### 6.5 Running a single device agent by hand
+
+Useful for debugging one device, or for the manual smoke test in §7.3.
+
+```bash
+python -m src.tuners.distributed.device_agent \
+    --worker-id 0 --host 0.0.0.0 --port 8770 \
+    --knob-tier core --knob-source expert \
+    --base-dir ./.instances --log-level INFO
+```
+
+Agent CLI flags: `--worker-id` (required), `--host`, `--port`, `--knob-tier`,
+`--knob-source`, `--base-dir`, `--log-level`.
+
+---
+
+## 7. How to test
+
+All commands assume the project virtualenv is active:
+
+```bash
+source .venv/bin/activate
+```
+
+> If test collection fails with `ModuleNotFoundError: No module named 'shap'`,
+> install the declared deps (`pip install shap ruff`) — `src/__init__.py`
+> imports the analysis chain at import time, which the whole suite depends on.
+
+### 7.1 The distributed test suite (no Docker/PG needed)
+
+```bash
+python -m pytest tests/unit/tuners/distributed -q
+```
+
+Expect **27 passing**. The suite has three files:
+
+| File | Covers |
+|---|---|
+| `test_inventory.py` | `devices.yaml` parsing: defaults/overrides, worker binding, validation errors (missing host, duplicate endpoint, bad port, unknown keys), SSH-key expansion |
+| `test_rpc_roundtrip.py` | End-to-end: spins up **two real agent HTTP servers on localhost** backed by an in-memory `FakeBackend`, then drives the full coordinator stack — health handshake, `setup`/`snapshot` fan-out, `run_eval` with **central scoring** (higher throughput ⇒ ≥ score), **config-only clone** (only the target resets), and RPC-failure → dead-worker fallback |
+| `test_bootstrap.py` | Pure SSH command builders: `RemoteLayout` paths, `ssh`/`rsync` argv (key, target, excludes, trailing slashes), agent launch command (worker/port/base-dir, `nohup`, pidfile), env exports, install-deps, stop-via-pidfile |
+
+The RPC round-trip test is the key integration proof: it exercises transport,
+dispatch, `RemoteEnvironment`, and `RemoteWorkloadOrchestrator` exactly as a
+real fleet would — **without Docker or PostgreSQL**.
+
+### 7.2 Regression check (existing suites)
+
+Confirms the `InstanceConfig`/`population.py`/`tuner.py` edits didn't break local
+mode:
+
+```bash
+python -m pytest tests/unit/tuners -q
+```
+
+Expect **150 passing**.
+
+### 7.3 Manual single-device smoke test (real DB)
+
+On a machine with Docker (or `--no-docker` + local PG):
+
+```bash
+# Terminal 1 — start an agent
+source .venv/bin/activate
+python -m src.tuners.distributed.device_agent --worker-id 0 --port 8770 \
+    --knob-tier core --base-dir ./.instances
+
+# Terminal 2 — talk to it
+curl -s localhost:8770/health | python -m json.tool
+
+curl -s -X POST localhost:8770/setup -H 'Content-Type: application/json' \
+  -d '{"run_id":"smoke","benchmark":"sysbench","workload_type":"oltp_read_write",
+       "tables":4,"table_size":10000}' | python -m json.tool
+
+curl -s -X POST localhost:8770/snapshot | python -m json.tool
+
+curl -s -X POST localhost:8770/run_eval -H 'Content-Type: application/json' \
+  -d '{"knob_config":{"shared_buffers":"256MB"},"generation":0}' | python -m json.tool
+
+curl -s -X POST localhost:8770/shutdown | python -m json.tool
+```
+
+### 7.4 Lint
+
+```bash
+python -m ruff check src/tuners/distributed/ tests/unit/tuners/distributed/
+```
+
+---
+
+## 8. Fault handling
+
+- **Agent unreachable / RPC timeout** → the worker is marked dead (failure
+  metric) and enters the standard rescue path (resample or config-clone).
+  Recovery re-runs `/setup` on the device.
+- **Health/protocol mismatch at startup** → `wait_for_agents` fails fast with the
+  offending workers listed, before any long run begins.
+- **Cleanup** always attempts `/shutdown` on every agent (and bootstrap
+  teardown) so devices are left clean for the next run.
+
+---
+
+## 9. Assumptions & current limitations
+
+- **Identical hardware fleet.** Heterogeneous fleets are out of scope. The
+  **coordinator can be any light machine**: each agent reports its detected
+  `WorkerResources` from `/setup`, and the coordinator resolves hardware-aware
+  knob ranges against **device** hardware (identical fleet ⇒ one device is
+  representative). `--worker-ram`/`--worker-cpus` are the manual override if no
+  device reports resources.
+- **Version-based knob pruning is skipped** in distributed mode — the coordinator
+  has no direct TCP path to the remote instances, so it relies on the
+  identical-fleet assumption (every device runs the same PostgreSQL).
+- **Synchronized measurement windows** are approximated by an agent-side
+  "don't start before epoch" gate (the `measurement_start_epoch` field). A full
+  two-phase prepare→go protocol that aligns the *measurement sub-window* (rather
+  than the eval start) would require splitting the shared
+  `WorkloadOrchestrator.evaluate_worker` and is deferred as future work.
+- **`LocalDeviceBackend`** wires `sysbench` and `tpch`; custom-workload wiring is
+  a clearly-marked `NotImplementedError`.
+- **Trusted network + SSH-key access.** Secrets pass via SSH/env, never the repo.
+
+---
+
+## 10. Extending the feature
+
+- **Custom workloads on devices** — implement the `else` branch in
+  `LocalDeviceBackend.setup` (`device_agent.py`) mirroring the PBT tuner's
+  custom-executor wiring.
+- **True synchronized measurement** — split the agent's `run_eval` into
+  `prepare` (through warmup) and `measure` (on a coordinator "go"), and add a
+  distributed barrier in the coordinator between the two phases.
+- **New RPC endpoints** — add the schema to `agent_api.py`, a route to `ROUTES`,
+  a handler branch in `device_agent._dispatch_post`, and a client call.
+
+---
+
+## 11. Quick reference
+
+```bash
+# Run distributed (bootstrap + tune)
+python -m src.tuners.pbt --distributed --inventory configs/distributed/devices.example.yaml \
+    --benchmark sysbench --tier core --config standard --population 4
+
+# Run distributed against already-running agents
+python -m src.tuners.pbt --distributed --inventory devices.yaml --no-bootstrap ...
+
+# Start one agent by hand
+python -m src.tuners.distributed.device_agent --worker-id 0 --port 8770 --knob-tier core
+
+# Test everything (no Docker needed)
+python -m pytest tests/unit/tuners/distributed -q          # 27 tests
+python -m pytest tests/unit/tuners -q   # 150 tests
+python -m ruff check src/tuners/distributed/
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,11 +51,13 @@ nav:
       - Knob Importance Analysis: architecture/knob-importance-analysis.md
       - SCALPEL: architecture/scalpel.md
       - Performance Evaluation: architecture/performance-evaluation.md
+      - Distributed Tuning: architecture/distributed-tuning.md
   - Guides:
       - Adding Knobs: guides/adding-knobs.md
       - Adding Workloads: guides/adding-workloads.md
       - BO Baseline: guides/bo-baseline.md
       - Evaluation Runbook: guides/evaluation-runbook.md
+      - Distributed Tuning: guides/distributed-tuning.md
       - SCALPEL Rollout: guides/scalpel-rollout.md
       - Visualization: guides/visualization.md
   - Reference:

--- a/src/tuners/cli.py
+++ b/src/tuners/cli.py
@@ -125,6 +125,51 @@ def _add_tuning_group(parser: argparse.ArgumentParser) -> None:
         ),
     )
 
+    dist = parser.add_argument_group("Distributed Tuning (multi-device)")
+    dist.add_argument(
+        "--distributed",
+        action="store_true",
+        help=(
+            "Run in DISTRIBUTED mode: one worker per dedicated device (see "
+            "--inventory). Requires an identical device fleet. Local mode is "
+            "unaffected when this flag is absent."
+        ),
+    )
+    dist.add_argument(
+        "--inventory",
+        type=str,
+        default=None,
+        help=(
+            "Path to the devices.yaml fleet inventory (required with "
+            "--distributed). See configs/distributed/devices.example.yaml."
+        ),
+    )
+    dist.add_argument(
+        "--no-bootstrap",
+        action="store_true",
+        help=(
+            "Skip SSH bootstrap; assume device agents are already running "
+            "(distributed mode only)."
+        ),
+    )
+    dist.add_argument(
+        "--no-remote-deps",
+        action="store_true",
+        help="During bootstrap, skip 'pip install -r requirements.txt' on devices.",
+    )
+    dist.add_argument(
+        "--eval-timeout",
+        type=float,
+        default=1800.0,
+        help="Per-worker remote evaluation RPC timeout in seconds (default: 1800).",
+    )
+    dist.add_argument(
+        "--agent-timeout",
+        type=float,
+        default=60.0,
+        help="Per-agent control RPC timeout in seconds (default: 60).",
+    )
+
 
 def _add_workload_group(parser: argparse.ArgumentParser) -> None:
     group = parser.add_argument_group("Workload Settings")
@@ -495,6 +540,12 @@ def build_lifecycle_config(
         scoring_policy=args.scoring_policy,
         scoring_policy_version=args.scoring_policy_version,
         metric_reference_version=args.metric_reference_version,
+        distributed=getattr(args, "distributed", False),
+        inventory=getattr(args, "inventory", None),
+        bootstrap=not getattr(args, "no_bootstrap", False),
+        remote_install_deps=not getattr(args, "no_remote_deps", False),
+        eval_timeout=getattr(args, "eval_timeout", 1800.0),
+        agent_timeout=getattr(args, "agent_timeout", 60.0),
     )
 
 

--- a/src/tuners/distributed/__init__.py
+++ b/src/tuners/distributed/__init__.py
@@ -1,0 +1,47 @@
+# Copyright (C) 2026 Ibrahim Al-Shawa and PBTune contributors
+# Licensed under the GNU General Public License v3.0
+# See LICENSE file for details
+
+"""
+Distributed Multi-Device Tuning
+===============================
+
+A NEW execution mode (alongside the existing single-device / ``local`` mode)
+in which every population worker runs on its own dedicated physical device.
+
+Motivation — *fairness*: in single-device mode all workers share one machine,
+so the B1–B17 lockstep barriers exist only to equalise noisy-neighbour
+contention. With one worker per identical, dedicated device there is no
+co-tenancy at all, so fairness becomes *structural* rather than something the
+algorithm has to fight for.
+
+Topology
+--------
+- **Coordinator** (control plane, one process): runs the unchanged PBT
+  algorithm (:class:`~src.tuners.pbt.population.Population`, evolution,
+  central :class:`CompositeScorer`) and talks to devices only through a
+  :class:`~src.tuners.distributed.remote_environment.RemoteEnvironment` that
+  implements the existing ``DatabaseEnvironment`` ABC.
+- **Device agent** (one per device): a long-running HTTP/JSON server that owns
+  exactly one local PostgreSQL instance and runs today's ``WorkloadOrchestrator``
+  pipeline locally, next to its database, returning raw metrics.
+
+This package is entirely additive — importing it has no effect on the local
+mode, and the local code paths are never modified.
+"""
+
+from src.tuners.distributed.inventory import (
+    DeviceSpec,
+    FleetInventory,
+    load_inventory,
+)
+
+__all__ = [
+    "DeviceSpec",
+    "FleetInventory",
+    "load_inventory",
+]
+
+AGENT_PROTOCOL_VERSION = "1.0"
+"""Wire-protocol version. Coordinator and agent must agree on the major
+version; a mismatch is a hard error surfaced by the /health handshake."""

--- a/src/tuners/distributed/agent_api.py
+++ b/src/tuners/distributed/agent_api.py
@@ -1,0 +1,318 @@
+# Copyright (C) 2026 Ibrahim Al-Shawa and PBTune contributors
+# Licensed under the GNU General Public License v3.0
+# See LICENSE file for details
+
+"""
+Device-Agent Wire Protocol
+==========================
+
+JSON request/response schemas exchanged between the **coordinator** and each
+**device agent**. Kept dependency-free (plain dataclasses + ``to_dict`` /
+``from_dict``) so both sides can (de)serialise with the stdlib ``json`` module —
+matching this repo's minimal-dependency philosophy (no web framework).
+
+Endpoints (all POST unless noted), rooted at ``{agent_base_url}``:
+
+======================  ================================================
+Route                   Payload  ->  Result
+======================  ================================================
+``GET /health``         --                    -> :class:`HealthResponse`
+``POST /setup``         :class:`SetupRequest`  -> :class:`SetupResponse`
+``POST /snapshot``      --                    -> :class:`SnapshotResponse`
+``POST /reset``         :class:`ResetRequest`  -> :class:`AckResponse`
+``POST /run_eval``      :class:`RunEvalRequest`-> :class:`RunEvalResponse`
+``POST /cleanup``       :class:`CleanupRequest`-> :class:`AckResponse`
+``POST /shutdown``      --                    -> :class:`AckResponse`
+======================  ================================================
+
+On any handler error the agent replies with a non-2xx status and an
+:class:`ErrorResponse` body.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, Optional
+
+
+# --------------------------------------------------------------------------- #
+# Generic envelopes
+# --------------------------------------------------------------------------- #
+@dataclass
+class ErrorResponse:
+    """Uniform error body returned with any non-2xx agent response."""
+
+    error: str
+    detail: Optional[str] = None
+    worker_id: Optional[int] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "ErrorResponse":
+        return cls(
+            error=d.get("error", "unknown error"),
+            detail=d.get("detail"),
+            worker_id=d.get("worker_id"),
+        )
+
+
+@dataclass
+class AckResponse:
+    """Simple success acknowledgement for side-effecting endpoints."""
+
+    ok: bool = True
+    detail: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "AckResponse":
+        return cls(ok=bool(d.get("ok", False)), detail=d.get("detail"))
+
+
+# --------------------------------------------------------------------------- #
+# /health
+# --------------------------------------------------------------------------- #
+@dataclass
+class HealthResponse:
+    """Liveness + capability handshake for a device agent."""
+
+    status: str  # "ok" | "starting" | "error"
+    protocol_version: str
+    agent_version: str
+    worker_id: int
+    pg_running: bool = False
+    pg_server_version: Optional[str] = None
+    backend: Optional[str] = None  # "docker" | "bare_metal"
+    hardware: Dict[str, Any] = field(default_factory=dict)
+    detail: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "HealthResponse":
+        return cls(
+            status=d.get("status", "error"),
+            protocol_version=d.get("protocol_version", ""),
+            agent_version=d.get("agent_version", ""),
+            worker_id=int(d.get("worker_id", -1)),
+            pg_running=bool(d.get("pg_running", False)),
+            pg_server_version=d.get("pg_server_version"),
+            backend=d.get("backend"),
+            hardware=d.get("hardware", {}) or {},
+            detail=d.get("detail"),
+        )
+
+
+# --------------------------------------------------------------------------- #
+# /setup
+# --------------------------------------------------------------------------- #
+@dataclass
+class SetupRequest:
+    """Instruct the agent to create/prepare its single local PG instance.
+
+    Mirrors the parameters the local :class:`EnvironmentFactory` needs so the
+    agent can stand up a functionally identical single-worker environment.
+    """
+
+    run_id: str
+    benchmark: str  # "sysbench" | "tpch" | "custom"
+    workload_type: str  # e.g. "oltp_read_write", "olap"
+    use_docker: bool = True
+    force_recreate_baseline: bool = False
+    # Benchmark shaping — only the fields relevant to ``benchmark`` are honoured.
+    tables: Optional[int] = None
+    table_size: Optional[int] = None
+    scale_factor: Optional[float] = None
+    image_name: Optional[str] = None
+    dbname: str = "test_dataset"
+    db_user: str = "postgres"
+    # Free-form extras for forward-compat without a protocol bump.
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "SetupRequest":
+        known = {f: d.get(f) for f in _SETUP_FIELDS if f in d}
+        return cls(**known)  # type: ignore[arg-type]
+
+
+_SETUP_FIELDS = {f for f in SetupRequest.__dataclass_fields__}  # noqa: C416
+
+
+@dataclass
+class SetupResponse:
+    """Result of standing up the device's instance.
+
+    ``resources`` carries the device's detected ``WorkerResources`` (serialised)
+    so the coordinator can resolve hardware-aware knob ranges against the
+    *device* hardware rather than its own — letting the coordinator run on any
+    light machine.
+    """
+
+    ok: bool
+    port: int
+    data_dir: str
+    backend: str
+    detail: Optional[str] = None
+    resources: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "SetupResponse":
+        return cls(
+            ok=bool(d.get("ok", False)),
+            port=int(d.get("port", 0)),
+            data_dir=d.get("data_dir", ""),
+            backend=d.get("backend", ""),
+            detail=d.get("detail"),
+            resources=d.get("resources", {}) or {},
+        )
+
+
+# --------------------------------------------------------------------------- #
+# /snapshot
+# --------------------------------------------------------------------------- #
+@dataclass
+class SnapshotResponse:
+    """Identifier of the base snapshot the device now holds locally."""
+
+    ok: bool
+    snapshot_id: str
+    detail: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "SnapshotResponse":
+        return cls(
+            ok=bool(d.get("ok", False)),
+            snapshot_id=d.get("snapshot_id", ""),
+            detail=d.get("detail"),
+        )
+
+
+# --------------------------------------------------------------------------- #
+# /reset  (config-only clone target: restore device to its local base snapshot)
+# --------------------------------------------------------------------------- #
+@dataclass
+class ResetRequest:
+    """Reset the device's data directory to its local base snapshot.
+
+    This is how a distributed *exploit* lands: the elite worker's knob config
+    is copied (cheaply, over the wire) and the poor worker's device resets its
+    data to the byte-identical benchmark baseline it already holds — no
+    gigabyte-scale PGDATA transfer across the network.
+    """
+
+    snapshot_id: str = ""  # empty => the agent's default base snapshot
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "ResetRequest":
+        return cls(snapshot_id=d.get("snapshot_id", ""))
+
+
+# --------------------------------------------------------------------------- #
+# /run_eval  (the core of the fairness story — runs entirely on-device)
+# --------------------------------------------------------------------------- #
+@dataclass
+class RunEvalRequest:
+    """Run one full apply -> run -> measure evaluation on the device.
+
+    The benchmark client executes locally, next to the DB, so no network
+    latency ever enters the measurement window.
+    """
+
+    knob_config: Dict[str, Any]
+    generation: int
+    apply_config: bool = True
+    restore_due: bool = False
+    next_eval_will_restore: bool = False
+    # Optional coordinator-issued synchronised measurement start (Phase 4).
+    # ``None`` => start measuring immediately after warmup.
+    measurement_start_epoch: Optional[float] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "RunEvalRequest":
+        return cls(
+            knob_config=d.get("knob_config", {}) or {},
+            generation=int(d.get("generation", 0)),
+            apply_config=bool(d.get("apply_config", True)),
+            restore_due=bool(d.get("restore_due", False)),
+            next_eval_will_restore=bool(d.get("next_eval_will_restore", False)),
+            measurement_start_epoch=d.get("measurement_start_epoch"),
+        )
+
+
+@dataclass
+class RunEvalResponse:
+    """Raw evaluation result. Scoring happens *centrally* on the coordinator so
+    adaptive metric normalisation spans the whole population identically to
+    single-device mode."""
+
+    ok: bool
+    # Serialised PerformanceMetrics (see src/utils/metrics.py). None on failure.
+    metrics: Optional[Dict[str, Any]] = None
+    restart_occurred: bool = False
+    # SHOW-verified knob values actually in effect on the instance.
+    actual_config: Dict[str, Any] = field(default_factory=dict)
+    # Serialised per-worker timing record (schema v1.1). Optional.
+    timing: Optional[Dict[str, Any]] = None
+    error: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "RunEvalResponse":
+        return cls(
+            ok=bool(d.get("ok", False)),
+            metrics=d.get("metrics"),
+            restart_occurred=bool(d.get("restart_occurred", False)),
+            actual_config=d.get("actual_config", {}) or {},
+            timing=d.get("timing"),
+            error=d.get("error"),
+        )
+
+
+# --------------------------------------------------------------------------- #
+# /cleanup
+# --------------------------------------------------------------------------- #
+@dataclass
+class CleanupRequest:
+    remove_data: bool = False
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "CleanupRequest":
+        return cls(remove_data=bool(d.get("remove_data", False)))
+
+
+# Routes recognised by the agent HTTP server. Kept here so client and server
+# share a single source of truth.
+ROUTES = {
+    "health": "/health",
+    "setup": "/setup",
+    "snapshot": "/snapshot",
+    "reset": "/reset",
+    "run_eval": "/run_eval",
+    "cleanup": "/cleanup",
+    "shutdown": "/shutdown",
+}

--- a/src/tuners/distributed/bootstrap.py
+++ b/src/tuners/distributed/bootstrap.py
@@ -1,0 +1,289 @@
+# Copyright (C) 2026 Ibrahim Al-Shawa and PBTune contributors
+# Licensed under the GNU General Public License v3.0
+# See LICENSE file for details
+
+"""
+Fleet Bootstrap
+===============
+
+Provisions and launches the device agents over SSH (the user chose "tool
+bootstraps them"). Per device the bootstrap:
+
+1. **syncs the repository** to the device (``rsync`` over SSH),
+2. optionally **installs Python dependencies** (``pip install -r requirements.txt``),
+3. **launches the device agent** detached (``nohup``), recording a pidfile and
+   logfile so it can be stopped later, and
+4. leaves health-checking to :meth:`Coordinator.wait_for_agents`.
+
+Teardown stops each agent via its recorded pidfile.
+
+Design
+------
+Command *construction* is factored into pure functions
+(:func:`rsync_command`, :func:`ssh_command`, :func:`launch_agent_command`,
+:func:`stop_agent_command`) so it is unit-testable without touching the network.
+Execution is a thin :class:`subprocess`-based wrapper (:class:`FleetBootstrapper`).
+
+Assumptions (per the agreed design): a trusted LAN, SSH-key access, and a remote
+``python3`` capable of importing this project. Devices are identical hardware.
+"""
+
+from __future__ import annotations
+
+import shlex
+import subprocess
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+from typing import List, Optional, Sequence
+
+from src.tuners.distributed.inventory import DeviceSpec, FleetInventory
+from src.utils.logger import get_logger
+
+LOGGER = get_logger("FleetBootstrap")
+
+# Paths excluded from the code sync — large, host-specific, or regenerated.
+DEFAULT_RSYNC_EXCLUDES = (
+    ".git",
+    ".venv",
+    "__pycache__",
+    "*.pyc",
+    ".instances",
+    "pg_instances",
+    "results",
+    "smac3_output",
+    "graphify-out",
+    "notebooks",
+    "papers",
+    ".pytest_cache",
+)
+
+
+@dataclass
+class RemoteLayout:
+    """Resolved remote paths for one device, derived from its ``data_dir``."""
+
+    root: str  # base data dir (DeviceSpec.data_dir)
+    code_dir: str  # where the repo is synced
+    instances_dir: str  # PG instance data (agent --base-dir)
+    log_file: str
+    pid_file: str
+
+    @classmethod
+    def for_device(cls, device: DeviceSpec) -> "RemoteLayout":
+        root = PurePosixPath(device.data_dir)
+        return cls(
+            root=str(root),
+            code_dir=str(root / "code"),
+            instances_dir=str(root / "instances"),
+            log_file=str(root / f"agent-worker-{device.worker_id}.log"),
+            pid_file=str(root / f"agent-worker-{device.worker_id}.pid"),
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Pure command builders (unit-testable, no I/O)
+# --------------------------------------------------------------------------- #
+def _ssh_target(device: DeviceSpec) -> str:
+    return f"{device.ssh_user}@{device.host}" if device.ssh_user else device.host
+
+
+def _ssh_opts(device: DeviceSpec) -> List[str]:
+    opts = ["-o", "BatchMode=yes", "-o", "StrictHostKeyChecking=accept-new"]
+    if device.ssh_key:
+        opts += ["-i", device.ssh_key]
+    return opts
+
+
+def ssh_command(device: DeviceSpec, remote_cmd: str) -> List[str]:
+    """Build an ``ssh ... 'remote_cmd'`` argv for a device."""
+    return ["ssh", *_ssh_opts(device), _ssh_target(device), remote_cmd]
+
+
+def rsync_command(
+    device: DeviceSpec,
+    local_dir: str,
+    remote_dir: str,
+    excludes: Sequence[str] = DEFAULT_RSYNC_EXCLUDES,
+) -> List[str]:
+    """Build an ``rsync -az --delete`` argv that syncs the repo to a device."""
+    ssh_parts = " ".join(["ssh", *_ssh_opts(device)])
+    local = local_dir if local_dir.endswith("/") else local_dir + "/"
+    argv = ["rsync", "-az", "--delete", "-e", ssh_parts]
+    for pattern in excludes:
+        argv += ["--exclude", pattern]
+    argv += [local, f"{_ssh_target(device)}:{remote_dir}/"]
+    return argv
+
+
+def launch_agent_command(
+    device: DeviceSpec,
+    layout: RemoteLayout,
+    *,
+    knob_tier: str,
+    knob_source: str = "expert",
+    log_level: str = "INFO",
+    env_exports: Optional[dict] = None,
+) -> str:
+    """Build the remote shell command that launches the agent detached.
+
+    The agent is started with ``nohup`` from the synced code dir; its PID is
+    written to ``layout.pid_file`` and stdout/stderr to ``layout.log_file``.
+    """
+    exports = ""
+    if env_exports:
+        exports = (
+            " ".join(f"{k}={shlex.quote(str(v))}" for k, v in env_exports.items())
+            + " "
+        )
+    agent = (
+        f"{exports}{device.python} -m src.tuners.distributed.device_agent "
+        f"--worker-id {device.worker_id} "
+        f"--host 0.0.0.0 --port {device.agent_port} "
+        f"--knob-tier {shlex.quote(knob_tier)} "
+        f"--knob-source {shlex.quote(knob_source)} "
+        f"--base-dir {shlex.quote(layout.instances_dir)} "
+        f"--log-level {log_level}"
+    )
+    # mkdir -p, cd into code, launch detached, record pid.
+    return (
+        f"mkdir -p {shlex.quote(layout.root)} {shlex.quote(layout.instances_dir)} && "
+        f"cd {shlex.quote(layout.code_dir)} && "
+        f"nohup {agent} > {shlex.quote(layout.log_file)} 2>&1 & "
+        f"echo $! > {shlex.quote(layout.pid_file)}"
+    )
+
+
+def install_deps_command(layout: RemoteLayout, device: DeviceSpec) -> str:
+    """Build the remote command that installs requirements into the device env."""
+    return (
+        f"cd {shlex.quote(layout.code_dir)} && "
+        f"{device.python} -m pip install -q -r requirements.txt"
+    )
+
+
+def stop_agent_command(layout: RemoteLayout) -> str:
+    """Build the remote command that stops the agent via its pidfile."""
+    pid = shlex.quote(layout.pid_file)
+    return (
+        f"if [ -f {pid} ]; then kill \"$(cat {pid})\" 2>/dev/null || true; "
+        f"rm -f {pid}; fi"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Executor
+# --------------------------------------------------------------------------- #
+class BootstrapError(RuntimeError):
+    """Raised when a bootstrap step fails on a device."""
+
+
+class FleetBootstrapper:
+    """Runs the bootstrap/teardown steps against a fleet over SSH."""
+
+    def __init__(
+        self,
+        inventory: FleetInventory,
+        population_size: int,
+        local_repo_dir: str,
+        *,
+        knob_tier: str,
+        knob_source: str = "expert",
+        install_deps: bool = True,
+        command_timeout_s: float = 900.0,
+        env_exports: Optional[dict] = None,
+    ):
+        inventory.validate_for_population(population_size)
+        self.inventory = inventory
+        self.population_size = population_size
+        self.local_repo_dir = local_repo_dir
+        self.knob_tier = knob_tier
+        self.knob_source = knob_source
+        self.install_deps = install_deps
+        self.command_timeout_s = command_timeout_s
+        self.env_exports = env_exports or {}
+        self.devices: List[DeviceSpec] = [
+            inventory.device_for_worker(wid) for wid in range(population_size)
+        ]
+
+    # -- low-level runner ------------------------------------------------- #
+    def _run(self, argv: Sequence[str], *, device: DeviceSpec, step: str) -> None:
+        LOGGER.info("[%s] %s: %s", device.display_name, step, " ".join(argv))
+        try:
+            result = subprocess.run(
+                list(argv),
+                capture_output=True,
+                text=True,
+                timeout=self.command_timeout_s,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise BootstrapError(
+                f"{device.display_name}: {step} timed out after {self.command_timeout_s}s"
+            ) from exc
+        if result.returncode != 0:
+            raise BootstrapError(
+                f"{device.display_name}: {step} failed (rc={result.returncode})\n"
+                f"stdout: {result.stdout.strip()}\nstderr: {result.stderr.strip()}"
+            )
+
+    # -- per-device steps ------------------------------------------------- #
+    def bootstrap_device(self, device: DeviceSpec) -> None:
+        layout = RemoteLayout.for_device(device)
+        # Ensure the code dir exists, then sync.
+        self._run(
+            ssh_command(device, f"mkdir -p {shlex.quote(layout.code_dir)}"),
+            device=device,
+            step="mkdir code dir",
+        )
+        self._run(
+            rsync_command(device, self.local_repo_dir, layout.code_dir),
+            device=device,
+            step="sync code",
+        )
+        if self.install_deps:
+            self._run(
+                ssh_command(device, install_deps_command(layout, device)),
+                device=device,
+                step="install deps",
+            )
+        # Stop any stale agent, then launch fresh.
+        self._run(
+            ssh_command(device, stop_agent_command(layout)),
+            device=device,
+            step="stop stale agent",
+        )
+        self._run(
+            ssh_command(
+                device,
+                launch_agent_command(
+                    device,
+                    layout,
+                    knob_tier=self.knob_tier,
+                    knob_source=self.knob_source,
+                    env_exports=self.env_exports,
+                ),
+            ),
+            device=device,
+            step="launch agent",
+        )
+
+    def teardown_device(self, device: DeviceSpec) -> None:
+        layout = RemoteLayout.for_device(device)
+        self._run(
+            ssh_command(device, stop_agent_command(layout)),
+            device=device,
+            step="stop agent",
+        )
+
+    # -- fleet-wide ------------------------------------------------------- #
+    def bootstrap_all(self) -> None:
+        LOGGER.info("Bootstrapping %d device(s)...", len(self.devices))
+        for device in self.devices:
+            self.bootstrap_device(device)
+        LOGGER.info("Bootstrap complete; agents launching in the background.")
+
+    def teardown_all(self) -> None:
+        for device in self.devices:
+            try:
+                self.teardown_device(device)
+            except BootstrapError as exc:
+                LOGGER.warning("Teardown issue: %s", exc)

--- a/src/tuners/distributed/config.py
+++ b/src/tuners/distributed/config.py
@@ -1,0 +1,77 @@
+# Copyright (C) 2026 Ibrahim Al-Shawa and PBTune contributors
+# Licensed under the GNU General Public License v3.0
+# See LICENSE file for details
+
+"""
+Distributed Execution Configuration
+===================================
+
+Defines the ``ExecutionMode`` selector and the ``DistributedConfig`` that
+parameterises a distributed run. Kept in the distributed package (rather than
+``tuner_config.py``) so that enabling this feature is purely additive: the
+existing single-device configuration is untouched.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+from src.tuners.distributed.inventory import FleetInventory, load_inventory
+
+
+class ExecutionMode(str, Enum):
+    """How the population is physically executed.
+
+    ``LOCAL``
+        The existing behaviour: all workers run as co-tenant PostgreSQL
+        instances on a single machine (ports 5440+). This is the default and
+        is never altered by the distributed feature.
+    ``DISTRIBUTED``
+        One worker per dedicated device; the coordinator drives device agents
+        over HTTP/JSON RPC.
+    """
+
+    LOCAL = "local"
+    DISTRIBUTED = "distributed"
+
+
+@dataclass
+class DistributedConfig:
+    """Runtime settings for :class:`ExecutionMode.DISTRIBUTED`.
+
+    Attributes
+    ----------
+    inventory:
+        The parsed device fleet (one device per worker).
+    request_timeout_s:
+        Per-RPC timeout for ordinary control calls (setup, reset, health).
+    eval_timeout_s:
+        Timeout for a ``run_eval`` RPC. Must comfortably exceed
+        warmup + measurement + restart time; a breach marks the worker dead
+        and hands it to the standard rescue path.
+    health_poll_interval_s, health_timeout_s:
+        Polling cadence / overall deadline when waiting for agents to become
+        healthy after (bootstrap and) setup.
+    synchronized_measurement:
+        When True (Phase 4), the coordinator issues a common measurement-start
+        epoch so every device begins its timed window at the same wall-clock —
+        an extra fairness guard against any shared infrastructure. Ignored
+        until the Phase 4 barrier lands.
+    """
+
+    inventory: FleetInventory
+    request_timeout_s: float = 60.0
+    eval_timeout_s: float = 1800.0
+    health_poll_interval_s: float = 2.0
+    health_timeout_s: float = 120.0
+    synchronized_measurement: bool = False
+
+    @classmethod
+    def from_inventory_path(cls, path: str, **kwargs: object) -> "DistributedConfig":
+        """Build a config by loading and validating ``devices.yaml`` from disk."""
+        inventory = load_inventory(path)
+        return cls(inventory=inventory, **kwargs)  # type: ignore[arg-type]
+
+    def validate_for_population(self, population_size: int) -> None:
+        self.inventory.validate_for_population(population_size)

--- a/src/tuners/distributed/coordinator.py
+++ b/src/tuners/distributed/coordinator.py
@@ -1,0 +1,166 @@
+# Copyright (C) 2026 Ibrahim Al-Shawa and PBTune contributors
+# Licensed under the GNU General Public License v3.0
+# See LICENSE file for details
+
+"""
+Coordinator
+===========
+
+Control-plane glue for distributed mode. Builds an :class:`AgentClient` per
+device from the fleet inventory, waits for every agent to report healthy, and
+constructs the two drop-in components the existing ``Population`` loop needs:
+
+- a :class:`RemoteEnvironment` (proxies lifecycle to the agents), and
+- a :class:`RemoteWorkloadOrchestrator` (RPC eval + central scoring).
+
+The PBT algorithm itself (``Population``, evolution, scoring) is untouched — the
+coordinator only swaps ``env`` and ``orchestrator``. Distributed runs also set
+``synchronize_workers=False`` because the B1–B17 substep barriers run locally on
+each device; the coordinator's only sync point is the generation boundary.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, List
+
+from src.config.database import DatabaseConfig
+from src.tuners.distributed.agent_api import HealthResponse, ROUTES, SetupRequest
+from src.tuners.distributed.config import DistributedConfig
+from src.tuners.distributed.inventory import DeviceSpec
+from src.tuners.distributed.remote_environment import RemoteEnvironment
+from src.tuners.distributed.remote_orchestrator import RemoteWorkloadOrchestrator
+from src.tuners.distributed.transport import AgentClient, AgentRPCError
+from src.tuners.distributed import AGENT_PROTOCOL_VERSION
+from src.utils.logger import get_logger
+
+LOGGER = get_logger("Coordinator")
+
+
+class Coordinator:
+    """Manages the device fleet for a distributed tuning run."""
+
+    def __init__(
+        self,
+        distributed_config: DistributedConfig,
+        setup_template: SetupRequest,
+        db_config: DatabaseConfig,
+        population_size: int,
+    ):
+        distributed_config.validate_for_population(population_size)
+        self.config = distributed_config
+        self.setup_template = setup_template
+        self.db_config = db_config
+        self.population_size = population_size
+
+        # Bind the first ``population_size`` devices to workers 0..N-1.
+        self.devices: Dict[int, DeviceSpec] = {
+            wid: distributed_config.inventory.device_for_worker(wid)
+            for wid in range(population_size)
+        }
+        self.clients: Dict[int, AgentClient] = {
+            wid: AgentClient(
+                spec.agent_base_url, default_timeout=distributed_config.request_timeout_s
+            )
+            for wid, spec in self.devices.items()
+        }
+
+    # -- health handshake ------------------------------------------------- #
+    def wait_for_agents(self) -> None:
+        """Poll every agent's /health until all are reachable, or time out.
+
+        Also enforces the protocol-version handshake so a coordinator/agent
+        mismatch fails fast rather than corrupting a long run.
+        """
+        deadline = time.monotonic() + self.config.health_timeout_s
+        pending = set(self.clients)
+        last_err: Dict[int, str] = {}
+
+        while pending and time.monotonic() < deadline:
+            for worker_id in list(pending):
+                try:
+                    health = HealthResponse.from_dict(
+                        self.clients[worker_id].get(
+                            ROUTES["health"], timeout=self.config.request_timeout_s
+                        )
+                    )
+                    self._check_protocol(worker_id, health)
+                    pending.discard(worker_id)
+                    LOGGER.info(
+                        "➤ Agent for worker %d healthy on %s (backend=%s)",
+                        worker_id,
+                        self.devices[worker_id].display_name,
+                        health.backend,
+                    )
+                except (AgentRPCError, RuntimeError) as exc:
+                    last_err[worker_id] = str(exc)
+            if pending:
+                time.sleep(self.config.health_poll_interval_s)
+
+        if pending:
+            details = {wid: last_err.get(wid, "unreachable") for wid in pending}
+            raise RuntimeError(
+                f"Timed out waiting for device agents to become healthy: {details}"
+            )
+
+    def _check_protocol(self, worker_id: int, health: HealthResponse) -> None:
+        got = (health.protocol_version or "").split(".")[0]
+        want = AGENT_PROTOCOL_VERSION.split(".")[0]
+        if got != want:
+            raise RuntimeError(
+                f"Protocol mismatch with worker {worker_id}: coordinator="
+                f"{AGENT_PROTOCOL_VERSION} agent={health.protocol_version}"
+            )
+
+    # -- component factories --------------------------------------------- #
+    def make_environment(self, schema_provider: Any, run_id: str) -> RemoteEnvironment:
+        return RemoteEnvironment(
+            run_id=run_id,
+            db_config=self.db_config,
+            schema_provider=schema_provider,
+            clients=self.clients,
+            devices=self.devices,
+            setup_template=self.setup_template,
+            request_timeout_s=self.config.request_timeout_s,
+        )
+
+    def make_orchestrator(
+        self, orch_config: Any, executor: Any, env: RemoteEnvironment
+    ) -> RemoteWorkloadOrchestrator:
+        return RemoteWorkloadOrchestrator(
+            config=orch_config,
+            workload_executor=executor,
+            env=env,
+            clients=self.clients,
+            eval_timeout_s=self.config.eval_timeout_s,
+        )
+
+    # -- teardown --------------------------------------------------------- #
+    def shutdown_agents(self) -> None:
+        """Best-effort /shutdown to every agent (used at end of a run)."""
+        for worker_id, client in self.clients.items():
+            try:
+                client.post(ROUTES["shutdown"], {}, timeout=self.config.request_timeout_s)
+            except AgentRPCError as exc:
+                LOGGER.debug("Shutdown of worker %d agent failed: %s", worker_id, exc)
+
+    def health_snapshot(self) -> List[HealthResponse]:
+        out = []
+        for worker_id in sorted(self.clients):
+            try:
+                out.append(
+                    HealthResponse.from_dict(
+                        self.clients[worker_id].get(ROUTES["health"])
+                    )
+                )
+            except AgentRPCError:
+                out.append(
+                    HealthResponse(
+                        status="error",
+                        protocol_version="",
+                        agent_version="",
+                        worker_id=worker_id,
+                        detail="unreachable",
+                    )
+                )
+        return out

--- a/src/tuners/distributed/device_agent.py
+++ b/src/tuners/distributed/device_agent.py
@@ -1,0 +1,561 @@
+# Copyright (C) 2026 Ibrahim Al-Shawa and PBTune contributors
+# Licensed under the GNU General Public License v3.0
+# See LICENSE file for details
+
+"""
+Device Agent
+============
+
+A long-running HTTP/JSON server that runs **on each device** and owns exactly
+one local PostgreSQL instance. It exposes the small RPC surface defined in
+:mod:`src.tuners.distributed.agent_api` and executes today's proven
+``WorkloadOrchestrator`` pipeline *locally* — so the benchmark client always
+runs next to the database and no network latency ever enters the measurement
+window (the crux of the fairness guarantee).
+
+Scoring deliberately does **not** happen here: the agent returns raw
+``PerformanceMetrics`` and the coordinator scores centrally, so adaptive
+normalisation spans the whole population exactly as in single-device mode.
+
+The evaluation logic sits behind the :class:`EvaluationBackend` seam so the
+HTTP/dispatch layer can be unit-tested with a fake backend, while
+:class:`LocalDeviceBackend` performs the real DB wiring (mirroring
+``DatabaseTuner``'s single-machine setup for one worker).
+
+Run standalone::
+
+    python -m src.tuners.distributed.device_agent --worker-id 0 --port 8770
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import threading
+from abc import ABC, abstractmethod
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any, Dict, Optional, Tuple
+
+from src.tuners.distributed import AGENT_PROTOCOL_VERSION
+from src.tuners.distributed.agent_api import (
+    AckResponse,
+    CleanupRequest,
+    ErrorResponse,
+    HealthResponse,
+    ResetRequest,
+    ROUTES,
+    RunEvalRequest,
+    RunEvalResponse,
+    SetupRequest,
+    SetupResponse,
+    SnapshotResponse,
+)
+from src.tuners.distributed.transport import read_json_body, write_json
+
+LOGGER = logging.getLogger("DeviceAgent")
+
+AGENT_VERSION = "1.0.0"
+
+
+# --------------------------------------------------------------------------- #
+# Backend seam
+# --------------------------------------------------------------------------- #
+class EvaluationBackend(ABC):
+    """Everything the agent needs to evaluate a worker on this device.
+
+    Implemented for real by :class:`LocalDeviceBackend`; a lightweight fake is
+    used in tests to exercise the HTTP/dispatch layer without Docker/PG.
+    """
+
+    @abstractmethod
+    def setup(self, req: SetupRequest) -> SetupResponse:
+        """Create/prepare the single local instance and return its coordinates."""
+
+    @abstractmethod
+    def create_snapshot(self) -> str:
+        """Create the local base snapshot; return its identifier."""
+
+    @abstractmethod
+    def reset(self, snapshot_id: str) -> None:
+        """Restore the instance's data to the given (or default) base snapshot."""
+
+    @abstractmethod
+    def run_eval(
+        self, req: RunEvalRequest
+    ) -> Tuple[Dict[str, Any], bool, Dict[str, Any], Optional[Dict[str, Any]]]:
+        """Run one evaluation locally.
+
+        Returns ``(metrics_dict, restart_occurred, actual_config, timing_dict)``.
+        """
+
+    @abstractmethod
+    def cleanup(self, remove_data: bool) -> None:
+        """Tear down the local instance."""
+
+    # -- introspection (defaults are safe no-ops) ------------------------- #
+    def pg_running(self) -> bool:
+        return False
+
+    def pg_server_version(self) -> Optional[str]:
+        return None
+
+    def backend_name(self) -> Optional[str]:
+        return None
+
+    def hardware(self) -> Dict[str, Any]:
+        return {}
+
+
+class AgentState:
+    """Holds the backend, its assigned worker id, and a lifecycle lock."""
+
+    def __init__(self, worker_id: int, backend: EvaluationBackend):
+        self.worker_id = worker_id
+        self.backend = backend
+        self.lock = threading.Lock()  # serialise mutating ops on the instance
+        self.is_set_up = False
+        self.shutdown_event = threading.Event()
+
+    def health(self) -> HealthResponse:
+        try:
+            return HealthResponse(
+                status="ok" if self.is_set_up else "starting",
+                protocol_version=AGENT_PROTOCOL_VERSION,
+                agent_version=AGENT_VERSION,
+                worker_id=self.worker_id,
+                pg_running=self.backend.pg_running(),
+                pg_server_version=self.backend.pg_server_version(),
+                backend=self.backend.backend_name(),
+                hardware=self.backend.hardware(),
+            )
+        except Exception as exc:  # noqa: BLE001 — health must never raise
+            return HealthResponse(
+                status="error",
+                protocol_version=AGENT_PROTOCOL_VERSION,
+                agent_version=AGENT_VERSION,
+                worker_id=self.worker_id,
+                detail=str(exc),
+            )
+
+
+# --------------------------------------------------------------------------- #
+# HTTP request handler
+# --------------------------------------------------------------------------- #
+class _AgentHandler(BaseHTTPRequestHandler):
+    # Injected by DeviceAgent via functools.partial-style subclass attribute.
+    state: AgentState = None  # type: ignore[assignment]
+
+    server_version = f"PBTDeviceAgent/{AGENT_VERSION}"
+
+    def log_message(self, fmt: str, *args: Any) -> None:  # quieter default logging
+        LOGGER.debug("%s - " + fmt, self.address_string(), *args)
+
+    # -- helpers ---------------------------------------------------------- #
+    def _fail(self, status: int, message: str, detail: Optional[str] = None) -> None:
+        write_json(
+            self,
+            status,
+            ErrorResponse(
+                error=message, detail=detail, worker_id=self.state.worker_id
+            ).to_dict(),
+        )
+
+    # -- routing ---------------------------------------------------------- #
+    def do_GET(self) -> None:  # noqa: N802 (stdlib naming)
+        if self.path == ROUTES["health"]:
+            write_json(self, 200, self.state.health().to_dict())
+        else:
+            self._fail(404, f"unknown route: GET {self.path}")
+
+    def do_POST(self) -> None:  # noqa: N802
+        try:
+            body = read_json_body(self)
+        except ValueError as exc:
+            self._fail(400, "malformed JSON body", str(exc))
+            return
+
+        try:
+            self._dispatch_post(self.path, body)
+        except NotImplementedError as exc:
+            self._fail(501, "not implemented", str(exc))
+        except Exception as exc:  # noqa: BLE001 — surface as structured 500
+            LOGGER.exception("Handler error on %s", self.path)
+            self._fail(500, "agent handler error", str(exc))
+
+    def _dispatch_post(self, path: str, body: Dict[str, Any]) -> None:
+        state = self.state
+        if path == ROUTES["setup"]:
+            with state.lock:
+                resp = state.backend.setup(SetupRequest.from_dict(body))
+                state.is_set_up = resp.ok
+            write_json(self, 200 if resp.ok else 500, resp.to_dict())
+
+        elif path == ROUTES["snapshot"]:
+            with state.lock:
+                snap_id = state.backend.create_snapshot()
+            write_json(self, 200, SnapshotResponse(ok=True, snapshot_id=snap_id).to_dict())
+
+        elif path == ROUTES["reset"]:
+            reset_req = ResetRequest.from_dict(body)
+            with state.lock:
+                state.backend.reset(reset_req.snapshot_id)
+            write_json(self, 200, AckResponse(ok=True).to_dict())
+
+        elif path == ROUTES["run_eval"]:
+            eval_req = RunEvalRequest.from_dict(body)
+            # run_eval holds the lock: one evaluation at a time per device.
+            with state.lock:
+                metrics, restart_occurred, actual_cfg, timing = state.backend.run_eval(
+                    eval_req
+                )
+            write_json(
+                self,
+                200,
+                RunEvalResponse(
+                    ok=True,
+                    metrics=metrics,
+                    restart_occurred=restart_occurred,
+                    actual_config=actual_cfg,
+                    timing=timing,
+                ).to_dict(),
+            )
+
+        elif path == ROUTES["cleanup"]:
+            cleanup_req = CleanupRequest.from_dict(body)
+            with state.lock:
+                state.backend.cleanup(cleanup_req.remove_data)
+                state.is_set_up = False
+            write_json(self, 200, AckResponse(ok=True).to_dict())
+
+        elif path == ROUTES["shutdown"]:
+            write_json(self, 200, AckResponse(ok=True, detail="shutting down").to_dict())
+            state.shutdown_event.set()
+
+        else:
+            self._fail(404, f"unknown route: POST {path}")
+
+
+# --------------------------------------------------------------------------- #
+# Server wrapper
+# --------------------------------------------------------------------------- #
+class DeviceAgent:
+    """Owns the HTTP server and its :class:`AgentState`."""
+
+    def __init__(self, worker_id: int, backend: EvaluationBackend, host: str, port: int):
+        self.state = AgentState(worker_id, backend)
+        handler_cls = type("_BoundAgentHandler", (_AgentHandler,), {"state": self.state})
+        self.httpd = ThreadingHTTPServer((host, port), handler_cls)
+        self.host, self.port = self.httpd.server_address[0], self.httpd.server_address[1]
+
+    def serve_forever(self) -> None:
+        """Serve until a /shutdown request (or Ctrl-C) arrives."""
+        server_thread = threading.Thread(
+            target=self.httpd.serve_forever, name="agent-http", daemon=True
+        )
+        server_thread.start()
+        LOGGER.info(
+            "Device agent (worker %d) listening on %s:%d",
+            self.state.worker_id,
+            self.host,
+            self.port,
+        )
+        try:
+            self.state.shutdown_event.wait()
+        except KeyboardInterrupt:
+            LOGGER.info("Interrupted; shutting down device agent")
+        finally:
+            self.close()
+
+    def close(self) -> None:
+        self.httpd.shutdown()
+        self.httpd.server_close()
+
+
+# --------------------------------------------------------------------------- #
+# Real backend — mirrors DatabaseTuner's single-machine setup for one worker
+# --------------------------------------------------------------------------- #
+class LocalDeviceBackend(EvaluationBackend):
+    """Real evaluation backend backed by a local Docker/bare-metal PG instance.
+
+    Deliberately reuses the *same* building blocks as ``DatabaseTuner``
+    (``get_knob_space``, ``detect_worker_resources``, ``create_metric_config``,
+    the benchmark executors, ``EnvironmentFactory``, ``WorkloadOrchestrator``)
+    so on-device evaluation is byte-for-byte consistent with local mode.
+
+    Heavy imports are deferred to :meth:`setup` so the module stays importable
+    (for tests and the coordinator) without the full DB/Docker stack present.
+    """
+
+    #: Local instance index on this device is always 0 (one worker per device);
+    #: the *global* worker id it represents is carried separately for logging.
+    LOCAL_WORKER_ID = 0
+
+    def __init__(
+        self,
+        global_worker_id: int,
+        knob_tier: str,
+        base_dir: str,
+        knob_source: str = "expert",
+    ):
+        self.global_worker_id = global_worker_id
+        self.knob_tier = knob_tier
+        self.knob_source = knob_source
+        self.base_dir = base_dir
+
+        # Built lazily in setup(); typed Any since the concrete env/orchestrator/
+        # worker/resources classes are imported lazily inside setup().
+        self._env: Any = None
+        self._orchestrator: Any = None
+        self._worker: Any = None
+        self._knob_space: Any = None
+        self._resources: Any = None
+        self._port: int = 0
+        self._data_dir: str = ""
+        self._backend_name: str = ""
+        self._snapshot_id: str = ""
+
+    # -- lifecycle -------------------------------------------------------- #
+    def setup(self, req: SetupRequest) -> SetupResponse:
+        from pathlib import Path
+
+        from src.benchmarks.sysbench.executor import SysbenchExecutor
+        from src.benchmarks.tpch.executor import TPCHExecutor
+        from src.config.database import DatabaseConfig
+        from src.tuners.engine.orchestrator import (
+            WorkloadOrchestrator,
+            WorkloadOrchestratorConfig,
+        )
+        from src.knobs import get_knob_space
+        from src.tuners.pbt.worker import PBTWorker as Worker
+        from src.utils.environments import EnvironmentFactory
+        from src.utils.hardware_info import detect_worker_resources
+        from src.utils.metrics import WorkloadType, create_metric_config
+        from src.utils.scoring.workload_features import WorkloadFeatureExtractor
+
+        base_dir = Path(self.base_dir)
+
+        # One worker per device => detect resources for a single worker.
+        self._resources = detect_worker_resources(
+            max_parallel_workers=1, data_path=base_dir
+        )
+
+        knob_space = get_knob_space(
+            self.knob_tier,
+            knob_source=self.knob_source,
+            workload_type=req.workload_type,
+        )
+        knob_space.resolve_hardware_ranges(self._resources)
+        knob_space.worker_resources = self._resources
+        self._knob_space = knob_space
+
+        workload_type = (
+            WorkloadType.OLAP if req.benchmark == "tpch" else WorkloadType.OLTP
+        )
+        metric_config = create_metric_config(workload_type.value)
+
+        features_extractor = WorkloadFeatureExtractor()
+        if req.benchmark == "sysbench":
+            tables = req.tables or 10
+            table_size = req.table_size or 100000
+            script = req.workload_type
+            executor: Any = SysbenchExecutor(
+                tables=tables, table_size=table_size, script=script
+            )
+            metric_config.workload_features = features_extractor.extract_sysbench_features(
+                script=script,
+                threads=int(getattr(executor, "threads", 8)),
+                cpu_cores=int(self._resources.cpu_cores or 1),
+                table_size=table_size,
+                tables=tables,
+            )
+            run_id = f"sysbench_{script}_t{tables}_s{table_size}"
+        elif req.benchmark == "tpch":
+            scale_factor = req.scale_factor or 1.0
+            executor = TPCHExecutor(scale_factor=scale_factor)
+            run_id = f"tpch_sf{scale_factor}"
+        else:
+            raise NotImplementedError(
+                f"LocalDeviceBackend does not yet wire benchmark={req.benchmark!r}; "
+                "sysbench and tpch are supported."
+            )
+
+        import os
+
+        db_config = DatabaseConfig(
+            user=req.db_user,
+            password=os.getenv("DB_PASSWORD", ""),
+            host="127.0.0.1",
+            port=5440,
+            dbname=req.dbname,
+        )
+
+        env = EnvironmentFactory.create(
+            schema_provider=executor,
+            use_docker=req.use_docker,
+            base_dir=base_dir,
+            base_port=5440,
+            db_config=db_config,
+            worker_resources=self._resources,
+            run_id=run_id,
+            image_name=req.image_name,
+            force_recreate_baseline=req.force_recreate_baseline,
+        )
+        env.setup_instances(1)
+        env.initialize_schema(self.LOCAL_WORKER_ID)
+
+        orch_config = WorkloadOrchestratorConfig(
+            workload_type=workload_type,
+            metric_config=metric_config,
+            db_config=db_config,
+            worker_memory_budget_bytes=self._resources.ram_bytes,
+        )
+        orchestrator = WorkloadOrchestrator(orch_config, executor, env)
+
+        worker = Worker(
+            worker_id=self.global_worker_id,
+            knob_space=knob_space,
+            knob_config={},
+            db_config=env.get_db_config(self.LOCAL_WORKER_ID),
+            port=env.get_db_config(self.LOCAL_WORKER_ID).port,
+        )
+
+        self._env = env
+        self._orchestrator = orchestrator
+        self._worker = worker
+        cfg = env.get_db_config(self.LOCAL_WORKER_ID)
+        self._port = cfg.port
+        self._data_dir = str(getattr(env, "base_dir", base_dir))
+        self._backend_name = env.__class__.__name__
+
+        return SetupResponse(
+            ok=True,
+            port=self._port,
+            data_dir=self._data_dir,
+            backend=self._backend_name,
+            resources=self._serialize_resources(),
+        )
+
+    def _serialize_resources(self) -> Dict[str, Any]:
+        """Serialise the device's detected WorkerResources for the coordinator."""
+        import dataclasses
+
+        if self._resources is None:
+            return {}
+        try:
+            return dataclasses.asdict(self._resources)
+        except TypeError:
+            # Not a dataclass for some reason — fall back to a minimal view.
+            return {
+                "ram_bytes": getattr(self._resources, "ram_bytes", 0),
+                "cpu_cores": getattr(self._resources, "cpu_cores", 0),
+                "disk_type": getattr(self._resources, "disk_type", "unknown"),
+            }
+
+    def create_snapshot(self) -> str:
+        self._require_setup()
+        self._snapshot_id = self._env.create_snapshot(self.LOCAL_WORKER_ID)
+        return self._snapshot_id
+
+    def reset(self, snapshot_id: str) -> None:
+        self._require_setup()
+        self._env.restore_snapshot(self.LOCAL_WORKER_ID, snapshot_id or "")
+
+    def run_eval(
+        self, req: RunEvalRequest
+    ) -> Tuple[Dict[str, Any], bool, Dict[str, Any], Optional[Dict[str, Any]]]:
+        self._require_setup()
+        worker = self._worker
+        worker.knob_config = dict(req.knob_config)
+
+        # Optional coordinator-issued synchronised start: hold until the shared
+        # epoch so every device begins its evaluation at the same wall-clock.
+        # (An extra fairness guard against shared infrastructure; on a truly
+        # shared-nothing identical fleet fairness already holds without it.)
+        if req.measurement_start_epoch is not None:
+            import time as _time
+
+            delay = req.measurement_start_epoch - _time.time()
+            if delay > 0:
+                _time.sleep(min(delay, 300.0))
+
+        metrics, _score, restart_occurred, actual_cfg, recorder = (
+            self._orchestrator.evaluate_worker(
+                worker,
+                apply_config=req.apply_config,
+                generation=req.generation,
+                barriers=None,
+                restore_due=req.restore_due,
+                next_eval_will_restore=req.next_eval_will_restore,
+            )
+        )
+        timing = None
+        to_dict = getattr(recorder, "to_dict", None)
+        if callable(to_dict):
+            try:
+                timing = to_dict()
+            except Exception:  # noqa: BLE001 — timing is best-effort telemetry
+                timing = None
+        return metrics.to_dict(), bool(restart_occurred), dict(actual_cfg or {}), timing
+
+    def cleanup(self, remove_data: bool) -> None:
+        if self._env is not None:
+            self._env.cleanup(remove_data=remove_data)
+
+    # -- introspection ---------------------------------------------------- #
+    def pg_running(self) -> bool:
+        return self._env is not None
+
+    def pg_server_version(self) -> Optional[str]:
+        return getattr(self._env, "pg_server_version", None) if self._env else None
+
+    def backend_name(self) -> Optional[str]:
+        return self._backend_name or None
+
+    def hardware(self) -> Dict[str, Any]:
+        if self._resources is None:
+            return {}
+        return {
+            "cpu_cores": getattr(self._resources, "cpu_cores", None),
+            "ram_bytes": getattr(self._resources, "ram_bytes", None),
+            "disk_type": getattr(self._resources, "disk_type", None),
+        }
+
+    def _require_setup(self) -> None:
+        if self._env is None or self._orchestrator is None or self._worker is None:
+            raise RuntimeError("backend not set up; call /setup first")
+
+
+# --------------------------------------------------------------------------- #
+# CLI entrypoint
+# --------------------------------------------------------------------------- #
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="PBT distributed device agent")
+    parser.add_argument("--worker-id", type=int, required=True)
+    parser.add_argument("--host", default="0.0.0.0")
+    parser.add_argument("--port", type=int, default=8770)
+    parser.add_argument("--knob-tier", default="core")
+    parser.add_argument("--knob-source", default="expert")
+    parser.add_argument("--base-dir", default="./.instances")
+    parser.add_argument(
+        "--log-level", default="INFO", choices=["DEBUG", "INFO", "WARNING", "ERROR"]
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=getattr(logging, args.log_level),
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    backend = LocalDeviceBackend(
+        global_worker_id=args.worker_id,
+        knob_tier=args.knob_tier,
+        base_dir=args.base_dir,
+        knob_source=args.knob_source,
+    )
+    agent = DeviceAgent(args.worker_id, backend, args.host, args.port)
+    agent.serve_forever()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/tuners/distributed/inventory.py
+++ b/src/tuners/distributed/inventory.py
@@ -1,0 +1,298 @@
+# Copyright (C) 2026 Ibrahim Al-Shawa and PBTune contributors
+# Licensed under the GNU General Public License v3.0
+# See LICENSE file for details
+
+"""
+Fleet Inventory
+===============
+
+Parses the ``devices.yaml`` inventory that describes the physical device fleet
+used by distributed tuning. Each device hosts exactly one PostgreSQL instance
+and is mapped to exactly one population worker (by list order).
+
+Example ``devices.yaml``
+------------------------
+
+.. code-block:: yaml
+
+    # Fleet-wide defaults (each device may override any of these).
+    fleet:
+      agent_port: 8770          # HTTP port the device agent listens on
+      ssh_user: pbt             # SSH user used for bootstrap (Phase 3)
+      ssh_key: ~/.ssh/id_rsa    # SSH private key path
+      data_dir: /var/lib/pbt    # remote base dir for PG instance data
+      python: python3           # remote interpreter used to launch the agent
+
+    devices:
+      - host: 10.0.0.11
+      - host: 10.0.0.12
+        agent_port: 8771        # per-device override
+      - host: 10.0.0.13
+        ssh_user: ubuntu
+
+Design notes
+------------
+- ``worker_id`` is assigned implicitly from list order (0, 1, 2, …) so a device's
+  identity is stable across a run without the user having to number them.
+- Validation is intentionally strict and fails fast: a malformed inventory is a
+  configuration error the operator should fix before a (potentially long) run.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import yaml
+
+
+class InventoryError(ValueError):
+    """Raised when a ``devices.yaml`` inventory is missing or malformed."""
+
+
+# Fleet-level default keys and their built-in fallbacks. Per-device entries may
+# override any of these; anything absent everywhere falls back to these values.
+_FLEET_DEFAULTS: Dict[str, Any] = {
+    "agent_port": 8770,
+    "ssh_user": None,
+    "ssh_key": None,
+    "data_dir": "/var/lib/pbt",
+    "python": "python3",
+    "agent_scheme": "http",
+}
+
+# Keys a per-device entry is allowed to carry (besides the mandatory ``host``).
+_DEVICE_OVERRIDE_KEYS = frozenset(
+    {"agent_port", "ssh_user", "ssh_key", "data_dir", "python", "agent_scheme", "label"}
+)
+
+
+@dataclass
+class DeviceSpec:
+    """A single device in the fleet, bound to one worker.
+
+    Attributes
+    ----------
+    worker_id:
+        Population worker index this device is responsible for (list order).
+    host:
+        Hostname or IP the coordinator uses to reach the device agent (and,
+        transitively, its PostgreSQL instance).
+    agent_port:
+        TCP port the device's HTTP agent listens on.
+    ssh_user, ssh_key:
+        Credentials used by the Phase 3 bootstrap to provision/launch the agent
+        over SSH. Unused by the coordinator's runtime RPC path.
+    data_dir:
+        Remote base directory under which the agent stores the instance's data.
+    python:
+        Remote interpreter used to launch the agent during bootstrap.
+    agent_scheme:
+        ``http`` (default) or ``https``.
+    label:
+        Optional human-friendly name for logs/reports (defaults to ``host``).
+    """
+
+    worker_id: int
+    host: str
+    agent_port: int = 8770
+    ssh_user: Optional[str] = None
+    ssh_key: Optional[str] = None
+    data_dir: str = "/var/lib/pbt"
+    python: str = "python3"
+    agent_scheme: str = "http"
+    label: Optional[str] = None
+
+    @property
+    def display_name(self) -> str:
+        """Human-friendly identifier for logs and reports."""
+        return self.label or self.host
+
+    @property
+    def agent_base_url(self) -> str:
+        """Base URL of the device agent, e.g. ``http://10.0.0.11:8770``."""
+        return f"{self.agent_scheme}://{self.host}:{self.agent_port}"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "worker_id": self.worker_id,
+            "host": self.host,
+            "agent_port": self.agent_port,
+            "ssh_user": self.ssh_user,
+            "ssh_key": self.ssh_key,
+            "data_dir": self.data_dir,
+            "python": self.python,
+            "agent_scheme": self.agent_scheme,
+            "label": self.label,
+        }
+
+
+@dataclass
+class FleetInventory:
+    """An ordered fleet of devices, one per worker."""
+
+    devices: List[DeviceSpec] = field(default_factory=list)
+    source_path: Optional[Path] = None
+
+    def __len__(self) -> int:
+        return len(self.devices)
+
+    @property
+    def size(self) -> int:
+        """Number of devices == maximum supported population size."""
+        return len(self.devices)
+
+    def device_for_worker(self, worker_id: int) -> DeviceSpec:
+        """Return the device bound to ``worker_id``.
+
+        Raises
+        ------
+        InventoryError
+            If ``worker_id`` has no device (population larger than the fleet).
+        """
+        if worker_id < 0 or worker_id >= len(self.devices):
+            raise InventoryError(
+                f"No device for worker_id={worker_id}; fleet has "
+                f"{len(self.devices)} device(s) (valid worker ids 0..{len(self.devices) - 1})"
+            )
+        return self.devices[worker_id]
+
+    def validate_for_population(self, population_size: int) -> None:
+        """Ensure the fleet can host ``population_size`` workers.
+
+        One worker per device is a hard requirement of distributed mode
+        (fairness: no co-tenancy). The fleet may be *larger* than the
+        population — extra devices are simply unused.
+
+        Raises
+        ------
+        InventoryError
+            If there are fewer devices than workers.
+        """
+        if population_size > len(self.devices):
+            raise InventoryError(
+                f"Distributed mode needs one device per worker: population_size="
+                f"{population_size} but the inventory only lists {len(self.devices)} "
+                f"device(s). Add more devices to {self.source_path or 'the inventory'} "
+                f"or reduce --population."
+            )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "source_path": str(self.source_path) if self.source_path else None,
+            "devices": [d.to_dict() for d in self.devices],
+        }
+
+
+def _coerce_agent_port(value: Any, *, context: str) -> int:
+    try:
+        port = int(value)
+    except (TypeError, ValueError) as exc:
+        raise InventoryError(f"{context}: agent_port must be an integer, got {value!r}") from exc
+    if not (1 <= port <= 65535):
+        raise InventoryError(f"{context}: agent_port {port} is out of range 1..65535")
+    return port
+
+
+def _expand_key_path(value: Optional[str]) -> Optional[str]:
+    """Expand ``~`` and env vars in an SSH key path, leaving None untouched."""
+    if value is None:
+        return None
+    return os.path.expandvars(os.path.expanduser(str(value)))
+
+
+def parse_inventory(raw: Dict[str, Any], *, source_path: Optional[Path] = None) -> FleetInventory:
+    """Build a :class:`FleetInventory` from an already-loaded YAML mapping.
+
+    Separated from :func:`load_inventory` so it can be unit-tested without disk.
+    """
+    if not isinstance(raw, dict):
+        raise InventoryError("Inventory root must be a mapping with a 'devices' key")
+
+    fleet_raw = raw.get("fleet", {}) or {}
+    if not isinstance(fleet_raw, dict):
+        raise InventoryError("'fleet' section must be a mapping")
+
+    unknown_fleet = set(fleet_raw) - set(_FLEET_DEFAULTS)
+    if unknown_fleet:
+        raise InventoryError(
+            f"Unknown key(s) in 'fleet' section: {sorted(unknown_fleet)}. "
+            f"Allowed: {sorted(_FLEET_DEFAULTS)}"
+        )
+
+    defaults = dict(_FLEET_DEFAULTS)
+    defaults.update(fleet_raw)
+
+    devices_raw = raw.get("devices")
+    if not isinstance(devices_raw, list) or not devices_raw:
+        raise InventoryError("'devices' must be a non-empty list")
+
+    seen_endpoints: set[tuple[str, int]] = set()
+    devices: List[DeviceSpec] = []
+    for worker_id, entry in enumerate(devices_raw):
+        if not isinstance(entry, dict):
+            raise InventoryError(
+                f"devices[{worker_id}] must be a mapping (got {type(entry).__name__})"
+            )
+        host = entry.get("host")
+        if not host or not isinstance(host, str):
+            raise InventoryError(f"devices[{worker_id}] is missing a valid 'host'")
+
+        unknown = set(entry) - _DEVICE_OVERRIDE_KEYS - {"host"}
+        if unknown:
+            raise InventoryError(
+                f"devices[{worker_id}] ({host}) has unknown key(s): {sorted(unknown)}. "
+                f"Allowed: {sorted(_DEVICE_OVERRIDE_KEYS | {'host'})}"
+            )
+
+        merged = {k: entry.get(k, defaults.get(k)) for k in _DEVICE_OVERRIDE_KEYS}
+        agent_port = _coerce_agent_port(
+            merged["agent_port"], context=f"devices[{worker_id}] ({host})"
+        )
+
+        endpoint = (host, agent_port)
+        if endpoint in seen_endpoints:
+            raise InventoryError(
+                f"Duplicate device endpoint {host}:{agent_port} — each device must "
+                f"expose a unique host:agent_port"
+            )
+        seen_endpoints.add(endpoint)
+
+        devices.append(
+            DeviceSpec(
+                worker_id=worker_id,
+                host=host,
+                agent_port=agent_port,
+                ssh_user=merged["ssh_user"],
+                ssh_key=_expand_key_path(merged["ssh_key"]),
+                data_dir=str(merged["data_dir"]),
+                python=str(merged["python"]),
+                agent_scheme=str(merged["agent_scheme"]),
+                label=merged.get("label"),
+            )
+        )
+
+    return FleetInventory(devices=devices, source_path=source_path)
+
+
+def load_inventory(path: str | os.PathLike[str]) -> FleetInventory:
+    """Load and validate a ``devices.yaml`` inventory from disk.
+
+    Raises
+    ------
+    InventoryError
+        If the file is missing, unreadable, or malformed.
+    """
+    p = Path(path).expanduser()
+    if not p.is_file():
+        raise InventoryError(f"Inventory file not found: {p}")
+    try:
+        with p.open("r", encoding="utf-8") as fh:
+            raw = yaml.safe_load(fh)
+    except yaml.YAMLError as exc:
+        raise InventoryError(f"Failed to parse YAML inventory {p}: {exc}") from exc
+    if raw is None:
+        raise InventoryError(f"Inventory file {p} is empty")
+    return parse_inventory(raw, source_path=p)

--- a/src/tuners/distributed/remote_environment.py
+++ b/src/tuners/distributed/remote_environment.py
@@ -1,0 +1,319 @@
+# Copyright (C) 2026 Ibrahim Al-Shawa and PBTune contributors
+# Licensed under the GNU General Public License v3.0
+# See LICENSE file for details
+
+"""
+Remote Environment
+==================
+
+A :class:`~src.utils.environments.base.DatabaseEnvironment` implementation that
+represents the whole fleet from the coordinator's point of view. Every
+lifecycle call is proxied to the owning device's HTTP agent, so the existing
+``Population`` orchestration works unchanged — it only ever sees the ABC.
+
+Key distributed semantics
+-------------------------
+- **One worker per device.** ``setup_instances`` fans out ``/setup`` to each
+  agent; each returns the port of its single local PostgreSQL instance.
+- **Per-substep restart/start/stop are on-device.** The device's own
+  orchestrator drives them inside ``run_eval``; the coordinator's copies are
+  no-ops.
+- **Snapshot = every device snapshots its own identical baseline.**
+  ``create_snapshot`` fans out so each device holds a local base snapshot.
+- **Clone = config-only.** The elite's *knobs* are copied in-memory by the
+  evolution step (coordinator RAM); ``clone_instances`` merely tells each
+  target device to reset its data to the byte-identical local baseline — no
+  gigabyte PGDATA transfer over the network.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from src.config.database import DatabaseConfig
+from src.tuners.distributed.agent_api import (
+    CleanupRequest,
+    HealthResponse,
+    ResetRequest,
+    ROUTES,
+    SetupRequest,
+    SetupResponse,
+    SnapshotResponse,
+)
+from src.tuners.distributed.inventory import DeviceSpec
+from src.tuners.distributed.transport import AgentClient, AgentRPCError
+from src.utils.environments.base import DatabaseEnvironment, InstanceConfig
+from src.utils.logger import get_logger
+
+LOGGER = get_logger("RemoteEnvironment")
+
+
+class RemoteEnvironment(DatabaseEnvironment):
+    """Fleet-wide environment backed by per-device HTTP agents."""
+
+    def __init__(
+        self,
+        run_id: str,
+        db_config: DatabaseConfig,
+        schema_provider: Any,
+        clients: Dict[int, AgentClient],
+        devices: Dict[int, DeviceSpec],
+        setup_template: SetupRequest,
+        request_timeout_s: float = 60.0,
+        force_recreate_baseline: bool = False,
+    ):
+        super().__init__(
+            run_id=run_id,
+            db_config=db_config,
+            schema_provider=schema_provider,
+            force_recreate_baseline=force_recreate_baseline,
+        )
+        self._clients = clients
+        self._devices = devices
+        self._setup_template = setup_template
+        self._request_timeout_s = request_timeout_s
+        self._instances: Dict[int, InstanceConfig] = {}
+        self._hardware: Dict[int, Dict[str, Any]] = {}
+        self._device_resources: Dict[int, Dict[str, Any]] = {}
+        self.docker_version = None
+
+    # -- helpers ---------------------------------------------------------- #
+    def _client(self, worker_id: int) -> AgentClient:
+        try:
+            return self._clients[worker_id]
+        except KeyError as exc:
+            raise RuntimeError(f"No agent for worker_id={worker_id}") from exc
+
+    def _worker_ids(self) -> List[int]:
+        return sorted(self._clients.keys())
+
+    def _fan_out(self, fn, worker_ids: Optional[List[int]] = None) -> Dict[int, Any]:
+        """Run ``fn(worker_id)`` concurrently across devices; collect results."""
+        ids = worker_ids if worker_ids is not None else self._worker_ids()
+        results: Dict[int, Any] = {}
+        with ThreadPoolExecutor(max_workers=max(1, len(ids))) as pool:
+            futures = {pool.submit(fn, wid): wid for wid in ids}
+            for fut in as_completed(futures):
+                wid = futures[fut]
+                results[wid] = fut.result()
+        return results
+
+    # -- lifecycle -------------------------------------------------------- #
+    def setup_instances(
+        self,
+        num_workers: int,
+        force_recreate: bool = False,
+        num_parallel_workers: int = 1,
+    ) -> List[InstanceConfig]:
+        if num_workers > len(self._clients):
+            raise RuntimeError(
+                f"Requested {num_workers} workers but only {len(self._clients)} "
+                f"device agents are registered"
+            )
+
+        def _setup(worker_id: int) -> SetupResponse:
+            req = SetupRequest.from_dict(self._setup_template.to_dict())
+            if force_recreate:
+                req.force_recreate_baseline = True
+            resp = SetupResponse.from_dict(
+                self._client(worker_id).post(
+                    ROUTES["setup"], req.to_dict(), timeout=None
+                )
+            )
+            if not resp.ok:
+                raise RuntimeError(
+                    f"Device setup failed for worker {worker_id}: {resp.detail}"
+                )
+            return resp
+
+        results = self._fan_out(_setup, list(range(num_workers)))
+        for worker_id in range(num_workers):
+            resp = results[worker_id]
+            device = self._devices[worker_id]
+            self._instances[worker_id] = InstanceConfig(
+                worker_id=worker_id,
+                port=resp.port,
+                data_dir=Path(resp.data_dir or "/"),
+                running=True,
+                host=device.host,
+            )
+            if resp.resources:
+                self._device_resources[worker_id] = resp.resources
+            LOGGER.info(
+                "➤ Worker %d ready on %s:%d (%s)",
+                worker_id,
+                device.host,
+                resp.port,
+                resp.backend,
+            )
+        return [self._instances[w] for w in range(num_workers)]
+
+    def initialize_schema(self, worker_id: int) -> None:
+        """No-op on the coordinator: schema is prepared on each device during
+        its local ``/setup`` (the base implementation would connect directly to
+        the remote PostgreSQL, which the coordinator cannot reach)."""
+        return None
+
+    def representative_resources(self) -> Optional[Dict[str, Any]]:
+        """Return one device's detected resources (identical fleet ⇒ any device).
+
+        Used by the coordinator to resolve hardware-aware knob ranges against the
+        *device* hardware instead of its own. Returns ``None`` if no device has
+        reported resources yet (e.g. before ``setup_instances``).
+        """
+        if not self._device_resources:
+            return None
+        return self._device_resources[min(self._device_resources)]
+
+    # Per-instance process control lives on the device (driven by its own
+    # orchestrator during run_eval); the coordinator's copies are no-ops.
+    def start_instance(self, worker_id: int) -> bool:
+        return True
+
+    def stop_instance(self, worker_id: int, mode: str = "fast") -> bool:
+        return True
+
+    def stop_all(self, mode: str = "fast") -> bool:
+        return True
+
+    def restart_instance(self, worker_id: int, quiet: bool = False) -> bool:
+        return True
+
+    def recover_instance(self, worker_id: int) -> bool:
+        """Best-effort recovery: re-run setup on the device."""
+        try:
+            return self.rebuild_worker_instance(worker_id)
+        except AgentRPCError as exc:
+            LOGGER.warning("Recovery of worker %d failed: %s", worker_id, exc)
+            return False
+
+    def verify_instances(self) -> None:
+        def _health(worker_id: int) -> HealthResponse:
+            return HealthResponse.from_dict(
+                self._client(worker_id).get(
+                    ROUTES["health"], timeout=self._request_timeout_s
+                )
+            )
+
+        results = self._fan_out(_health)
+        unhealthy = []
+        for worker_id, health in results.items():
+            self._hardware[worker_id] = health.hardware or {}
+            if health.status != "ok":
+                unhealthy.append((worker_id, health.status, health.detail))
+        if unhealthy:
+            raise RuntimeError(f"Unhealthy device agents: {unhealthy}")
+
+    def cleanup(self, remove_data: bool = False) -> None:
+        def _cleanup(worker_id: int) -> None:
+            client = self._client(worker_id)
+            try:
+                client.post(
+                    ROUTES["cleanup"],
+                    CleanupRequest(remove_data=remove_data).to_dict(),
+                    timeout=self._request_timeout_s,
+                )
+            except AgentRPCError as exc:
+                LOGGER.warning("Cleanup failed for worker %d: %s", worker_id, exc)
+
+        self._fan_out(_cleanup)
+
+    # -- snapshots / clone ------------------------------------------------ #
+    def create_snapshot(self, worker_id: int = 0) -> str:
+        """Every device snapshots its own identical baseline.
+
+        ``worker_id`` is ignored on purpose: in distributed mode the baseline
+        must exist on *every* device so any device can later ``/reset`` to it.
+        Returns the snapshot id reported by the lowest-numbered device.
+        """
+        def _snap(wid: int) -> str:
+            return SnapshotResponse.from_dict(
+                self._client(wid).post(ROUTES["snapshot"], {}, timeout=None)
+            ).snapshot_id
+
+        results = self._fan_out(_snap)
+        first = min(results)
+        return results[first]
+
+    def restore_snapshot(
+        self, worker_id: int, snapshot_id: str = "", quiet: bool = False
+    ) -> bool:
+        try:
+            self._client(worker_id).post(
+                ROUTES["reset"],
+                ResetRequest(snapshot_id=snapshot_id).to_dict(),
+                timeout=None,
+            )
+            return True
+        except AgentRPCError as exc:
+            LOGGER.warning("Snapshot restore failed for worker %d: %s", worker_id, exc)
+            return False
+
+    def clone_instances(
+        self, source_worker_id: int, target_worker_ids: List[int]
+    ) -> bool:
+        """Config-only clone: reset each target device to its local baseline.
+
+        The elite's knob configuration has already been copied into each target
+        worker in coordinator RAM by the evolution step; here we only ensure the
+        target's *data* is the byte-identical benchmark baseline again.
+        """
+        def _reset(wid: int) -> bool:
+            return self.restore_snapshot(wid, "")
+
+        results = self._fan_out(_reset, list(target_worker_ids))
+        return all(results.values())
+
+    def rebuild_worker_instance(self, worker_id: int) -> bool:
+        req = SetupRequest.from_dict(self._setup_template.to_dict())
+        req.force_recreate_baseline = True
+        resp = SetupResponse.from_dict(
+            self._client(worker_id).post(ROUTES["setup"], req.to_dict(), timeout=None)
+        )
+        if resp.ok:
+            device = self._devices[worker_id]
+            self._instances[worker_id] = InstanceConfig(
+                worker_id=worker_id,
+                port=resp.port,
+                data_dir=Path(resp.data_dir or "/"),
+                running=True,
+                host=device.host,
+            )
+        return resp.ok
+
+    # -- config / metrics ------------------------------------------------- #
+    def get_db_config(self, worker_id: int) -> DatabaseConfig:
+        device = self._devices[worker_id]
+        instance = self._instances.get(worker_id)
+        port = instance.port if instance else 5440
+        return DatabaseConfig(
+            user=self.base_config.user,
+            password=self.base_config.password,
+            host=device.host,
+            port=port,
+            dbname=self.base_config.dbname,
+        )
+
+    def collect_memory_utilization(self, worker_id: int) -> float:
+        # Memory utilisation is measured on-device and already embedded in the
+        # returned PerformanceMetrics, so there is nothing to collect centrally.
+        return 0.0
+
+    def get_resource_allocations(self):
+        from src.utils.types import WorkerResourceAllocation
+
+        allocations = []
+        for worker_id in self._worker_ids():
+            hw = self._hardware.get(worker_id, {})
+            allocations.append(
+                WorkerResourceAllocation(
+                    worker_id=worker_id,
+                    cpu_cores=int(hw.get("cpu_cores") or 0) or 1,
+                    cpuset_cpus=None,
+                    ram_bytes=int(hw.get("ram_bytes") or 0),
+                    docker_memory_limit_bytes=None,
+                )
+            )
+        return allocations

--- a/src/tuners/distributed/remote_orchestrator.py
+++ b/src/tuners/distributed/remote_orchestrator.py
@@ -1,0 +1,150 @@
+# Copyright (C) 2026 Ibrahim Al-Shawa and PBTune contributors
+# Licensed under the GNU General Public License v3.0
+# See LICENSE file for details
+
+"""
+Remote Workload Orchestrator
+============================
+
+Coordinator-side ``WorkloadOrchestrator`` whose ``evaluate_worker`` dispatches
+the actual apply→run→measure work to the device that owns the worker (over
+HTTP/JSON RPC) and then **scores centrally**.
+
+Central scoring is deliberate: the composite scorer's adaptive normalisation
+must see the whole population's metrics together, exactly as in single-device
+mode. Devices therefore return raw :class:`PerformanceMetrics`; the score is
+computed here with the same ``engine.compute_breakdown`` call the local
+orchestrator uses (orchestrator.py), so scores are identical in meaning.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any, Dict, Optional
+
+from src.tuners.engine.orchestrator import (
+    WorkloadOrchestrator,
+    WorkloadOrchestratorConfig,
+)
+from src.tuners.engine.worker import BaseWorker
+from src.tuners.distributed.agent_api import ROUTES, RunEvalRequest, RunEvalResponse
+from src.tuners.distributed.transport import AgentClient, AgentRPCError
+from src.utils.metrics import PerformanceMetrics
+from src.utils.timing import TimingRecorder
+
+
+def metrics_from_dict(d: Dict[str, Any]) -> PerformanceMetrics:
+    """Reconstruct :class:`PerformanceMetrics` from its ``to_dict`` payload.
+
+    Filters to known dataclass fields so protocol-forward extra keys are
+    ignored rather than raising.
+    """
+    valid = {f.name for f in dataclasses.fields(PerformanceMetrics)}
+    return PerformanceMetrics(**{k: v for k, v in d.items() if k in valid})
+
+
+def _recorder_from_timing(timing: Optional[Dict[str, Any]]) -> TimingRecorder:
+    """Best-effort reconstruction of a TimingRecorder from a serialised dict.
+
+    Distributed timing provenance is thinner than local mode's; if the payload
+    can't be rehydrated we fall back to a fresh recorder so downstream code
+    (which only reads/serialises it) never sees ``None``.
+    """
+    from_dict = getattr(TimingRecorder, "from_dict", None)
+    if timing and callable(from_dict):
+        try:
+            return from_dict(timing)
+        except Exception:  # noqa: BLE001 — telemetry only
+            pass
+    return TimingRecorder()
+
+
+class RemoteWorkloadOrchestrator(WorkloadOrchestrator):
+    """Runs evaluations on remote devices; scores on the coordinator."""
+
+    def __init__(
+        self,
+        config: WorkloadOrchestratorConfig,
+        workload_executor: Any,
+        env: Any,
+        clients: Dict[int, AgentClient],
+        eval_timeout_s: float = 1800.0,
+        dead_failure_type: str = "EXECUTION_CRASH",
+    ):
+        super().__init__(config, workload_executor, env)
+        self._clients = clients
+        self._eval_timeout_s = eval_timeout_s
+        self._dead_failure_type = dead_failure_type
+
+    def _client_for(self, worker_id: int) -> AgentClient:
+        try:
+            return self._clients[worker_id]
+        except KeyError as exc:
+            raise RuntimeError(
+                f"No device agent registered for worker_id={worker_id}"
+            ) from exc
+
+    def evaluate_worker(
+        self,
+        worker: BaseWorker,
+        apply_config: bool = True,
+        generation: Optional[int] = None,
+        barriers: Optional[Any] = None,
+        random_seed: Optional[int] = None,
+        restore_due: bool = False,
+        next_eval_will_restore: bool = False,
+    ) -> tuple[PerformanceMetrics, float, bool, Dict[str, Any], TimingRecorder]:
+        """Dispatch the evaluation to the owning device, then score centrally.
+
+        ``barriers`` is accepted for signature compatibility but ignored:
+        the B1–B17 substep lockstep runs *locally on each device*, and the
+        coordinator's only synchronisation point is the generation boundary
+        (the ThreadPoolExecutor join in ``Population.evaluate_generation``).
+        Distributed runs therefore set ``synchronize_workers=False``.
+        """
+        client = self._client_for(worker.worker_id)
+        req = RunEvalRequest(
+            knob_config=dict(worker.knob_config or {}),
+            generation=int(generation or 0),
+            apply_config=apply_config,
+            restore_due=restore_due,
+            next_eval_will_restore=next_eval_will_restore,
+        )
+
+        restart_occurred = False
+        actual_config: Dict[str, Any] = {}
+        timing: Optional[Dict[str, Any]] = None
+        try:
+            resp = RunEvalResponse.from_dict(
+                client.post(
+                    ROUTES["run_eval"], req.to_dict(), timeout=self._eval_timeout_s
+                )
+            )
+            if resp.ok and resp.metrics is not None:
+                metrics = metrics_from_dict(resp.metrics)
+                restart_occurred = resp.restart_occurred
+                actual_config = resp.actual_config
+                timing = resp.timing
+            else:
+                worker.logger.error(
+                    " ➤ Remote eval reported failure: %s", resp.error or "unknown"
+                )
+                metrics = PerformanceMetrics(failure_type=self._dead_failure_type)
+        except AgentRPCError as exc:
+            # Transport/timeout/HTTP error => treat as a dead worker and let the
+            # standard population rescue path (resample / config-clone) recover.
+            worker.logger.error(" ➤ Remote eval RPC failed: %s", exc)
+            metrics = PerformanceMetrics(failure_type=self._dead_failure_type)
+
+        engine = self._get_scoring_engine()
+        score_breakdown = engine.compute_breakdown(metrics, worker_logger=worker.logger)
+        worker.score_breakdown = score_breakdown
+        score = score_breakdown.final_score
+
+        return (
+            metrics,
+            score,
+            restart_occurred,
+            actual_config,
+            _recorder_from_timing(timing),
+        )

--- a/src/tuners/distributed/transport.py
+++ b/src/tuners/distributed/transport.py
@@ -1,0 +1,149 @@
+# Copyright (C) 2026 Ibrahim Al-Shawa and PBTune contributors
+# Licensed under the GNU General Public License v3.0
+# See LICENSE file for details
+
+"""
+RPC Transport
+=============
+
+Thin, dependency-free HTTP/JSON transport shared by the coordinator (client)
+and the device agent (server). Uses only the Python standard library
+(``urllib``, ``http.server``, ``json``) in keeping with this repo's
+minimal-dependency philosophy — the API surface between coordinator and agent
+is small (seven endpoints on a trusted network), so a full web framework would
+be overkill.
+
+Client: :class:`AgentClient`.
+Server helpers: :func:`read_json_body`, :func:`write_json` (used by
+``device_agent``'s ``BaseHTTPRequestHandler``).
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from typing import Any, Dict, Optional
+
+from src.tuners.distributed.agent_api import ErrorResponse
+
+
+class AgentRPCError(RuntimeError):
+    """Raised when an agent RPC fails (transport error or non-2xx response)."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status: Optional[int] = None,
+        error: Optional[ErrorResponse] = None,
+        url: Optional[str] = None,
+    ):
+        super().__init__(message)
+        self.status = status
+        self.error = error
+        self.url = url
+
+
+class AgentClient:
+    """Minimal JSON-over-HTTP client for a single device agent.
+
+    Parameters
+    ----------
+    base_url:
+        e.g. ``http://10.0.0.11:8770``.
+    default_timeout:
+        Fallback per-request timeout (seconds) when a call doesn't specify one.
+    """
+
+    def __init__(self, base_url: str, default_timeout: float = 60.0):
+        self.base_url = base_url.rstrip("/")
+        self.default_timeout = default_timeout
+
+    def _request(
+        self,
+        method: str,
+        route: str,
+        payload: Optional[Dict[str, Any]],
+        timeout: Optional[float],
+    ) -> Dict[str, Any]:
+        url = f"{self.base_url}{route}"
+        data = None
+        headers = {"Accept": "application/json"}
+        if payload is not None:
+            data = json.dumps(payload).encode("utf-8")
+            headers["Content-Type"] = "application/json"
+
+        req = urllib.request.Request(url, data=data, headers=headers, method=method)
+        try:
+            with urllib.request.urlopen(
+                req, timeout=timeout or self.default_timeout
+            ) as resp:
+                raw = resp.read().decode("utf-8") or "{}"
+                return json.loads(raw)
+        except urllib.error.HTTPError as exc:
+            body = {}
+            try:
+                body = json.loads(exc.read().decode("utf-8") or "{}")
+            except (ValueError, OSError):
+                pass
+            err = ErrorResponse.from_dict(body) if body else None
+            detail = err.error if err else exc.reason
+            raise AgentRPCError(
+                f"{method} {url} -> HTTP {exc.code}: {detail}",
+                status=exc.code,
+                error=err,
+                url=url,
+            ) from exc
+        except (urllib.error.URLError, TimeoutError, OSError) as exc:
+            reason = getattr(exc, "reason", exc)
+            raise AgentRPCError(
+                f"{method} {url} -> transport error: {reason}", url=url
+            ) from exc
+        except ValueError as exc:  # malformed JSON in a 2xx body
+            raise AgentRPCError(
+                f"{method} {url} -> invalid JSON response: {exc}", url=url
+            ) from exc
+
+    def get(self, route: str, *, timeout: Optional[float] = None) -> Dict[str, Any]:
+        return self._request("GET", route, None, timeout)
+
+    def post(
+        self,
+        route: str,
+        payload: Optional[Dict[str, Any]] = None,
+        *,
+        timeout: Optional[float] = None,
+    ) -> Dict[str, Any]:
+        return self._request("POST", route, payload or {}, timeout)
+
+
+# --------------------------------------------------------------------------- #
+# Server-side helpers (used by device_agent's request handler)
+# --------------------------------------------------------------------------- #
+def read_json_body(handler) -> Dict[str, Any]:
+    """Read and parse a JSON request body from a BaseHTTPRequestHandler.
+
+    Returns an empty dict when there is no body. Raises ``ValueError`` on
+    malformed JSON so the handler can reply 400.
+    """
+    length = int(handler.headers.get("Content-Length", 0) or 0)
+    if length <= 0:
+        return {}
+    raw = handler.rfile.read(length).decode("utf-8")
+    if not raw.strip():
+        return {}
+    parsed = json.loads(raw)
+    if not isinstance(parsed, dict):
+        raise ValueError("request body must be a JSON object")
+    return parsed
+
+
+def write_json(handler, status: int, obj: Dict[str, Any]) -> None:
+    """Serialise ``obj`` as JSON and write it as the HTTP response."""
+    body = json.dumps(obj).encode("utf-8")
+    handler.send_response(status)
+    handler.send_header("Content-Type", "application/json")
+    handler.send_header("Content-Length", str(len(body)))
+    handler.end_headers()
+    handler.wfile.write(body)

--- a/src/tuners/pbt/population.py
+++ b/src/tuners/pbt/population.py
@@ -365,8 +365,11 @@ class Population:
             instance = instances[worker.worker_id]
             worker.port = instance.port
 
+            # Host defaults to loopback for local backends; the distributed
+            # RemoteEnvironment stamps each InstanceConfig with its device's
+            # address so the worker binds to the correct host.
             worker.db_config = DatabaseConfig(
-                host="127.0.0.1",
+                host=getattr(instance, "host", "127.0.0.1"),
                 port=instance.port,
                 dbname=dbname,
                 user=user,

--- a/src/tuners/pbt/tuner.py
+++ b/src/tuners/pbt/tuner.py
@@ -129,6 +129,25 @@ class PBTTuner(BaseTuner):
         self.restart_count: int = 0
         self._restarted_this_generation: bool = False
 
+        # Distributed multi-device mode (populated in _create_environment()).
+        # Typed Any: the Coordinator/FleetBootstrapper classes are imported
+        # lazily inside _create_environment().
+        self._coordinator: Any = None
+        self._bootstrapper: Any = None
+        if self.lifecycle.distributed:
+            if not self.lifecycle.inventory:
+                raise TunerConfigError(
+                    "--distributed requires --inventory <devices.yaml>"
+                )
+            # One worker per dedicated device => no co-tenancy, so the B1–B17
+            # substep barriers (which only equalise co-tenancy) are pointless;
+            # the generation boundary is the sole sync point. Run the whole
+            # fleet concurrently — never batch.
+            self.lifecycle.synchronize_workers = False
+            self.pbt_config.synchronize_workers = False  # session provenance
+            if self.lifecycle.num_parallel_workers < self.pbt_config.population_size:
+                self.lifecycle.num_parallel_workers = self.pbt_config.population_size
+
     @property
     def max_rounds(self) -> int:
         """PBT runs a fixed number of generations."""
@@ -222,6 +241,188 @@ class PBTTuner(BaseTuner):
             len(initial_configs), len(initial_configs) - 1
         )
         return initial_configs[:population_size]
+
+    # ------------------------------------------------------------------
+    # Distributed lifecycle overrides (no-ops unless --distributed)
+    # ------------------------------------------------------------------
+    def _create_environment(self) -> None:
+        """Build the RemoteEnvironment + coordinator when distributed; else base.
+
+        No agents are contacted here — only local objects are built. The SSH
+        bootstrap and health handshake happen in :meth:`_bring_up_instances`.
+        """
+        if not self.lifecycle.distributed:
+            super()._create_environment()
+            return
+
+        from src.config.database import get_db_config
+        from src.tuners.distributed.agent_api import SetupRequest
+        from src.tuners.distributed.bootstrap import FleetBootstrapper
+        from src.tuners.distributed.config import DistributedConfig
+        from src.tuners.distributed.coordinator import Coordinator
+        from src.tuners.engine.orchestrator import WorkloadOrchestratorConfig
+
+        assert self.worker_resources is not None
+        # Guaranteed by the __init__ guard when distributed is set.
+        assert self.lifecycle.inventory is not None
+        db_config = get_db_config()
+        pop_size = self.pbt_config.population_size
+
+        dist_cfg = DistributedConfig.from_inventory_path(
+            self.lifecycle.inventory,
+            request_timeout_s=float(self.lifecycle.agent_timeout),
+            eval_timeout_s=float(self.lifecycle.eval_timeout),
+        )
+        dist_cfg.validate_for_population(pop_size)
+
+        bc = self.benchmark_config
+        if self.benchmark == "sysbench":
+            wl_str = bc.sysbench_workload
+        elif self.benchmark == "tpch":
+            wl_str = "olap"
+        else:
+            wl_str = self._workload_type.value
+        setup_template = SetupRequest(
+            run_id=self.snapshot_identifier,
+            benchmark=self.benchmark or "sysbench",
+            workload_type=wl_str,
+            use_docker=self.lifecycle.use_docker,
+            force_recreate_baseline=self.lifecycle.force_recreate_baseline,
+            tables=getattr(bc, "sysbench_tables", None),
+            table_size=getattr(bc, "sysbench_table_size", None),
+            scale_factor=getattr(bc, "scale_factor", None),
+            image_name=self.lifecycle.docker_image,
+            dbname=db_config.dbname,
+            db_user=db_config.user,
+        )
+
+        coordinator = Coordinator(dist_cfg, setup_template, db_config, pop_size)
+        self._coordinator = coordinator
+        if self.lifecycle.bootstrap:
+            self._bootstrapper = FleetBootstrapper(
+                inventory=dist_cfg.inventory,
+                population_size=pop_size,
+                local_repo_dir=str(Path(__file__).resolve().parents[3]),
+                knob_tier=self.lifecycle.knob_tier,
+                knob_source=self.lifecycle.knob_source,
+                install_deps=self.lifecycle.remote_install_deps,
+                env_exports=(
+                    {"DB_PASSWORD": db_config.password}
+                    if db_config.password
+                    else None
+                ),
+            )
+
+        self.env = coordinator.make_environment(
+            self._workload_executor, self.snapshot_identifier
+        )
+        orchestrator_config = WorkloadOrchestratorConfig(
+            workload_type=self._workload_type,
+            metric_config=self.metric_config,
+            db_config=db_config,
+            warmup_duration=self.benchmark_config.warmup_duration,
+            measurement_duration=self.benchmark_config.evaluation_duration,
+            cooldown_duration=3.0,
+            tuning_mode=self.lifecycle.tuning_mode,
+            adaptive_restart_interval=self.lifecycle.adaptive_restart_interval,
+            random_seed=self.lifecycle.random_seed,
+            warmup_passes=self.benchmark_config.warmup_passes,
+            worker_memory_budget_bytes=self.worker_resources.ram_bytes,
+        )
+        self.orchestrator = coordinator.make_orchestrator(
+            orchestrator_config, self._workload_executor, self.env
+        )
+
+    def _bring_up_instances(self) -> None:
+        """Bring up the device fleet when distributed; else the local flow."""
+        if not self.lifecycle.distributed:
+            super()._bring_up_instances()
+            return
+
+        from src.utils.hardware_info import get_system_info
+
+        self.system_info = get_system_info(data_path=self.data_root)
+        log_section_header(
+            LOGGER, "Bringing up distributed device fleet", top_separator=False
+        )
+
+        # SSH bootstrap (optional) + health/protocol handshake.
+        with self.bootstrap_timing.span("bootstrap_fleet"):
+            if self._bootstrapper is not None:
+                LOGGER.info("Bootstrapping device fleet over SSH...")
+                self._bootstrapper.bootstrap_all()
+            LOGGER.info("Waiting for device agents to report healthy...")
+            self._coordinator.wait_for_agents()
+
+        with self.bootstrap_timing.span("setup_instances"):
+            self._instances = self.env.setup_instances(
+                num_workers=self.num_instances,
+                force_recreate=self.lifecycle.force_recreate_instances,
+                num_parallel_workers=self.num_instances,
+            )
+        with self.bootstrap_timing.span("verify_instances"):
+            self.env.verify_instances()
+
+        # Resolve hardware-aware knob ranges from DEVICE hardware (reported by
+        # the agents), not the coordinator's — so the coordinator can run on any
+        # light machine.
+        self._resolve_device_hardware_ranges()
+
+        # Version-based knob pruning is skipped: the coordinator has no direct
+        # TCP path to the remote instances; the identical-fleet assumption holds
+        # (every device runs the same PostgreSQL).
+        LOGGER.info(
+            "Distributed mode: skipping direct-connection knob prune "
+            "(identical-fleet assumption)."
+        )
+        LOGGER.info(
+            "%s%sDevice fleet is ready.%s", COLORS.bold, COLORS.green, COLORS.reset
+        )
+
+    def _resolve_device_hardware_ranges(self) -> None:
+        """Re-resolve hardware-aware knob ranges from DEVICE hardware."""
+        import dataclasses
+
+        from src.utils.hardware_info import WorkerResources
+
+        get_res = getattr(self.env, "representative_resources", None)
+        res = get_res() if callable(get_res) else None
+        if not res:
+            LOGGER.warning(
+                "No device resources reported; keeping coordinator-derived knob "
+                "ranges. If coordinator hardware differs from the devices, pass "
+                "--worker-ram/--worker-cpus to match the fleet."
+            )
+            return
+        valid = {f.name for f in dataclasses.fields(WorkerResources)}
+        device_res = WorkerResources(**{k: v for k, v in res.items() if k in valid})
+        # Resolve knob ranges against device hardware. We intentionally do NOT
+        # reassign self.worker_resources (an inherited base attribute) here —
+        # the knob space carries the device resources directly.
+        self.full_knob_space.resolve_hardware_ranges(device_res)
+        self.knob_space.worker_resources = device_res
+        LOGGER.info(
+            "Resolved knob hardware ranges from DEVICE hardware "
+            "(RAM=%.1f GB, CPU=%s cores, disk=%s) — coordinator hardware ignored.",
+            (device_res.ram_bytes or 0) / 1e9,
+            device_res.cpu_cores,
+            device_res.disk_type,
+        )
+
+    def teardown(self) -> None:
+        """Stop instances, then shut the device fleet down (distributed only)."""
+        try:
+            super().teardown()
+        finally:
+            if getattr(self.lifecycle, "distributed", False) and getattr(
+                self, "_coordinator", None
+            ) is not None:
+                try:
+                    self._coordinator.shutdown_agents()
+                    if self._bootstrapper is not None:
+                        self._bootstrapper.teardown_all()
+                except (RuntimeError, OSError) as exc:
+                    LOGGER.warning("Device fleet shutdown issue: %s", exc)
 
     def build_optimizer(self) -> None:
         """Wire the :class:`Population` to the live instances and baseline snapshot.

--- a/src/tuners/utils/types.py
+++ b/src/tuners/utils/types.py
@@ -254,6 +254,16 @@ class TunerLifecycleConfig:
     scoring_policy_version: Optional[str] = None
     metric_reference_version: Optional[str] = None
 
+    # Distributed multi-device mode (see src/tuners/distributed/). When
+    # ``distributed`` is set, each worker runs on its own device via an HTTP
+    # agent; ``inventory`` points at the devices.yaml fleet description.
+    distributed: bool = False
+    inventory: Optional[str] = None
+    bootstrap: bool = True
+    remote_install_deps: bool = True
+    eval_timeout: float = 1800.0
+    agent_timeout: float = 60.0
+
     def __post_init__(self) -> None:
         self.strategy = TuningStrategy.from_value(self.strategy)
         if isinstance(self.tuning_mode, str):

--- a/src/utils/environments/base.py
+++ b/src/utils/environments/base.py
@@ -31,12 +31,18 @@ COLORS = get_color_context()
 
 @dataclass
 class InstanceConfig:
-    """Configuration for a single PostgreSQL instance."""
+    """Configuration for a single PostgreSQL instance.
+
+    ``host`` defaults to loopback so local (single-device) backends are
+    unchanged. The distributed :class:`RemoteEnvironment` sets it to the
+    owning device's address so workers bind to the right host.
+    """
 
     worker_id: int
     port: int
     data_dir: Path
     running: bool = False
+    host: str = "127.0.0.1"
 
 
 class DatabaseEnvironment(ABC):

--- a/tests/unit/tuners/distributed/test_bootstrap.py
+++ b/tests/unit/tuners/distributed/test_bootstrap.py
@@ -1,0 +1,98 @@
+"""Unit tests for the SSH bootstrap command builders (no network I/O)."""
+
+from src.tuners.distributed.bootstrap import (
+    RemoteLayout,
+    install_deps_command,
+    launch_agent_command,
+    rsync_command,
+    ssh_command,
+    stop_agent_command,
+)
+from src.tuners.distributed.inventory import DeviceSpec
+
+
+def _device(**kw):
+    base = dict(
+        worker_id=2,
+        host="10.0.0.13",
+        agent_port=8772,
+        ssh_user="pbt",
+        ssh_key="/home/u/.ssh/id_rsa",
+        data_dir="/var/lib/pbt",
+        python="python3",
+    )
+    base.update(kw)
+    return DeviceSpec(**base)
+
+
+def test_remote_layout_paths():
+    layout = RemoteLayout.for_device(_device())
+    assert layout.root == "/var/lib/pbt"
+    assert layout.code_dir == "/var/lib/pbt/code"
+    assert layout.instances_dir == "/var/lib/pbt/instances"
+    assert layout.pid_file.endswith("agent-worker-2.pid")
+    assert layout.log_file.endswith("agent-worker-2.log")
+
+
+def test_ssh_command_includes_key_and_target():
+    argv = ssh_command(_device(), "echo hi")
+    assert argv[0] == "ssh"
+    assert "-i" in argv and "/home/u/.ssh/id_rsa" in argv
+    assert "pbt@10.0.0.13" in argv
+    assert argv[-1] == "echo hi"
+    assert "BatchMode=yes" in argv
+
+
+def test_ssh_command_without_user_or_key():
+    argv = ssh_command(_device(ssh_user=None, ssh_key=None), "ls")
+    assert "10.0.0.13" in argv  # bare host, no user@
+    assert "-i" not in argv
+
+
+def test_rsync_command_has_excludes_and_trailing_slashes():
+    argv = rsync_command(_device(), "/local/repo", "/var/lib/pbt/code")
+    assert argv[0] == "rsync"
+    assert "--delete" in argv
+    # exclude patterns present
+    assert "--exclude" in argv and ".git" in argv and ".venv" in argv
+    # source has trailing slash; dest is host:dir/
+    assert argv[-2] == "/local/repo/"
+    assert argv[-1] == "pbt@10.0.0.13:/var/lib/pbt/code/"
+    # -e ssh string carries the key
+    e_idx = argv.index("-e")
+    assert "id_rsa" in argv[e_idx + 1]
+
+
+def test_launch_agent_command_wires_worker_and_port():
+    layout = RemoteLayout.for_device(_device())
+    cmd = launch_agent_command(_device(), layout, knob_tier="core")
+    assert "-m src.tuners.distributed.device_agent" in cmd
+    assert "--worker-id 2" in cmd
+    assert "--port 8772" in cmd
+    assert "--knob-tier core" in cmd
+    assert "--base-dir" in cmd and "/var/lib/pbt/instances" in cmd
+    assert "nohup" in cmd
+    assert layout.pid_file in cmd
+    assert layout.log_file in cmd
+
+
+def test_launch_agent_command_env_exports():
+    layout = RemoteLayout.for_device(_device())
+    cmd = launch_agent_command(
+        _device(), layout, knob_tier="core", env_exports={"DB_PASSWORD": "s3cret"}
+    )
+    assert "DB_PASSWORD=s3cret" in cmd
+
+
+def test_install_deps_command():
+    layout = RemoteLayout.for_device(_device())
+    cmd = install_deps_command(layout, _device())
+    assert "pip install" in cmd and "requirements.txt" in cmd
+    assert "/var/lib/pbt/code" in cmd
+
+
+def test_stop_agent_command_uses_pidfile():
+    layout = RemoteLayout.for_device(_device())
+    cmd = stop_agent_command(layout)
+    assert "kill" in cmd
+    assert layout.pid_file in cmd

--- a/tests/unit/tuners/distributed/test_inventory.py
+++ b/tests/unit/tuners/distributed/test_inventory.py
@@ -1,0 +1,112 @@
+"""Unit tests for the distributed fleet inventory parser."""
+
+import pytest
+
+from src.tuners.distributed.inventory import (
+    DeviceSpec,
+    InventoryError,
+    parse_inventory,
+)
+
+
+def _minimal():
+    return {
+        "fleet": {"agent_port": 8770, "ssh_user": "pbt", "data_dir": "/srv/pbt"},
+        "devices": [
+            {"host": "10.0.0.11"},
+            {"host": "10.0.0.12", "agent_port": 8771},
+            {"host": "10.0.0.13", "ssh_user": "ubuntu"},
+        ],
+    }
+
+
+def test_parse_assigns_worker_ids_by_order():
+    inv = parse_inventory(_minimal())
+    assert [d.worker_id for d in inv.devices] == [0, 1, 2]
+    assert inv.size == 3
+
+
+def test_fleet_defaults_and_per_device_overrides():
+    inv = parse_inventory(_minimal())
+    d0, d1, d2 = inv.devices
+    # Fleet defaults propagate.
+    assert d0.agent_port == 8770
+    assert d0.ssh_user == "pbt"
+    assert d0.data_dir == "/srv/pbt"
+    # Per-device overrides win.
+    assert d1.agent_port == 8771
+    assert d2.ssh_user == "ubuntu"
+    # Untouched keys still fall back to fleet defaults.
+    assert d2.agent_port == 8770
+
+
+def test_agent_base_url_and_display_name():
+    d = DeviceSpec(worker_id=0, host="host-a", agent_port=9000, label="alpha")
+    assert d.agent_base_url == "http://host-a:9000"
+    assert d.display_name == "alpha"
+    assert DeviceSpec(worker_id=1, host="host-b").display_name == "host-b"
+
+
+def test_device_for_worker_and_bounds():
+    inv = parse_inventory(_minimal())
+    assert inv.device_for_worker(1).host == "10.0.0.12"
+    with pytest.raises(InventoryError):
+        inv.device_for_worker(3)
+
+
+def test_validate_for_population():
+    inv = parse_inventory(_minimal())
+    inv.validate_for_population(3)  # exact fit ok
+    inv.validate_for_population(2)  # fleet larger than population ok
+    with pytest.raises(InventoryError):
+        inv.validate_for_population(4)  # more workers than devices
+
+
+def test_missing_devices_section_raises():
+    with pytest.raises(InventoryError):
+        parse_inventory({"fleet": {}})
+
+
+def test_empty_devices_raises():
+    with pytest.raises(InventoryError):
+        parse_inventory({"devices": []})
+
+
+def test_device_missing_host_raises():
+    with pytest.raises(InventoryError):
+        parse_inventory({"devices": [{"agent_port": 8770}]})
+
+
+def test_duplicate_endpoint_raises():
+    raw = {"devices": [{"host": "h1", "agent_port": 8770}, {"host": "h1"}]}
+    with pytest.raises(InventoryError):
+        parse_inventory(raw)
+
+
+def test_unknown_device_key_raises():
+    with pytest.raises(InventoryError):
+        parse_inventory({"devices": [{"host": "h1", "bogus": 1}]})
+
+
+def test_unknown_fleet_key_raises():
+    with pytest.raises(InventoryError):
+        parse_inventory({"fleet": {"nope": 1}, "devices": [{"host": "h1"}]})
+
+
+def test_invalid_port_raises():
+    with pytest.raises(InventoryError):
+        parse_inventory({"devices": [{"host": "h1", "agent_port": 99999}]})
+
+
+def test_ssh_key_is_expanded(monkeypatch):
+    monkeypatch.setenv("HOME", "/home/tester")
+    inv = parse_inventory(
+        {"fleet": {"ssh_key": "~/.ssh/id_rsa"}, "devices": [{"host": "h1"}]}
+    )
+    assert inv.devices[0].ssh_key == "/home/tester/.ssh/id_rsa"
+
+
+def test_roundtrip_to_dict():
+    inv = parse_inventory(_minimal())
+    assert isinstance(inv.to_dict()["devices"], list)
+    assert inv.to_dict()["devices"][0]["host"] == "10.0.0.11"

--- a/tests/unit/tuners/distributed/test_rpc_roundtrip.py
+++ b/tests/unit/tuners/distributed/test_rpc_roundtrip.py
@@ -1,0 +1,234 @@
+"""
+End-to-end RPC integration test for distributed mode (Phases 0-2).
+
+Spins up two *real* device-agent HTTP servers on localhost backed by an
+in-memory :class:`FakeBackend`, then drives them through the full coordinator
+stack: health handshake -> setup -> snapshot -> run_eval (central scoring) ->
+config-only clone/reset -> cleanup. No Docker or PostgreSQL required — this
+exercises the transport, dispatch, RemoteEnvironment, and RemoteWorkload
+Orchestrator wiring exactly as a real fleet would.
+"""
+
+import threading
+from typing import Any, Dict, Optional, Tuple
+
+import pytest
+
+from src.config.database import DatabaseConfig
+from src.tuners.distributed.agent_api import (
+    RunEvalRequest,
+    SetupRequest,
+    SetupResponse,
+)
+from src.tuners.distributed.config import DistributedConfig
+from src.tuners.distributed.coordinator import Coordinator
+from src.tuners.distributed.device_agent import DeviceAgent, EvaluationBackend
+from src.tuners.distributed.inventory import parse_inventory
+from src.tuners.pbt.worker import PBTWorker as Worker
+from src.tuners.engine.orchestrator import WorkloadOrchestratorConfig
+from src.utils.metrics import WorkloadType, create_metric_config
+
+
+class FakeBackend(EvaluationBackend):
+    """Deterministic in-memory backend — throughput scales with a knob value."""
+
+    def __init__(self, worker_id: int):
+        self.worker_id = worker_id
+        self.setup_calls = 0
+        self.snapshot_calls = 0
+        self.reset_calls = 0
+        self.eval_calls = 0
+        self.last_knob_config: Dict[str, Any] = {}
+
+    def setup(self, req: SetupRequest) -> SetupResponse:
+        self.setup_calls += 1
+        return SetupResponse(
+            ok=True,
+            port=5440 + self.worker_id,
+            data_dir="/tmp/fake",
+            backend="fake",
+            resources={
+                "ram_bytes": 256 * 1024**3,
+                "cpu_cores": 64,
+                "disk_type": "SSD",
+            },
+        )
+
+    def create_snapshot(self) -> str:
+        self.snapshot_calls += 1
+        return f"base-{self.worker_id}"
+
+    def reset(self, snapshot_id: str) -> None:
+        self.reset_calls += 1
+
+    def run_eval(
+        self, req: RunEvalRequest
+    ) -> Tuple[Dict[str, Any], bool, Dict[str, Any], Optional[Dict[str, Any]]]:
+        self.eval_calls += 1
+        self.last_knob_config = dict(req.knob_config)
+        # Throughput scales with the (fake) knob so scoring can differentiate.
+        knob_val = float(req.knob_config.get("shared_buffers", 1))
+        metrics = {
+            "throughput": 100.0 * knob_val,
+            "latency_p50": 5.0,
+            "latency_p95": 10.0,
+            "latency_p99": 20.0,
+            "cache_hit_ratio": 0.99,
+            "error_rate": 0.0,
+            "total_queries": 1000,
+            "total_time": 60.0,
+        }
+        return metrics, False, {"shared_buffers": knob_val}, None
+
+    def cleanup(self, remove_data: bool) -> None:
+        pass
+
+    def pg_running(self) -> bool:
+        return True
+
+    def backend_name(self) -> Optional[str]:
+        return "fake"
+
+
+@pytest.fixture
+def fleet():
+    """Start two agent servers on ephemeral ports; yield (coordinator, backends)."""
+    backends = {0: FakeBackend(0), 1: FakeBackend(1)}
+    agents = {
+        wid: DeviceAgent(wid, backends[wid], host="127.0.0.1", port=0)
+        for wid in (0, 1)
+    }
+    threads = []
+    for agent in agents.values():
+        t = threading.Thread(target=agent.httpd.serve_forever, daemon=True)
+        t.start()
+        threads.append(t)
+
+    inventory = parse_inventory(
+        {
+            "devices": [
+                {"host": "127.0.0.1", "agent_port": agents[0].port},
+                {"host": "127.0.0.1", "agent_port": agents[1].port},
+            ]
+        }
+    )
+    dist_cfg = DistributedConfig(
+        inventory=inventory, health_timeout_s=10.0, health_poll_interval_s=0.1
+    )
+    setup_template = SetupRequest(
+        run_id="test", benchmark="sysbench", workload_type="oltp_read_write"
+    )
+    db_config = DatabaseConfig(
+        user="postgres", password="", host="ignored", port=0, dbname="test"
+    )
+    coordinator = Coordinator(dist_cfg, setup_template, db_config, population_size=2)
+
+    try:
+        yield coordinator, backends
+    finally:
+        for agent in agents.values():
+            agent.close()
+
+
+def test_health_handshake(fleet):
+    coordinator, _ = fleet
+    coordinator.wait_for_agents()  # raises on failure
+    snapshot = coordinator.health_snapshot()
+    assert {h.worker_id for h in snapshot} == {0, 1}
+    assert all(h.status in ("ok", "starting") for h in snapshot)
+
+
+def test_setup_and_snapshot_fan_out(fleet):
+    coordinator, backends = fleet
+    coordinator.wait_for_agents()
+    env = coordinator.make_environment(schema_provider=None, run_id="test")
+
+    instances = env.setup_instances(2)
+    assert [i.worker_id for i in instances] == [0, 1]
+    assert instances[0].host == "127.0.0.1"
+    assert instances[0].port == 5440
+    assert all(b.setup_calls == 1 for b in backends.values())
+
+    # create_snapshot must fan out to EVERY device (baseline on all).
+    env.create_snapshot()
+    assert all(b.snapshot_calls == 1 for b in backends.values())
+
+
+def test_device_resources_reported_for_knob_ranges(fleet):
+    coordinator, _ = fleet
+    coordinator.wait_for_agents()
+    env = coordinator.make_environment(schema_provider=None, run_id="test")
+    env.setup_instances(2)
+
+    # The coordinator resolves knob ranges against DEVICE hardware, not its own.
+    res = env.representative_resources()
+    assert res is not None
+    assert res["ram_bytes"] == 256 * 1024**3
+    assert res["cpu_cores"] == 64
+    assert res["disk_type"] == "SSD"
+
+
+def test_run_eval_scores_centrally(fleet):
+    coordinator, backends = fleet
+    coordinator.wait_for_agents()
+    env = coordinator.make_environment(schema_provider=None, run_id="test")
+    env.setup_instances(2)
+
+    orch_config = WorkloadOrchestratorConfig(
+        workload_type=WorkloadType.OLTP,
+        metric_config=create_metric_config("oltp"),
+        db_config=coordinator.db_config,
+    )
+    orchestrator = coordinator.make_orchestrator(orch_config, executor=None, env=env)
+
+    # Two workers with different knob values => different throughput => the
+    # higher-throughput worker must score at least as high.
+    w_low = Worker(worker_id=0, knob_space=None, knob_config={"shared_buffers": 1})
+    w_high = Worker(worker_id=1, knob_space=None, knob_config={"shared_buffers": 4})
+
+    m_low, s_low, restart_low, actual_low, timing_low = orchestrator.evaluate_worker(
+        w_low, generation=0
+    )
+    m_high, s_high, *_ = orchestrator.evaluate_worker(w_high, generation=0)
+
+    assert backends[0].eval_calls == 1 and backends[1].eval_calls == 1
+    assert m_low.throughput == 100.0 and m_high.throughput == 400.0
+    assert restart_low is False
+    assert actual_low == {"shared_buffers": 1.0}
+    assert timing_low is not None  # fresh TimingRecorder, never None
+    assert s_high >= s_low  # central scoring rewards higher throughput
+
+
+def test_config_only_clone_resets_targets(fleet):
+    coordinator, backends = fleet
+    coordinator.wait_for_agents()
+    env = coordinator.make_environment(schema_provider=None, run_id="test")
+    env.setup_instances(2)
+
+    # Clone elite (worker 0) onto worker 1 => only a local reset on the target.
+    assert env.clone_instances(source_worker_id=0, target_worker_ids=[1]) is True
+    assert backends[1].reset_calls == 1
+    assert backends[0].reset_calls == 0  # source is never reset
+
+
+def test_rpc_failure_marks_worker_dead(fleet):
+    coordinator, backends = fleet
+    coordinator.wait_for_agents()
+    env = coordinator.make_environment(schema_provider=None, run_id="test")
+    env.setup_instances(2)
+    orch_config = WorkloadOrchestratorConfig(
+        workload_type=WorkloadType.OLTP,
+        metric_config=create_metric_config("oltp"),
+        db_config=coordinator.db_config,
+    )
+    orchestrator = coordinator.make_orchestrator(orch_config, executor=None, env=env)
+
+    # Point worker 0's client at a dead port to force a transport error.
+    from src.tuners.distributed.transport import AgentClient
+
+    orchestrator._clients[0] = AgentClient("http://127.0.0.1:1", default_timeout=0.5)
+    w = Worker(worker_id=0, knob_space=None, knob_config={"shared_buffers": 2})
+    metrics, score, *_ = orchestrator.evaluate_worker(w, generation=0)
+
+    assert metrics.failure_type == "EXECUTION_CRASH"  # handed to rescue path
+    assert isinstance(score, float)


### PR DESCRIPTION
Add a new DISTRIBUTED execution mode alongside the existing single-device (local) mode. Each population worker runs on its own dedicated, identical device so measurements are free of co-tenant contention — fairness becomes structural rather than something the lockstep barriers must equalise.

Architecture: a lightweight coordinator runs the unchanged PBT algorithm and drives per-device HTTP/JSON agents. It swaps only two objects behind existing seams — RemoteEnvironment (DatabaseEnvironment ABC) and RemoteWorkloadOrchestrator (RPC eval + central scoring). Each device agent runs today's real WorkloadOrchestrator locally, next to its DB, and returns raw metrics; scoring stays central so adaptive normalisation spans the population.

Highlights:
- Stdlib HTTP/JSON transport (no web framework) matching the repo's minimal-dep ethos.
- Config-only exploit clone: copy elite knobs in coordinator RAM + local base-snapshot reset on targets — no gigabyte PGDATA transfer over the network.
- SSH bootstrap: rsync code, install deps, launch/teardown agents.
- Device-hardware-aware knob ranges: agents report detected WorkerResources so the coordinator can run on any light machine.
- Distributed runs force synchronize_workers=False and num_parallel_workers=population (whole fleet runs concurrently); the generation boundary remains a hard barrier.

Additive only — the local path is unchanged (host field on InstanceConfig + getattr-guarded main.py branches). New package src/tuner/distributed/ with 28 tests (incl. a 2-agent localhost integration test, no Docker/PG required).
