### PR TITLE
feat(experiments): Add distributed comparison lifecycle

### DIFF
--- a/configs/distributed/devices.example.yaml
+++ b/configs/distributed/devices.example.yaml
@@ -19,12 +19,18 @@ fleet:
   ssh_key: ~/.ssh/id_rsa    # SSH private key (path is ~ / $VAR expanded)
   data_dir: /var/lib/pbt    # remote base dir for the PG instance's data
   python: python3           # remote interpreter used to launch the agent
+  gcp_project: my-project   # required by --stop-gcp-after-campaign
+  gcp_zone: us-central1-a   # may be overridden per device
 
 devices:
   - host: 10.0.0.11         # -> worker 0
+    gcp_instance: pbt-worker-0
   - host: 10.0.0.12         # -> worker 1
+    gcp_instance: pbt-worker-1
     agent_port: 8771        # per-device override
   - host: 10.0.0.13         # -> worker 2
+    gcp_instance: pbt-worker-2
     ssh_user: ubuntu
   - host: 10.0.0.14         # -> worker 3
+    gcp_instance: pbt-worker-3
     label: rack-a-node-4    # optional friendly name for logs/reports

--- a/scripts/experiments/__main__.py
+++ b/scripts/experiments/__main__.py
@@ -14,6 +14,7 @@ from scripts.experiments.runner import (
     LEGACY_MANIFEST_PATH,
     ExperimentRunner,
 )
+from src.tuners.distributed.config import ExecutionMode
 
 
 def _print_aggregate_status(manifest_dir: Path, manifest_path: Path | None) -> None:
@@ -73,6 +74,68 @@ def main():
     parser.add_argument("--resume", action="store_true", help="Resume from manifest (default behavior, skips done)")
     parser.add_argument("--retry-failed", action="store_true", help="Retry failed runs from manifest")
     parser.add_argument("--status", action="store_true", help="Print aggregate status across all manifests and exit")
+    execution = parser.add_mutually_exclusive_group()
+    execution.add_argument(
+        "--execution-mode",
+        choices=[mode.value for mode in ExecutionMode],
+        default=ExecutionMode.LOCAL.value,
+        help=(
+            "PBT execution mode: local co-tenant workers or one worker per "
+            "dedicated remote device (default: local)"
+        ),
+    )
+    execution.add_argument(
+        "--distributed",
+        dest="execution_mode",
+        action="store_const",
+        const=ExecutionMode.DISTRIBUTED.value,
+        help="Shortcut for --execution-mode distributed",
+    )
+    parser.add_argument(
+        "--inventory",
+        type=Path,
+        default=None,
+        help="Fleet devices.yaml path (required in distributed mode)",
+    )
+    parser.add_argument(
+        "--no-bootstrap",
+        action="store_true",
+        help="Use already-running device agents instead of SSH bootstrap",
+    )
+    parser.add_argument(
+        "--no-remote-deps",
+        action="store_true",
+        help="Do not install requirements on devices during SSH bootstrap",
+    )
+    parser.add_argument(
+        "--eval-timeout",
+        type=float,
+        default=1800.0,
+        help="Per-worker remote evaluation timeout in seconds (default: 1800)",
+    )
+    parser.add_argument(
+        "--agent-timeout",
+        type=float,
+        default=60.0,
+        help="Per-agent control timeout in seconds (default: 60)",
+    )
+    parser.add_argument(
+        "--comparison-worker-id",
+        type=int,
+        default=0,
+        help=(
+            "Fleet worker used exclusively for BO and post-hoc evaluation "
+            "after distributed PBT finishes (default: 0)"
+        ),
+    )
+    parser.add_argument(
+        "--stop-gcp-after-campaign",
+        action="store_true",
+        help=(
+            "Stop every GCP worker VM after all requested experiments finish; "
+            "requires gcp_project, gcp_zone, and gcp_instance in the inventory"
+        ),
+    )
     parser.add_argument(
         "--manifest-dir",
         type=Path,
@@ -95,6 +158,12 @@ def main():
 
     args = parser.parse_args()
     manifest_dir = args.manifest_dir or DEFAULT_MANIFEST_DIR
+
+    if (
+        args.execution_mode == ExecutionMode.DISTRIBUTED.value
+        and args.inventory is None
+    ):
+        parser.error("--execution-mode distributed requires --inventory PATH")
 
     if args.status:
         _print_aggregate_status(manifest_dir, args.manifest)
@@ -121,11 +190,20 @@ def main():
         no_push=args.no_push,
         manifest_dir=manifest_dir,
         manifest_path=args.manifest,
+        execution_mode=args.execution_mode,
+        inventory=args.inventory,
+        bootstrap=not args.no_bootstrap,
+        remote_install_deps=not args.no_remote_deps,
+        eval_timeout=args.eval_timeout,
+        agent_timeout=args.agent_timeout,
+        comparison_worker_id=args.comparison_worker_id,
+        stop_gcp_after_campaign=args.stop_gcp_after_campaign,
     )
 
-    with runner.cpu_performance_session():
-        for exp in experiments_to_run:
-            runner.run_experiment(exp, retry_failed=args.retry_failed)
+    with runner.gcp_campaign_session():
+        with runner.cpu_performance_session():
+            for exp in experiments_to_run:
+                runner.run_experiment(exp, retry_failed=args.retry_failed)
 
 
 if __name__ == "__main__":

--- a/scripts/experiments/runner.py
+++ b/scripts/experiments/runner.py
@@ -1,15 +1,23 @@
 import atexit
 import json
 import logging
+import shlex
 import signal
 import subprocess
 import time
 from contextlib import contextmanager
 from datetime import datetime
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 from scripts.experiments.experiment_matrix import Experiment
 from src.config.data_root import resolve_data_root
+from src.tuners.distributed.bootstrap import (
+    RemoteLayout,
+    ssh_command,
+    stop_agent_command,
+)
+from src.tuners.distributed.config import ExecutionMode
+from src.tuners.distributed.inventory import DeviceSpec, load_inventory
 from src.utils.hardware_info import detect_worker_resources, _resolve_block_device_node
 from src.tuners.pbt.config import (
     RAPID_CONFIG,
@@ -73,6 +81,14 @@ class ExperimentRunner:
         no_push: bool = False,
         manifest_dir: Path | None = None,
         manifest_path: Path | None = None,
+        execution_mode: ExecutionMode | str = ExecutionMode.LOCAL,
+        inventory: Path | None = None,
+        bootstrap: bool = True,
+        remote_install_deps: bool = True,
+        eval_timeout: float = 1800.0,
+        agent_timeout: float = 60.0,
+        comparison_worker_id: int = 0,
+        stop_gcp_after_campaign: bool = False,
     ):
         """Run experiments and persist progress to per-experiment manifests.
 
@@ -90,6 +106,26 @@ class ExperimentRunner:
         self.no_push = no_push
         self.manifest_dir = manifest_dir or DEFAULT_MANIFEST_DIR
         self.manifest_path_override = manifest_path
+        self.execution_mode = ExecutionMode(execution_mode)
+        self.inventory = inventory.expanduser() if inventory is not None else None
+        self.bootstrap = bootstrap
+        self.remote_install_deps = remote_install_deps
+        self.eval_timeout = eval_timeout
+        self.agent_timeout = agent_timeout
+        self.comparison_worker_id = comparison_worker_id
+        self.stop_gcp_after_campaign = stop_gcp_after_campaign
+        self._fleet_inventory = None
+
+        if self.execution_mode is ExecutionMode.DISTRIBUTED and self.inventory is None:
+            raise ValueError("Distributed execution requires a fleet inventory path")
+        if self.eval_timeout <= 0 or self.agent_timeout <= 0:
+            raise ValueError("Distributed RPC timeouts must be positive")
+        if self.comparison_worker_id < 0:
+            raise ValueError("Comparison worker ID must be non-negative")
+        if self.stop_gcp_after_campaign and not self.distributed:
+            raise ValueError(
+                "GCP fleet shutdown is only available in distributed mode"
+            )
 
         # Active experiment's manifest, populated by run_experiment().
         self._active_manifest_path: Path | None = None
@@ -150,6 +186,236 @@ class ExperimentRunner:
             flags[1],
         )
         return flags
+
+    @property
+    def distributed(self) -> bool:
+        """Whether PBT workers execute on the remote device fleet."""
+        return self.execution_mode is ExecutionMode.DISTRIBUTED
+
+    def _distributed_pbt_flags(self) -> list[str]:
+        """Build remote-agent CLI flags for a distributed PBT command."""
+        if not self.distributed:
+            return []
+        assert self.inventory is not None
+        flags = [
+            "--distributed",
+            "--inventory",
+            str(self.inventory),
+            "--eval-timeout",
+            str(self.eval_timeout),
+            "--agent-timeout",
+            str(self.agent_timeout),
+        ]
+        if not self.bootstrap:
+            flags.append("--no-bootstrap")
+        if not self.remote_install_deps:
+            flags.append("--no-remote-deps")
+        return flags
+
+    def _load_fleet_inventory(self):
+        """Load the configured fleet once for comparison-phase SSH operations."""
+        if self._fleet_inventory is None:
+            assert self.inventory is not None
+            self._fleet_inventory = load_inventory(self.inventory)
+        return self._fleet_inventory
+
+    def _comparison_device(self) -> DeviceSpec:
+        """Return the sole fleet device used for BO and post-hoc evaluation."""
+        return self._load_fleet_inventory().device_for_worker(
+            self.comparison_worker_id
+        )
+
+    @staticmethod
+    def _ssh_transport_options(device: DeviceSpec) -> list[str]:
+        """Build shared non-interactive SSH options for rsync transfers."""
+        options = [
+            "-o",
+            "BatchMode=yes",
+            "-o",
+            "StrictHostKeyChecking=accept-new",
+            "-o",
+            "ServerAliveInterval=30",
+            "-o",
+            "ServerAliveCountMax=6",
+        ]
+        if device.ssh_key:
+            options.extend(["-i", device.ssh_key])
+        return options
+
+    @staticmethod
+    def _ssh_target(device: DeviceSpec) -> str:
+        """Return an SSH target using the inventory's optional user."""
+        return (
+            f"{device.ssh_user}@{device.host}"
+            if device.ssh_user
+            else device.host
+        )
+
+    def _run_remote_command(self, device: DeviceSpec, cmd: list[str]) -> bool:
+        """Execute one CLI command and always stop its PostgreSQL instances."""
+        if not cmd or cmd[0] != "python":
+            raise ValueError("Remote experiment commands must begin with 'python'")
+        layout = RemoteLayout.for_device(device)
+        remote_argv = [device.python, *cmd[1:]]
+        cleanup_argv = [
+            device.python,
+            "-m",
+            "src.scripts.cleanup_instances",
+            "--data-dir",
+            layout.instances_dir,
+            "--force",
+        ]
+        cleanup_cmd = shlex.join(cleanup_argv)
+        remote_cmd = (
+            f"cd {shlex.quote(layout.code_dir)} || exit $?; "
+            f"cleanup_comparison_instance() {{ {cleanup_cmd}; }}; "
+            "trap cleanup_comparison_instance EXIT; "
+            f"{shlex.join(remote_argv)}; phase_exit_code=$?; "
+            "trap - EXIT; cleanup_comparison_instance; cleanup_exit_code=$?; "
+            "if [ \"$phase_exit_code\" -ne 0 ]; then exit \"$phase_exit_code\"; fi; "
+            "exit \"$cleanup_exit_code\""
+        )
+        return self._run_command(ssh_command(device, remote_cmd))
+
+    def _stage_file_on_comparison_device(self, local_path: Path) -> str:
+        """Upload one coordinator artifact while preserving its project path."""
+        device = self._comparison_device()
+        layout = RemoteLayout.for_device(device)
+        try:
+            relative = local_path.resolve().relative_to(PROJECT_ROOT.resolve())
+        except ValueError as exc:
+            raise ValueError(
+                f"Comparison artifact must live under {PROJECT_ROOT}: {local_path}"
+            ) from exc
+
+        remote_path = str(PurePosixPath(layout.code_dir) / relative.as_posix())
+        parent = str(PurePosixPath(remote_path).parent)
+        if not self._run_command(
+            ssh_command(device, f"mkdir -p {shlex.quote(parent)}")
+        ):
+            raise RuntimeError(
+                f"Could not create comparison artifact directory on {device.display_name}"
+            )
+
+        ssh_shell = shlex.join(
+            ["ssh", *self._ssh_transport_options(device)]
+        )
+        upload = [
+            "rsync",
+            "-az",
+            "-e",
+            ssh_shell,
+            str(local_path),
+            f"{self._ssh_target(device)}:{remote_path}",
+        ]
+        if not self._run_command(upload):
+            raise RuntimeError(
+                f"Could not upload {local_path} to {device.display_name}"
+            )
+        return remote_path
+
+    def _sync_comparison_results(self) -> None:
+        """Download BO/evaluation artifacts from the selected device."""
+        device = self._comparison_device()
+        layout = RemoteLayout.for_device(device)
+        RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+        ssh_shell = shlex.join(
+            ["ssh", *self._ssh_transport_options(device)]
+        )
+        download = [
+            "rsync",
+            "-az",
+            "-e",
+            ssh_shell,
+            f"{self._ssh_target(device)}:{layout.code_dir}/results/",
+            f"{RESULTS_DIR}/",
+        ]
+        if not self._run_command(download):
+            raise RuntimeError(
+                f"Could not download comparison results from {device.display_name}"
+            )
+
+    def _prepare_comparison_device(self) -> None:
+        """Stop every PBT agent and instance before starting solo comparison."""
+        inventory = self._load_fleet_inventory()
+        selected = self._comparison_device()
+        LOGGER.info(
+            "Using worker %d (%s) exclusively for BO and EVAL; stopping %d "
+            "other fleet device(s).",
+            selected.worker_id,
+            selected.display_name,
+            max(0, len(inventory.devices) - 1),
+        )
+        failures: list[str] = []
+        for device in inventory.devices:
+            layout = RemoteLayout.for_device(device)
+            cleanup = (
+                f"{stop_agent_command(layout)}; "
+                f"if [ -d {shlex.quote(layout.code_dir)} ]; then "
+                f"cd {shlex.quote(layout.code_dir)} && "
+                f"{shlex.quote(device.python)} "
+                "-m src.scripts.cleanup_instances "
+                f"--data-dir {shlex.quote(layout.instances_dir)} --force; "
+                "fi"
+            )
+            if not self._run_command(ssh_command(device, cleanup)):
+                failures.append(device.display_name)
+        if failures:
+            raise RuntimeError(
+                "Could not stop unused fleet device(s): " + ", ".join(failures)
+            )
+
+    def _stop_gcp_fleet(self) -> None:
+        """Stop every worker VM after the complete experiment campaign."""
+        inventory = self._load_fleet_inventory()
+        missing = [
+            device.display_name
+            for device in inventory.devices
+            if not (
+                device.gcp_project
+                and device.gcp_zone
+                and device.gcp_instance
+            )
+        ]
+        if missing:
+            raise ValueError(
+                "GCP shutdown requires gcp_project, gcp_zone, and gcp_instance "
+                "for every fleet device; missing: " + ", ".join(missing)
+            )
+
+        LOGGER.info(
+            "Campaign complete: stopping %d GCP worker VM(s).",
+            len(inventory.devices),
+        )
+        failures: list[str] = []
+        for device in inventory.devices:
+            command = [
+                "gcloud",
+                "compute",
+                "instances",
+                "stop",
+                str(device.gcp_instance),
+                "--project",
+                str(device.gcp_project),
+                "--zone",
+                str(device.gcp_zone),
+                "--quiet",
+            ]
+            if not self._run_command(command):
+                failures.append(device.display_name)
+        if failures:
+            raise RuntimeError(
+                "Could not stop GCP worker VM(s): " + ", ".join(failures)
+            )
+
+    @contextmanager
+    def gcp_campaign_session(self):
+        """Ensure configured GCP worker VMs stop when the campaign exits."""
+        try:
+            yield
+        finally:
+            if self.stop_gcp_after_campaign:
+                self._stop_gcp_fleet()
 
     def _resolve_manifest_path(self, exp_id: str) -> Path:
         """Resolve the manifest path for ``exp_id``.
@@ -437,6 +703,12 @@ class ExperimentRunner:
         """
         if self.dry_run:
             return
+        if self.distributed:
+            LOGGER.info(
+                "Distributed mode: skipping coordinator disk-isolation preflight; "
+                "each PBT worker owns a dedicated fleet device."
+            )
+            return
         data_root = resolve_data_root()
         device = _resolve_block_device_node(data_root)
         if device is None:
@@ -472,7 +744,12 @@ class ExperimentRunner:
         pinning is a quality-of-measurement improvement, not a correctness
         invariant).
         """
-        if self.dry_run:
+        if self.dry_run or self.distributed:
+            if self.distributed:
+                LOGGER.info(
+                    "Distributed mode: leaving coordinator CPU policy unchanged; "
+                    "benchmark execution occurs on dedicated fleet devices."
+                )
             yield
             return
 
@@ -528,6 +805,11 @@ class ExperimentRunner:
     def run_experiment(self, exp: Experiment, retry_failed: bool = False) -> None:
         LOGGER.info(f"Starting experiment {exp.id} (Tier {exp.tier})")
 
+        if self.distributed and exp.strategy != "pbt":
+            raise ValueError(
+                "Distributed execution currently supports PBT experiments only"
+            )
+
         # Guarantee Disk-IO parity is enforceable before burning compute.
         self._preflight_disk_isolation()
 
@@ -572,12 +854,32 @@ class ExperimentRunner:
                     pbt_session_path = json_path
                 else:
                     self._mark_status(pbt_key, "failed", duration_s=duration)
+                    if self.distributed:
+                        self._prepare_comparison_device()
                     LOGGER.error("PBT phase failed. Skipping BO and EVAL for this seed.")
                     continue
             else:
                 LOGGER.info(f"Skipping PBT (already done/failed)")
                 json_str = self._active_manifest["runs"][pbt_key].get("session_json")
                 pbt_session_path = PROJECT_ROOT / json_str if json_str else None
+
+            comparison_pbt_session = pbt_session_path
+            if self.distributed:
+                # PBT agent shutdown does not remove its PostgreSQL container.
+                # Clean every fleet host before any comparison or early exit.
+                self._prepare_comparison_device()
+                if not pbt_session_path and not self.dry_run:
+                    LOGGER.error(
+                        "Cannot hand off distributed run: PBT session JSON not found."
+                    )
+                    continue
+                comparison_pbt_session = Path(
+                    self._stage_file_on_comparison_device(
+                        pbt_session_path
+                        if pbt_session_path is not None
+                        else PROJECT_ROOT / "DRY_RUN_PBT_SESSION_PATH.json"
+                    )
+                )
 
             # 2. BO Phase (only if enabled)
             if exp.run_bo:
@@ -588,14 +890,20 @@ class ExperimentRunner:
                         self._mark_status(bo_key, "failed", error="Missing PBT JSON")
                     else:
                         LOGGER.info(f"Phase 2/3: Running BO for {exp.id} (seed {seed})")
-                        cmd = self._build_bo_cmd(exp, pbt_session_path, seed)
+                        cmd = self._build_bo_cmd(exp, comparison_pbt_session, seed)
                         self._mark_status(bo_key, "running", started_at=datetime.utcnow().isoformat() + "Z")
                         
                         start_time = time.time()
-                        success = self._run_command(cmd)
+                        success = (
+                            self._run_remote_command(self._comparison_device(), cmd)
+                            if self.distributed
+                            else self._run_command(cmd)
+                        )
                         duration = time.time() - start_time
                         
                         if success:
+                            if self.distributed:
+                                self._sync_comparison_results()
                             json_path = self._find_latest_session_json(RESULTS_DIR, "bo")
                             json_str = str(json_path.relative_to(PROJECT_ROOT)) if json_path else None
                             self._mark_status(bo_key, "done", duration_s=duration, session_json=json_str)
@@ -609,7 +917,13 @@ class ExperimentRunner:
                     LOGGER.info(f"Skipping BO (already done/failed)")
                     json_str = self._active_manifest["runs"].get(bo_key, {}).get("session_json")
                     bo_session_path = PROJECT_ROOT / json_str if json_str else None
-            
+
+            comparison_bo_session = bo_session_path
+            if self.distributed and bo_session_path is not None:
+                comparison_bo_session = Path(
+                    self._stage_file_on_comparison_device(bo_session_path)
+                )
+
             # 3. EVAL Phase
             eval_key = self._get_run_key(exp.id, seed, "eval")
             if not self._is_done(eval_key, retry_failed):
@@ -618,14 +932,25 @@ class ExperimentRunner:
                     self._mark_status(eval_key, "failed", error="Missing PBT JSON")
                 else:
                     LOGGER.info(f"Phase 3/3: Running EVAL for {exp.id} (seed {seed})")
-                    cmd = self._build_eval_cmd(pbt_session_path, bo_session_path, exp.eval_repetitions, seed)
+                    cmd = self._build_eval_cmd(
+                        comparison_pbt_session,
+                        comparison_bo_session,
+                        exp.eval_repetitions,
+                        seed,
+                    )
                     self._mark_status(eval_key, "running", started_at=datetime.utcnow().isoformat() + "Z")
                     
                     start_time = time.time()
-                    success = self._run_command(cmd)
+                    success = (
+                        self._run_remote_command(self._comparison_device(), cmd)
+                        if self.distributed
+                        else self._run_command(cmd)
+                    )
                     duration = time.time() - start_time
                     
                     if success:
+                        if self.distributed:
+                            self._sync_comparison_results()
                         self._mark_status(eval_key, "done", duration_s=duration)
                         self._commit_and_push(exp, seed, "eval")
                     else:
@@ -765,7 +1090,6 @@ class ExperimentRunner:
         return cmd
 
     def _build_pbt_cmd(self, exp: Experiment, seed: int) -> list[str]:
-        worker_ram, worker_cpus = self._worker_resource_flags(exp)
         cmd = [
             "python", "-m", "src.tuners", "pbt",
             "--config", exp.config_profile,
@@ -780,10 +1104,23 @@ class ExperimentRunner:
             # flag makes that contract part of the experiment record.
             "--snapshot-restore-interval", "1",
             "--force-recreate-instances",
-            "--worker-ram", worker_ram,
-            "--worker-cpus", str(worker_cpus),
             "--verbose", "DEBUG"
         ]
+
+        if self.distributed:
+            # Device agents detect and report their full dedicated-device
+            # resources. Never derive worker limits from the coordinator.
+            cmd.extend(self._distributed_pbt_flags())
+        else:
+            worker_ram, worker_cpus = self._worker_resource_flags(exp)
+            cmd.extend(
+                [
+                    "--worker-ram",
+                    worker_ram,
+                    "--worker-cpus",
+                    str(worker_cpus),
+                ]
+            )
 
         if exp.sysbench_workload:
             cmd.extend(["--sysbench-workload", exp.sysbench_workload])
@@ -833,7 +1170,6 @@ class ExperimentRunner:
         # the session JSON, so these --worker-ram/--worker-cpus flags are
         # intentionally redundant (logged as ignored by the BO runner). They
         # are kept for the standalone-BO path where no session is supplied.
-        worker_ram, worker_cpus = self._worker_resource_flags(exp)
         cmd = [
             "python", "-m", "src.tuners", "bo",
             "--config", exp.config_profile,
@@ -845,10 +1181,23 @@ class ExperimentRunner:
             "--enable-snapshots",
             "--snapshot-restore-interval", "1",
             "--force-recreate-instances",
-            "--worker-ram", worker_ram,
-            "--worker-cpus", str(worker_cpus),
             "--verbose", "INFO"
         ]
+        if self.distributed:
+            # Distributed PBT has no single-host co-tenancy. Run BO alone on
+            # one of the same fleet devices and inherit its full resource
+            # envelope from the PBT session.
+            cmd.append("--no-cotenant")
+        else:
+            worker_ram, worker_cpus = self._worker_resource_flags(exp)
+            cmd.extend(
+                [
+                    "--worker-ram",
+                    worker_ram,
+                    "--worker-cpus",
+                    str(worker_cpus),
+                ]
+            )
         if exp.sysbench_workload:
             cmd.extend(["--sysbench-workload", exp.sysbench_workload])
         if exp.scale_factor is not None:

--- a/src/tuners/bo/config.py
+++ b/src/tuners/bo/config.py
@@ -284,8 +284,12 @@ class BOConfig:
             if isinstance(knobs, dict) and knobs:
                 self.pbt_knob_names = tuple(sorted(str(name) for name in knobs))
 
-        # Extract worker resources for resource equalization
-        worker_resources = payload.get("worker_resources")
+        # Extract the authoritative per-worker resource envelope. Unified
+        # sessions store it under ``tuning_session``; retain the root-level
+        # fallback for legacy traces.
+        worker_resources = session.get("worker_resources")
+        if not isinstance(worker_resources, dict):
+            worker_resources = payload.get("worker_resources")
         if isinstance(worker_resources, dict):
             self.pbt_worker_resources = worker_resources
 

--- a/src/tuners/bo/tuner.py
+++ b/src/tuners/bo/tuner.py
@@ -49,6 +49,7 @@ from src.config.database import get_db_config
 from src.tuners.base import BaseTuner
 from src.tuners.engine.worker import BaseWorker
 from src.tuners.engine.orchestrator import WorkloadOrchestrator
+from src.tuners.utils.knob_filter import apply_tuning_mode_filter
 from src.tuners.utils.metrics_table import build_worker_metric_row
 from src.tuners.utils.session_writer import build_scoring_block, convert_numpy_types
 from src.tuners.utils.types import (
@@ -72,6 +73,7 @@ from src.utils.logger import (
     log_section_header,
     log_worker_metrics_table,
 )
+from src.utils.hardware_info import WorkerResources
 from src.utils.metrics import PerformanceMetrics
 from src.utils.timing import TimingRecorder
 from src.utils.types import BenchmarkConfig
@@ -218,6 +220,46 @@ class BOTuner(BaseTuner):
         width does. ``degree == 1`` brings up just the foreground instance.
         """
         return max(1, int(self.bo_config.cotenancy_degree))
+
+    def _resolve_resources(self) -> None:
+        """Use the distributed PBT worker's full resource envelope for solo BO.
+
+        A distributed PBT worker owns one complete device and serializes that
+        100%-capacity envelope into its session. When ``--no-cotenant`` runs BO
+        alone on one of those same devices, re-detecting through the local
+        safety threshold would incorrectly reduce its resources. Session
+        resources are therefore authoritative for this matched comparison.
+        """
+        raw_resources = self.bo_config.pbt_worker_resources
+        if not self.bo_config.no_cotenant or not raw_resources:
+            super()._resolve_resources()
+            return
+
+        valid_fields = WorkerResources.__dataclass_fields__.keys()
+        resource_values = {
+            key: value
+            for key, value in raw_resources.items()
+            if key in valid_fields
+        }
+        resources = WorkerResources(**resource_values)
+        if resources.ram_bytes <= 0 or resources.cpu_cores <= 0:
+            raise ValueError(
+                "PBT session worker_resources must contain positive RAM and CPU values"
+            )
+
+        self.worker_resources = resources
+        self.full_knob_space.resolve_hardware_ranges(resources)
+        self.knob_space.worker_resources = resources
+        self.knob_space = apply_tuning_mode_filter(
+            self.full_knob_space, self.lifecycle.tuning_mode
+        )
+        LOGGER.info(
+            "Using authoritative distributed PBT worker resources at full "
+            "dedicated-device capacity (RAM=%.1f GB, CPU=%d cores, disk=%s).",
+            resources.ram_bytes / 1e9,
+            resources.cpu_cores,
+            resources.disk_type,
+        )
 
     def config_summary_lines(self) -> List[Tuple[str, str]]:
         return [

--- a/src/tuners/distributed/bootstrap.py
+++ b/src/tuners/distributed/bootstrap.py
@@ -88,7 +88,16 @@ def _ssh_target(device: DeviceSpec) -> str:
 
 
 def _ssh_opts(device: DeviceSpec) -> List[str]:
-    opts = ["-o", "BatchMode=yes", "-o", "StrictHostKeyChecking=accept-new"]
+    opts = [
+        "-o",
+        "BatchMode=yes",
+        "-o",
+        "StrictHostKeyChecking=accept-new",
+        "-o",
+        "ServerAliveInterval=30",
+        "-o",
+        "ServerAliveCountMax=6",
+    ]
     if device.ssh_key:
         opts += ["-i", device.ssh_key]
     return opts

--- a/src/tuners/distributed/inventory.py
+++ b/src/tuners/distributed/inventory.py
@@ -22,9 +22,12 @@ Example ``devices.yaml``
       ssh_key: ~/.ssh/id_rsa    # SSH private key path
       data_dir: /var/lib/pbt    # remote base dir for PG instance data
       python: python3           # remote interpreter used to launch the agent
+            gcp_project: my-project   # optional campaign-end VM shutdown identity
+            gcp_zone: us-central1-a
 
     devices:
-      - host: 10.0.0.11
+            - host: 10.0.0.11
+                gcp_instance: pbt-worker-0
       - host: 10.0.0.12
         agent_port: 8771        # per-device override
       - host: 10.0.0.13
@@ -61,11 +64,25 @@ _FLEET_DEFAULTS: Dict[str, Any] = {
     "data_dir": "/var/lib/pbt",
     "python": "python3",
     "agent_scheme": "http",
+    "gcp_project": None,
+    "gcp_zone": None,
+    "gcp_instance": None,
 }
 
 # Keys a per-device entry is allowed to carry (besides the mandatory ``host``).
 _DEVICE_OVERRIDE_KEYS = frozenset(
-    {"agent_port", "ssh_user", "ssh_key", "data_dir", "python", "agent_scheme", "label"}
+    {
+        "agent_port",
+        "ssh_user",
+        "ssh_key",
+        "data_dir",
+        "python",
+        "agent_scheme",
+        "label",
+        "gcp_project",
+        "gcp_zone",
+        "gcp_instance",
+    }
 )
 
 
@@ -93,6 +110,9 @@ class DeviceSpec:
         ``http`` (default) or ``https``.
     label:
         Optional human-friendly name for logs/reports (defaults to ``host``).
+    gcp_project, gcp_zone, gcp_instance:
+        Explicit Google Compute Engine identity used only when the experiment
+        runner is asked to stop worker VMs after a campaign.
     """
 
     worker_id: int
@@ -104,6 +124,9 @@ class DeviceSpec:
     python: str = "python3"
     agent_scheme: str = "http"
     label: Optional[str] = None
+    gcp_project: Optional[str] = None
+    gcp_zone: Optional[str] = None
+    gcp_instance: Optional[str] = None
 
     @property
     def display_name(self) -> str:
@@ -126,6 +149,9 @@ class DeviceSpec:
             "python": self.python,
             "agent_scheme": self.agent_scheme,
             "label": self.label,
+            "gcp_project": self.gcp_project,
+            "gcp_zone": self.gcp_zone,
+            "gcp_instance": self.gcp_instance,
         }
 
 
@@ -271,6 +297,9 @@ def parse_inventory(raw: Dict[str, Any], *, source_path: Optional[Path] = None) 
                 python=str(merged["python"]),
                 agent_scheme=str(merged["agent_scheme"]),
                 label=merged.get("label"),
+                gcp_project=merged.get("gcp_project"),
+                gcp_zone=merged.get("gcp_zone"),
+                gcp_instance=merged.get("gcp_instance"),
             )
         )
 

--- a/tests/unit/scripts/test_experiment_runner_manifest.py
+++ b/tests/unit/scripts/test_experiment_runner_manifest.py
@@ -264,6 +264,238 @@ def test_smoke_commands_use_minimal_budget(runner_factory):
     assert ev[ev.index("--repetitions") + 1] == "2"
 
 
+def test_distributed_pbt_command_uses_fleet_not_coordinator_resources(tmp_path):
+    """Distributed commands carry fleet controls and omit local resource flags."""
+    from scripts.experiments.experiment_matrix import build_smoke_experiments
+
+    inventory = tmp_path / "devices.yaml"
+    inventory.write_text("devices: []\n")
+    runner = ExperimentRunner(
+        dry_run=True,
+        no_push=True,
+        execution_mode="distributed",
+        inventory=inventory,
+        bootstrap=False,
+        remote_install_deps=False,
+        eval_timeout=2400.0,
+        agent_timeout=90.0,
+    )
+    exp = build_smoke_experiments()[0]
+
+    cmd = runner._build_pbt_cmd(exp, seed=42)
+
+    assert "--distributed" in cmd
+    assert cmd[cmd.index("--inventory") + 1] == str(inventory)
+    assert cmd[cmd.index("--eval-timeout") + 1] == "2400.0"
+    assert cmd[cmd.index("--agent-timeout") + 1] == "90.0"
+    assert "--no-bootstrap" in cmd
+    assert "--no-remote-deps" in cmd
+    assert "--worker-ram" not in cmd
+    assert "--worker-cpus" not in cmd
+
+    bo = runner._build_bo_cmd(exp, Path("/remote/trace.json"), seed=42)
+    assert "--no-cotenant" in bo
+    assert "--worker-ram" not in bo
+    assert "--worker-cpus" not in bo
+
+
+def test_distributed_mode_requires_inventory():
+    """A distributed campaign cannot start without a fleet inventory."""
+    with pytest.raises(ValueError, match="requires a fleet inventory"):
+        ExperimentRunner(
+            dry_run=True,
+            no_push=True,
+            execution_mode="distributed",
+        )
+
+
+def test_distributed_preflight_ignores_coordinator_disk(monkeypatch, tmp_path):
+    """Dedicated-device runs never validate the coordinator's block device."""
+    inventory = tmp_path / "devices.yaml"
+    inventory.write_text("devices: []\n")
+    runner = ExperimentRunner(
+        dry_run=False,
+        no_push=True,
+        execution_mode="distributed",
+        inventory=inventory,
+    )
+
+    def _boom(*args, **kwargs):  # pragma: no cover - must never be called
+        raise AssertionError("coordinator disk resolver must not run")
+
+    monkeypatch.setattr(
+        "scripts.experiments.runner._resolve_block_device_node", _boom
+    )
+
+    runner._preflight_disk_isolation()
+
+
+def test_remote_command_runs_on_selected_device(monkeypatch, tmp_path):
+    """BO/EVAL execute remotely and always clean the selected DB instance."""
+    inventory = tmp_path / "devices.yaml"
+    inventory.write_text(
+        """
+fleet:
+  ssh_user: pbt
+  data_dir: /srv/pbt
+  python: /srv/pbt/.venv/bin/python
+devices:
+  - host: 10.0.0.11
+  - host: 10.0.0.12
+""".strip()
+    )
+    runner = ExperimentRunner(
+        dry_run=False,
+        no_push=True,
+        execution_mode="distributed",
+        inventory=inventory,
+    )
+    captured: list[str] = []
+
+    def _capture(cmd, cwd=Path(".")):
+        captured.extend(cmd)
+        return True
+
+    monkeypatch.setattr(runner, "_run_command", _capture)
+
+    assert runner._run_remote_command(
+        runner._comparison_device(),
+        ["python", "-m", "src.tuners", "bo", "--no-cotenant"],
+    )
+    rendered = " ".join(captured)
+    assert "pbt@10.0.0.11" in rendered
+    assert "ServerAliveInterval=30" in rendered
+    assert "ServerAliveCountMax=6" in rendered
+    assert "cd /srv/pbt/code" in rendered
+    assert "/srv/pbt/.venv/bin/python -m src.tuners bo" in rendered
+    assert "trap cleanup_comparison_instance EXIT" in rendered
+    assert "src.scripts.cleanup_instances" in rendered
+    assert "--data-dir /srv/pbt/instances --force" in rendered
+
+
+def test_prepare_comparison_device_stops_other_agents(monkeypatch, tmp_path):
+    """All fleet agents and PostgreSQL instances stop before solo BO begins."""
+    inventory = tmp_path / "devices.yaml"
+    inventory.write_text(
+        """
+fleet:
+  ssh_user: pbt
+  data_dir: /srv/pbt
+devices:
+  - host: 10.0.0.11
+  - host: 10.0.0.12
+  - host: 10.0.0.13
+""".strip()
+    )
+    runner = ExperimentRunner(
+        dry_run=False,
+        no_push=True,
+        execution_mode="distributed",
+        inventory=inventory,
+        comparison_worker_id=1,
+    )
+    targets: list[str] = []
+
+    def _capture(cmd, cwd=Path(".")):
+        targets.append(" ".join(cmd))
+        return True
+
+    monkeypatch.setattr(runner, "_run_command", _capture)
+
+    runner._prepare_comparison_device()
+
+    assert len(targets) == 3
+    assert any("10.0.0.11" in cmd for cmd in targets)
+    selected = next(cmd for cmd in targets if "10.0.0.12" in cmd)
+    assert any("10.0.0.13" in cmd for cmd in targets)
+    assert "cleanup_instances" in selected
+    assert "agent-worker-1.pid" in selected
+    assert "agent-worker-0.pid" in next(
+        cmd for cmd in targets if "10.0.0.11" in cmd
+    )
+    assert "agent-worker-2.pid" in next(
+        cmd for cmd in targets if "10.0.0.13" in cmd
+    )
+
+
+def test_gcp_campaign_session_stops_all_worker_vms_on_exit(monkeypatch, tmp_path):
+    """Every configured worker VM stops even when the campaign raises."""
+    inventory = tmp_path / "devices.yaml"
+    inventory.write_text(
+        """
+fleet:
+  gcp_project: pbt-research
+  gcp_zone: us-central1-a
+devices:
+  - host: 10.0.0.11
+    gcp_instance: pbt-worker-0
+  - host: 10.0.0.12
+    gcp_instance: pbt-worker-1
+""".strip()
+    )
+    runner = ExperimentRunner(
+        dry_run=False,
+        no_push=True,
+        execution_mode="distributed",
+        inventory=inventory,
+        stop_gcp_after_campaign=True,
+    )
+    commands: list[list[str]] = []
+
+    def _capture(cmd, cwd=Path(".")):
+        commands.append(cmd)
+        return True
+
+    monkeypatch.setattr(runner, "_run_command", _capture)
+
+    with pytest.raises(RuntimeError, match="campaign failure"):
+        with runner.gcp_campaign_session():
+            raise RuntimeError("campaign failure")
+
+    assert commands == [
+        [
+            "gcloud",
+            "compute",
+            "instances",
+            "stop",
+            "pbt-worker-0",
+            "--project",
+            "pbt-research",
+            "--zone",
+            "us-central1-a",
+            "--quiet",
+        ],
+        [
+            "gcloud",
+            "compute",
+            "instances",
+            "stop",
+            "pbt-worker-1",
+            "--project",
+            "pbt-research",
+            "--zone",
+            "us-central1-a",
+            "--quiet",
+        ],
+    ]
+
+
+def test_gcp_shutdown_requires_explicit_instance_identity(tmp_path):
+    """Cloud shutdown fails closed instead of targeting VMs heuristically."""
+    inventory = tmp_path / "devices.yaml"
+    inventory.write_text("devices:\n  - host: 10.0.0.11\n")
+    runner = ExperimentRunner(
+        dry_run=True,
+        no_push=True,
+        execution_mode="distributed",
+        inventory=inventory,
+        stop_gcp_after_campaign=True,
+    )
+
+    with pytest.raises(ValueError, match="gcp_project, gcp_zone, and gcp_instance"):
+        runner._stop_gcp_fleet()
+
+
 # ---------------------------------------------------------------------------
 # Version control: stash → pull → stash pop → commit → push (+ retry)
 # ---------------------------------------------------------------------------

--- a/tests/unit/tuners/bo/test_distributed_resources.py
+++ b/tests/unit/tuners/bo/test_distributed_resources.py
@@ -1,0 +1,97 @@
+"""Resource-parity tests for BO after distributed PBT."""
+
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from src.tuners.base import BaseTuner
+from src.tuners.bo.config import BOConfig
+from src.tuners.bo.tuner import BOTuner
+from src.utils.hardware_info import WorkerResources
+from src.utils.types import TuningMode
+
+
+def test_pbt_session_loads_nested_worker_resources(tmp_path) -> None:
+    """Current unified sessions expose their worker envelope under metadata."""
+    session_path = tmp_path / "trace.json"
+    session_path.write_text(
+        """
+{
+  "tuning_session": {
+    "knob_tier": "minimal",
+    "knob_source": "expert",
+    "benchmark_name": "sysbench",
+    "workload_type": "oltp",
+    "tuning_mode": "offline",
+    "worker_resources": {
+      "ram_bytes": 34359738368,
+      "cpu_cores": 8,
+      "disk_type": "SSD",
+      "disk_read_bps": 1000000000,
+      "disk_write_bps": 900000000
+    }
+  }
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    config = BOConfig(no_cotenant=True)
+
+    config.apply_pbt_session(session_path, set_iteration_budget=False)
+
+    assert config.pbt_worker_resources == {
+        "ram_bytes": 34359738368,
+        "cpu_cores": 8,
+        "disk_type": "SSD",
+        "disk_read_bps": 1000000000,
+        "disk_write_bps": 900000000,
+    }
+
+
+def test_solo_bo_uses_full_distributed_pbt_resource_envelope() -> None:
+    """Solo BO must not reapply the local 80/95-percent safety threshold."""
+    resources = {
+        "ram_bytes": 32 * 1024**3,
+        "cpu_cores": 8,
+        "disk_type": "SSD",
+        "disk_read_bps": 1_000_000_000,
+        "disk_write_bps": 900_000_000,
+        "disk_read_iops": 100_000,
+        "disk_write_iops": 90_000,
+        "disk_class": "local_ssd",
+    }
+    tuner = object.__new__(BOTuner)
+    tuner.bo_config = BOConfig(
+        no_cotenant=True,
+        pbt_worker_resources=resources,
+    )
+    tuner.lifecycle = SimpleNamespace(tuning_mode=TuningMode.OFFLINE)
+    tuner.full_knob_space = Mock()
+    tuner.knob_space = tuner.full_knob_space
+
+    with patch.object(BaseTuner, "_resolve_resources", autospec=True) as fallback:
+        tuner._resolve_resources()
+
+    fallback.assert_not_called()
+    assert tuner.worker_resources == WorkerResources(**resources)
+    tuner.full_knob_space.resolve_hardware_ranges.assert_called_once_with(
+        tuner.worker_resources
+    )
+    assert tuner.knob_space.worker_resources == tuner.worker_resources
+
+
+def test_regular_bo_keeps_standard_resource_detection() -> None:
+    """The full-device override is restricted to explicit solo comparisons."""
+    tuner = object.__new__(BOTuner)
+    tuner.bo_config = BOConfig(
+        no_cotenant=False,
+        pbt_worker_resources={
+            "ram_bytes": 32 * 1024**3,
+            "cpu_cores": 8,
+            "disk_type": "SSD",
+        },
+    )
+
+    with patch.object(BaseTuner, "_resolve_resources", autospec=True) as fallback:
+        tuner._resolve_resources()
+
+    fallback.assert_called_once_with(tuner)

--- a/tests/unit/tuners/distributed/test_bootstrap.py
+++ b/tests/unit/tuners/distributed/test_bootstrap.py
@@ -41,6 +41,8 @@ def test_ssh_command_includes_key_and_target():
     assert "pbt@10.0.0.13" in argv
     assert argv[-1] == "echo hi"
     assert "BatchMode=yes" in argv
+    assert "ServerAliveInterval=30" in argv
+    assert "ServerAliveCountMax=6" in argv
 
 
 def test_ssh_command_without_user_or_key():

--- a/tests/unit/tuners/distributed/test_inventory.py
+++ b/tests/unit/tuners/distributed/test_inventory.py
@@ -40,6 +40,29 @@ def test_fleet_defaults_and_per_device_overrides():
     assert d2.agent_port == 8770
 
 
+def test_gcp_identity_defaults_and_instance_names():
+    """Project/zone may be fleet defaults while VM names remain per-device."""
+    raw = _minimal()
+    raw["fleet"].update(
+        {"gcp_project": "research-project", "gcp_zone": "us-central1-a"}
+    )
+    for index, device in enumerate(raw["devices"]):
+        device["gcp_instance"] = f"pbt-worker-{index}"
+
+    inventory = parse_inventory(raw)
+
+    assert all(
+        device.gcp_project == "research-project"
+        for device in inventory.devices
+    )
+    assert all(device.gcp_zone == "us-central1-a" for device in inventory.devices)
+    assert [device.gcp_instance for device in inventory.devices] == [
+        "pbt-worker-0",
+        "pbt-worker-1",
+        "pbt-worker-2",
+    ]
+
+
 def test_agent_base_url_and_display_name():
     d = DeviceSpec(worker_id=0, host="host-a", agent_port=9000, label="alpha")
     assert d.agent_base_url == "http://host-a:9000"


### PR DESCRIPTION
Run BO and post-hoc evaluation on one selected fleet device after distributed PBT while preserving the full dedicated-device resource envelope.

Stop PostgreSQL workloads reliably, synchronize remote artifacts, harden SSH sessions, and optionally stop all GCP worker VMs after the campaign.