### PR TITLE
fix(experiments): Avoid pg_ctl for Docker workers

### DIFF
--- a/scripts/experiments/runner.py
+++ b/scripts/experiments/runner.py
@@ -264,6 +264,7 @@ class ExperimentRunner:
             "--data-dir",
             layout.instances_dir,
             "--force",
+            "--docker-only",
         ]
         cleanup_cmd = shlex.join(cleanup_argv)
         remote_cmd = (
@@ -355,7 +356,8 @@ class ExperimentRunner:
                 f"cd {shlex.quote(layout.code_dir)} && "
                 f"{shlex.quote(device.python)} "
                 "-m src.scripts.cleanup_instances "
-                f"--data-dir {shlex.quote(layout.instances_dir)} --force; "
+                f"--data-dir {shlex.quote(layout.instances_dir)} "
+                "--force --docker-only; "
                 "fi"
             )
             if not self._run_command(ssh_command(device, cleanup)):

--- a/src/scripts/cleanup_instances.py
+++ b/src/scripts/cleanup_instances.py
@@ -39,6 +39,19 @@ class _NoopBenchmarkExecutor(BenchmarkExecutor):
         return PerformanceMetrics()
 
 
+def _resolve_bare_metal_pgdata(worker_dir: Path) -> Path | None:
+    """Return PGDATA only when ``worker_dir`` has a bare-metal layout.
+
+    Bare-metal clusters store ``PG_VERSION`` either directly in ``worker_N``
+    (legacy) or in ``worker_N/pgdata``. Docker bind mounts instead place it in
+    ``worker_N/pgdata/data`` and must be cleaned through the Docker API.
+    """
+    for candidate in (worker_dir, worker_dir / "pgdata"):
+        if (candidate / "PG_VERSION").is_file():
+            return candidate
+    return None
+
+
 def _docker_force_remove(path: Path) -> None:
     """Uses a root Docker container to bypass permission boundaries and rm -rf a path."""
     if not path.exists():
@@ -138,6 +151,14 @@ def main():
     parser.add_argument(
         "--force", action="store_true", help="Force removal without confirmation"
     )
+    parser.add_argument(
+        "--docker-only",
+        action="store_true",
+        help=(
+            "Stop/remove Docker PostgreSQL containers only; do not inspect "
+            "persisted worker directories as bare-metal instances"
+        ),
+    )
 
     args = parser.parse_args()
 
@@ -165,6 +186,11 @@ def main():
     except Exception:
         docker_available = False
 
+    if args.docker_only and not docker_available:
+        logging.error("Docker-only cleanup requested, but Docker is unavailable")
+        return 1
+
+    docker_cleanup_failures: list[str] = []
     if docker_available:
         print("\nCleaning up Docker containers...")
         for container in client.containers.list(all=True):
@@ -176,7 +202,14 @@ def main():
                     container.remove(force=True)
                 except Exception as e:
                     logging.warning(f"Failed to remove {name}: {e}")
-        print("✓ Docker containers cleaned")
+                    docker_cleanup_failures.append(name)
+        if docker_cleanup_failures:
+            logging.error(
+                "Failed to remove Docker container(s): %s",
+                ", ".join(docker_cleanup_failures),
+            )
+        else:
+            print("✓ Docker containers cleaned")
 
         if args.remove_snapshots:
             print("\nCleaning up Docker snapshot images...")
@@ -190,11 +223,22 @@ def main():
                             logging.warning(f"Failed to remove image {tag}: {e}")
             print("✓ Docker snapshots cleaned")
 
-    # Detect running bare-metal instances by checking data directories
+    # Detect only actual bare-metal PGDATA directories. Docker uses
+    # worker_N/pgdata/data, which must not fall through to pg_ctl cleanup.
     worker_dirs = sorted(base_dir.rglob("worker_*")) if base_dir_exists else []
-    if worker_dirs:
+    bare_metal_instances: list[tuple[int, Path]] = []
+    if not args.docker_only:
+        for worker_dir in worker_dirs:
+            suffix = worker_dir.name.split("_", 1)[1]
+            pgdata = _resolve_bare_metal_pgdata(worker_dir)
+            if suffix.isdigit() and pgdata is not None:
+                bare_metal_instances.append((int(suffix), pgdata))
+
+    bare_metal_cleanup_failed = False
+    if bare_metal_instances:
         print(
-            f"\nFound {len(worker_dirs)} instance directories to stop via base environment"
+            f"\nFound {len(bare_metal_instances)} bare-metal PostgreSQL "
+            "instances to stop"
         )
 
         try:
@@ -218,19 +262,25 @@ def main():
             container_prefix="cleanup-worker",
         )
 
-        for worker_dir in worker_dirs:
-            suffix = worker_dir.name.split("_", 1)[1]
-            if suffix.isdigit():
-                worker_id = int(suffix)
-                manager.instances[worker_id] = InstanceConfig(
-                    worker_id=worker_id,
-                    port=5432 + worker_id,
-                    data_dir=worker_dir,
-                    running=True,
-                )
+        for worker_id, pgdata in bare_metal_instances:
+            manager.instances[worker_id] = InstanceConfig(
+                worker_id=worker_id,
+                port=5432 + worker_id,
+                data_dir=pgdata,
+                running=True,
+            )
 
-        manager.stop_all(mode="immediate")
-        print("✓ All bare-metal instances stopped")
+        try:
+            manager.stop_all(mode="immediate")
+        except FileNotFoundError as exc:
+            bare_metal_cleanup_failed = True
+            logging.error(
+                "Cannot stop bare-metal PostgreSQL instances because %s is not "
+                "available on PATH",
+                exc.filename or "pg_ctl",
+            )
+        else:
+            print("✓ All bare-metal instances stopped")
 
     if args.remove_data:
         print("\nRemoving data directories...")
@@ -272,7 +322,7 @@ def main():
             print("✓ Host-level database snapshots removed")
 
     print("\n✓ Cleanup complete!")
-    return 0
+    return 1 if docker_cleanup_failures or bare_metal_cleanup_failed else 0
 
 
 if __name__ == "__main__":

--- a/tests/unit/scripts/test_cleanup_instances.py
+++ b/tests/unit/scripts/test_cleanup_instances.py
@@ -14,14 +14,22 @@ from src.scripts import cleanup_instances
 def test_cleanup_constructs_manager_and_stops_instances(tmp_path: Path) -> None:
     """Cleanup should build manager, register worker dirs, and stop all instances."""
     base_dir = tmp_path / "pg_instances"
-    (base_dir / "worker_0").mkdir(parents=True)
-    (base_dir / "worker_2").mkdir(parents=True)
+    worker_0 = base_dir / "worker_0"
+    worker_0.mkdir(parents=True)
+    (worker_0 / "PG_VERSION").write_text("18", encoding="utf-8")
+    worker_2_pgdata = base_dir / "worker_2" / "pgdata"
+    worker_2_pgdata.mkdir(parents=True)
+    (worker_2_pgdata / "PG_VERSION").write_text("18", encoding="utf-8")
     (base_dir / "worker_invalid").mkdir(parents=True)
 
     fake_manager = SimpleNamespace(instances={}, stop_all=MagicMock())
 
     args = Namespace(
-        remove_data=False, remove_snapshots=False, data_dir=str(base_dir), force=False
+        remove_data=False,
+        remove_snapshots=False,
+        data_dir=str(base_dir),
+        force=False,
+        docker_only=False,
     )
 
     with (
@@ -34,6 +42,7 @@ def test_cleanup_constructs_manager_and_stops_instances(tmp_path: Path) -> None:
             "src.scripts.cleanup_instances.EnvironmentFactory.create",
             return_value=fake_manager,
         ) as create_mock,
+        patch("docker.from_env", side_effect=RuntimeError("Docker unavailable")),
         patch("src.scripts.cleanup_instances.shutil.rmtree") as rmtree_mock,
     ):
         from_env_mock.return_value = DatabaseConfig(
@@ -50,6 +59,8 @@ def test_cleanup_constructs_manager_and_stops_instances(tmp_path: Path) -> None:
     assert create_mock.called
     fake_manager.stop_all.assert_called_once_with(mode="immediate")
     assert sorted(fake_manager.instances.keys()) == [0, 2]
+    assert fake_manager.instances[0].data_dir == worker_0
+    assert fake_manager.instances[2].data_dir == worker_2_pgdata
     rmtree_mock.assert_not_called()
 
 
@@ -61,12 +72,118 @@ def test_cleanup_dry_run_returns_zero_when_base_dir_missing(tmp_path: Path) -> N
         remove_snapshots=False,
         data_dir=str(missing_dir),
         force=False,
+        docker_only=False,
     )
 
-    with patch(
-        "src.scripts.cleanup_instances.argparse.ArgumentParser.parse_args",
-        return_value=args,
+    with (
+        patch(
+            "src.scripts.cleanup_instances.argparse.ArgumentParser.parse_args",
+            return_value=args,
+        ),
+        patch("docker.from_env", side_effect=RuntimeError("Docker unavailable")),
     ):
         result = cleanup_instances.main()
 
     assert result == 0
+
+
+def test_docker_only_cleanup_does_not_invoke_bare_metal_manager(
+    tmp_path: Path,
+) -> None:
+    """Docker PGDATA directories must never trigger a pg_ctl cleanup path."""
+    base_dir = tmp_path / "instances"
+    (base_dir / "run" / "worker_0" / "pgdata").mkdir(parents=True)
+    container = MagicMock(name="pbt-worker-0")
+    container.name = "pbt-worker-0"
+    client = MagicMock()
+    client.containers.list.return_value = [container]
+    args = Namespace(
+        remove_data=False,
+        remove_snapshots=False,
+        data_dir=str(base_dir),
+        force=True,
+        docker_only=True,
+    )
+
+    with (
+        patch(
+            "src.scripts.cleanup_instances.argparse.ArgumentParser.parse_args",
+            return_value=args,
+        ),
+        patch("docker.from_env", return_value=client),
+        patch(
+            "src.scripts.cleanup_instances.EnvironmentFactory.create"
+        ) as create_manager,
+    ):
+        result = cleanup_instances.main()
+
+    assert result == 0
+    container.stop.assert_called_once_with(timeout=5)
+    container.remove.assert_called_once_with(force=True)
+    create_manager.assert_not_called()
+
+
+def test_docker_pgdata_is_not_treated_as_bare_metal_without_flag(
+    tmp_path: Path,
+) -> None:
+    """Default cleanup must recognize Docker's nested PGDATA layout."""
+    base_dir = tmp_path / "instances"
+    docker_pgdata = base_dir / "run" / "worker_0" / "pgdata" / "data"
+    docker_pgdata.mkdir(parents=True)
+    (docker_pgdata / "PG_VERSION").write_text("18", encoding="utf-8")
+    args = Namespace(
+        remove_data=False,
+        remove_snapshots=False,
+        data_dir=str(base_dir),
+        force=True,
+        docker_only=False,
+    )
+
+    with (
+        patch(
+            "src.scripts.cleanup_instances.argparse.ArgumentParser.parse_args",
+            return_value=args,
+        ),
+        patch("docker.from_env", side_effect=RuntimeError("Docker unavailable")),
+        patch(
+            "src.scripts.cleanup_instances.EnvironmentFactory.create"
+        ) as create_manager,
+    ):
+        result = cleanup_instances.main()
+
+    assert result == 0
+    create_manager.assert_not_called()
+
+
+def test_missing_pg_ctl_is_reported_without_traceback(tmp_path: Path) -> None:
+    """A missing bare-metal pg_ctl executable should produce a clean failure."""
+    base_dir = tmp_path / "instances"
+    worker_dir = base_dir / "worker_0"
+    worker_dir.mkdir(parents=True)
+    (worker_dir / "PG_VERSION").write_text("18", encoding="utf-8")
+    fake_manager = SimpleNamespace(
+        instances={},
+        stop_all=MagicMock(side_effect=FileNotFoundError(2, "missing", "pg_ctl")),
+    )
+    args = Namespace(
+        remove_data=False,
+        remove_snapshots=False,
+        data_dir=str(base_dir),
+        force=True,
+        docker_only=False,
+    )
+
+    with (
+        patch(
+            "src.scripts.cleanup_instances.argparse.ArgumentParser.parse_args",
+            return_value=args,
+        ),
+        patch("docker.from_env", side_effect=RuntimeError("Docker unavailable")),
+        patch(
+            "src.scripts.cleanup_instances.EnvironmentFactory.create",
+            return_value=fake_manager,
+        ),
+    ):
+        result = cleanup_instances.main()
+
+    assert result == 1

--- a/tests/unit/scripts/test_experiment_runner_manifest.py
+++ b/tests/unit/scripts/test_experiment_runner_manifest.py
@@ -370,7 +370,7 @@ devices:
     assert "/srv/pbt/.venv/bin/python -m src.tuners bo" in rendered
     assert "trap cleanup_comparison_instance EXIT" in rendered
     assert "src.scripts.cleanup_instances" in rendered
-    assert "--data-dir /srv/pbt/instances --force" in rendered
+    assert "--data-dir /srv/pbt/instances --force --docker-only" in rendered
 
 
 def test_prepare_comparison_device_stops_other_agents(monkeypatch, tmp_path):
@@ -409,6 +409,7 @@ devices:
     selected = next(cmd for cmd in targets if "10.0.0.12" in cmd)
     assert any("10.0.0.13" in cmd for cmd in targets)
     assert "cleanup_instances" in selected
+    assert "--docker-only" in selected
     assert "agent-worker-1.pid" in selected
     assert "agent-worker-0.pid" in next(
         cmd for cmd in targets if "10.0.0.11" in cmd


### PR DESCRIPTION
Distinguish Docker bind-mounted PGDATA from bare-metal PostgreSQL clusters during cleanup. Use Docker-only cleanup for distributed workers and report missing pg_ctl as a controlled failure instead of raising a traceback.

## Description

<!-- What does this PR do? Provide a brief summary of the changes. -->

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation (changes to documentation only)

## Testing

<!-- What tests were run to verify the changes? How can reviewers test this? -->

## Checklist

- [ ] All tests pass (`make test`)
- [ ] Documentation has been updated (if applicable)
- [ ] Commit messages follow [conventional commit](https://www.conventionalcommits.org/) format
- [ ] I have performed a self-review of my code
